### PR TITLE
CLI Implementation

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -11,6 +11,7 @@ AllCops:
   UseCache: true
 inherit_mode:
   merge:
+  - AllowedCops
   - Exclude
 plugins:
 - rubocop-performance

--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -15,6 +15,7 @@ RSpec/ExampleLength:
 # Configuration parameters: Max, AllowedGroups.
 RSpec/NestedGroups:
   Exclude:
+    - 'spec/factorix/cli/commands/launch_spec.rb'
     - 'spec/factorix/runtime_spec.rb'
 
 # This cop supports unsafe autocorrection (--autocorrect-all).

--- a/exe/factorix
+++ b/exe/factorix
@@ -1,0 +1,12 @@
+#!/usr/bin/env ruby
+# frozen_string_literal: true
+
+require_relative "../lib/factorix/cli"
+
+begin
+  Dry::CLI.new(Factorix::CLI).call
+  exit 0
+rescue => e
+  puts e.message
+  exit 1
+end

--- a/factorix.gemspec
+++ b/factorix.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) {|f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "dry-cli", ">= 1.2.0"
   spec.add_dependency "dry-core", ">= 1.1.0"
   spec.add_dependency "sys-proctable", ">= 1.3.0"
 end

--- a/lib/factorix/cli.rb
+++ b/lib/factorix/cli.rb
@@ -1,0 +1,18 @@
+# frozen_string_literal: true
+
+require "dry/cli"
+
+require_relative "cli/commands/disable"
+require_relative "cli/commands/enable"
+require_relative "cli/commands/launch"
+
+module Factorix
+  # Command-line interface for Factorix
+  class CLI
+    extend Dry::CLI::Registry
+
+    register "enable", Factorix::CLI::Commands::Enable
+    register "disable", Factorix::CLI::Commands::Disable
+    register "launch", Factorix::CLI::Commands::Launch
+  end
+end

--- a/lib/factorix/cli/commands/disable.rb
+++ b/lib/factorix/cli/commands/disable.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "dry/cli"
+
+module Factorix
+  class CLI
+    module Commands
+      # Command for the disable subcommand
+      class Disable < Dry::CLI::Command
+        desc "Disable a MOD"
+
+        argument :mod, required: true, desc: "The MOD to disable"
+        option :verbose, type: :boolean, default: false, desc: "Print more information"
+
+        # Disable a MOD
+        # @param mod [String] The MOD to disable
+        # @param options [Hash] The options for the command
+        # @option options [Boolean] :verbose Print more information
+        def call(mod:, **options)
+          puts "Disabling MOD: #{mod}" if options[:verbose]
+          list = Factorix::ModList.load
+          list.disable(Factorix::Mod[name: mod])
+          list.save
+        end
+      end
+    end
+  end
+end

--- a/lib/factorix/cli/commands/enable.rb
+++ b/lib/factorix/cli/commands/enable.rb
@@ -1,0 +1,28 @@
+# frozen_string_literal: true
+
+require "dry/cli"
+
+module Factorix
+  class CLI
+    module Commands
+      # Command for the enable subcommand
+      class Enable < Dry::CLI::Command
+        desc "Enable a MOD"
+
+        argument :mod, required: true, desc: "The MOD to enable"
+        option :verbose, type: :boolean, default: false, desc: "Print more information"
+
+        # Enable a MOD
+        # @param mod [String] The MOD to enable
+        # @param options [Hash] The options for the command
+        # @option options [Boolean] :verbose Print more information
+        def call(mod:, **options)
+          puts "Enabling MOD: #{mod}" if options[:verbose]
+          list = Factorix::ModList.load
+          list.enable(Factorix::Mod[name: mod])
+          list.save
+        end
+      end
+    end
+  end
+end

--- a/lib/factorix/cli/commands/launch.rb
+++ b/lib/factorix/cli/commands/launch.rb
@@ -1,0 +1,42 @@
+# frozen_string_literal: true
+
+require "dry/cli"
+
+require_relative "../../runtime"
+
+module Factorix
+  class CLI
+    module Commands
+      # Command for the launch subcommand
+      class Launch < Dry::CLI::Command
+        SYNCHRONOUS_OPTIONS = %w[--data-dump --help].freeze
+        private_constant :SYNCHRONOUS_OPTIONS
+
+        desc "Launch the game"
+
+        option :wait, type: :boolean, default: false, alias: ["w"], desc: "Wait for the game to finish"
+
+        # Launch the game
+        def call(args: [], **options)
+          runtime = Factorix::Runtime.runtime
+          async = args.none? { SYNCHRONOUS_OPTIONS.include?(it) }
+
+          runtime.launch(*args, async:)
+
+          return unless async && options[:wait]
+
+          wait_while { !runtime.running? }
+          wait_while { runtime.running? }
+        end
+
+        private def wait_while(&)
+          loop do
+            break unless yield
+
+            sleep 1
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/factorix/runtime.rb
+++ b/lib/factorix/runtime.rb
@@ -51,10 +51,14 @@ module Factorix
     # Launch the game
     # @return [void]
     # @raise [RuntimeError] if the game is already running
-    def launch(*)
+    def launch(*, async:)
       raise AlreadyRunning, "The game is already running" if running?
 
-      spawn([executable.to_s, "factorio"], *, out: IO::NULL)
+      if async
+        spawn([executable.to_s, "factorio"], *, out: IO::NULL)
+      else
+        system([executable.to_s, "factorio"], *, out: IO::NULL)
+      end
     end
 
     # Check if the game is running

--- a/lib/factorix/runtime/mac_os.rb
+++ b/lib/factorix/runtime/mac_os.rb
@@ -30,7 +30,7 @@ module Factorix
       # @return [Boolean] true if the game is running, false otherwise
       def running?
         Warning[:deprecated] = false
-        Sys::ProcTable.ps.any? { it.name == "factorio" }
+        Sys::ProcTable.ps.any? { it.cmdline.match?(/\A#{Regexp.quote(executable.to_s)}\b/) }
       ensure
         Warning[:deprecated] = true
       end

--- a/spec/factorix/cli/commands/disable_spec.rb
+++ b/spec/factorix/cli/commands/disable_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require "factorix/cli/commands/disable"
+require "tempfile"
+
+RSpec.describe Factorix::CLI::Commands::Disable do
+  let(:command) { Factorix::CLI::Commands::Disable.new }
+  let(:mod_name) { "test-mod" }
+
+  describe "#call with mocked ModList" do
+    let(:mod_list) { instance_double(Factorix::ModList) }
+
+    before do
+      allow(Factorix::ModList).to receive(:load).and_return(mod_list)
+      allow(mod_list).to receive(:disable)
+      allow(mod_list).to receive(:save)
+    end
+
+    context "with verbose option" do
+      let(:options) { {verbose: true} }
+
+      it "outputs disabling message" do
+        expect { command.call(mod: mod_name, **options) }.to output(/Disabling MOD: #{mod_name}/).to_stdout
+      end
+
+      it "disables the mod in the mod list" do
+        command.call(mod: mod_name, **options)
+        expect(mod_list).to have_received(:disable).with(Factorix::Mod[name: mod_name])
+      end
+
+      it "saves the mod list" do
+        command.call(mod: mod_name, **options)
+        expect(mod_list).to have_received(:save)
+      end
+    end
+
+    context "without verbose option" do
+      let(:options) { {verbose: false} }
+
+      it "does not output disabling message" do
+        expect { command.call(mod: mod_name, **options) }.not_to output.to_stdout
+      end
+
+      it "disables the mod in the mod list" do
+        command.call(mod: mod_name, **options)
+        expect(mod_list).to have_received(:disable).with(Factorix::Mod[name: mod_name])
+      end
+
+      it "saves the mod list" do
+        command.call(mod: mod_name, **options)
+        expect(mod_list).to have_received(:save)
+      end
+    end
+  end
+
+  describe "#call with actual file operations" do
+    let(:options) { {verbose: false} }
+    let(:mod_list_content) do
+      {
+        mods: [
+          {name: "base", enabled: true},
+          {name: mod_name, enabled: true}
+        ]
+      }
+    end
+    let(:temp_file) { Tempfile.new(["mod-list-", ".json"]) }
+    let(:mod_list_path) { Pathname(temp_file.path) }
+    let(:runtime) { instance_double(Factorix::Runtime) }
+
+    before do
+      temp_file.write(JSON.pretty_generate(mod_list_content))
+      temp_file.flush
+
+      allow(Factorix::Runtime).to receive(:runtime).and_return(runtime)
+      allow(runtime).to receive(:mod_list_path).and_return(mod_list_path)
+    end
+
+    after do
+      temp_file.close
+      temp_file.unlink
+    end
+
+    it "updates the mod-list.json file" do
+      command.call(mod: mod_name, **options)
+
+      # Verify the file was updated
+      updated_content = JSON.parse(File.read(temp_file.path))
+      expect(updated_content["mods"].find {|m| m["name"] == mod_name }["enabled"]).to be false
+    end
+  end
+end

--- a/spec/factorix/cli/commands/enable_spec.rb
+++ b/spec/factorix/cli/commands/enable_spec.rb
@@ -1,0 +1,91 @@
+# frozen_string_literal: true
+
+require "factorix/cli/commands/enable"
+require "tempfile"
+
+RSpec.describe Factorix::CLI::Commands::Enable do
+  let(:command) { Factorix::CLI::Commands::Enable.new }
+  let(:mod_name) { "test-mod" }
+
+  describe "#call with mocked ModList" do
+    let(:mod_list) { instance_double(Factorix::ModList) }
+
+    before do
+      allow(Factorix::ModList).to receive(:load).and_return(mod_list)
+      allow(mod_list).to receive(:enable)
+      allow(mod_list).to receive(:save)
+    end
+
+    context "with verbose option" do
+      let(:options) { {verbose: true} }
+
+      it "outputs enabling message" do
+        expect { command.call(mod: mod_name, **options) }.to output(/Enabling MOD: #{mod_name}/).to_stdout
+      end
+
+      it "enables the mod in the mod list" do
+        command.call(mod: mod_name, **options)
+        expect(mod_list).to have_received(:enable).with(Factorix::Mod[name: mod_name])
+      end
+
+      it "saves the mod list" do
+        command.call(mod: mod_name, **options)
+        expect(mod_list).to have_received(:save)
+      end
+    end
+
+    context "without verbose option" do
+      let(:options) { {verbose: false} }
+
+      it "does not output enabling message" do
+        expect { command.call(mod: mod_name, **options) }.not_to output.to_stdout
+      end
+
+      it "enables the mod in the mod list" do
+        command.call(mod: mod_name, **options)
+        expect(mod_list).to have_received(:enable).with(Factorix::Mod[name: mod_name])
+      end
+
+      it "saves the mod list" do
+        command.call(mod: mod_name, **options)
+        expect(mod_list).to have_received(:save)
+      end
+    end
+  end
+
+  describe "#call with actual file operations" do
+    let(:options) { {verbose: false} }
+    let(:mod_list_content) do
+      {
+        mods: [
+          {name: "base", enabled: true},
+          {name: mod_name, enabled: false}
+        ]
+      }
+    end
+    let(:temp_file) { Tempfile.new(["mod-list-", ".json"]) }
+    let(:mod_list_path) { Pathname(temp_file.path) }
+    let(:runtime) { instance_double(Factorix::Runtime) }
+
+    before do
+      temp_file.write(JSON.pretty_generate(mod_list_content))
+      temp_file.flush
+
+      allow(Factorix::Runtime).to receive(:runtime).and_return(runtime)
+      allow(runtime).to receive(:mod_list_path).and_return(mod_list_path)
+    end
+
+    after do
+      temp_file.close
+      temp_file.unlink
+    end
+
+    it "updates the mod-list.json file" do
+      command.call(mod: mod_name, **options)
+
+      # Verify the file was updated
+      updated_content = JSON.parse(File.read(temp_file.path))
+      expect(updated_content["mods"].find {|m| m["name"] == mod_name }["enabled"]).to be true
+    end
+  end
+end

--- a/spec/factorix/cli/commands/launch_spec.rb
+++ b/spec/factorix/cli/commands/launch_spec.rb
@@ -1,0 +1,108 @@
+# frozen_string_literal: true
+
+require "factorix/cli/commands/launch"
+
+RSpec.describe Factorix::CLI::Commands::Launch do
+  let(:runtime) { Factorix::Runtime.new }
+  let(:command) { Factorix::CLI::Commands::Launch.new }
+
+  before do
+    allow(Factorix::Runtime).to receive(:runtime).and_return(runtime)
+    allow(runtime).to receive_messages(
+      executable: Pathname("/path/to/factorio"),
+      spawn: nil,
+      system: nil
+    )
+  end
+
+  describe "#call" do
+    subject(:call) { command.call(args:, **options) }
+
+    let(:args) { [] }
+    let(:options) { {} }
+
+    before do
+      allow(runtime).to receive(:launch).and_call_original
+      allow(command).to receive(:wait_while)
+    end
+
+    context "when the game is already running" do
+      before do
+        allow(runtime).to receive(:running?).and_return(true)
+      end
+
+      it "raises AlreadyRunning" do
+        expect { call }.to raise_error(Factorix::Runtime::AlreadyRunning)
+      end
+    end
+
+    context "when the game is not running" do
+      before do
+        allow(runtime).to receive(:running?).and_return(false, true, false)
+      end
+
+      context "with no special args" do
+        it "launches the game asynchronously" do
+          call
+          expect(runtime).to have_received(:launch).with(async: true)
+        end
+
+        context "with wait option" do
+          let(:options) { {wait: true} }
+
+          it "waits for the game to start and finish" do
+            call
+            expect(command).to have_received(:wait_while).twice
+          end
+        end
+
+        context "without wait option" do
+          let(:options) { {wait: false} }
+
+          it "does not wait for the game" do
+            call
+            expect(command).not_to have_received(:wait_while)
+          end
+        end
+      end
+
+      context "with synchronous args" do
+        let(:args) { %w[--data-dump] }
+
+        it "launches the game synchronously" do
+          call
+          expect(runtime).to have_received(:launch).with("--data-dump", async: false)
+        end
+
+        context "with wait option" do
+          let(:options) { {wait: true} }
+
+          it "does not wait for the game" do
+            call
+            expect(command).not_to have_received(:wait_while)
+          end
+        end
+      end
+
+      context "with other args" do
+        let(:args) { %w[--start-server save.zip] }
+
+        it "passes the args to the runtime with async: true" do
+          call
+          expect(runtime).to have_received(:launch).with("--start-server", "save.zip", async: true)
+        end
+      end
+    end
+  end
+
+  describe "#wait_while" do
+    it "loops until the condition is false" do
+      counter = 0
+      condition = -> { (counter += 1) < 3 }
+
+      command.__send__(:wait_while) { condition.call }
+
+      expect(counter).to eq(3)
+    end
+  end
+end

--- a/spec/factorix/runtime/mac_os_spec.rb
+++ b/spec/factorix/runtime/mac_os_spec.rb
@@ -49,8 +49,8 @@ RSpec.describe Factorix::Runtime::MacOS do
     before do
       allow(Sys::ProcTable).to receive(:ps).and_return(
         [
-          Struct::ProcTableStruct.new(pid: 1, name: "factorio"),
-          Struct::ProcTableStruct.new(pid: 2, name: "another_process")
+          Struct::ProcTableStruct.new(pid: 1, cmdline: runtime.executable.to_s),
+          Struct::ProcTableStruct.new(pid: 2, cmdline: "another_process")
         ]
       )
     end
@@ -63,8 +63,8 @@ RSpec.describe Factorix::Runtime::MacOS do
       before do
         allow(Sys::ProcTable).to receive(:ps).and_return(
           [
-            Struct::ProcTableStruct.new(pid: 1, name: "another_process"),
-            Struct::ProcTableStruct.new(pid: 2, name: "yet_another_process")
+            Struct::ProcTableStruct.new(pid: 1, cmdline: "another_process"),
+            Struct::ProcTableStruct.new(pid: 2, cmdline: "yet_another_process")
           ]
         )
       end

--- a/spec/factorix/runtime_spec.rb
+++ b/spec/factorix/runtime_spec.rb
@@ -117,23 +117,66 @@ RSpec.describe Factorix::Runtime do
           executable: Pathname.new("/path/to/factorio")
         )
         allow(runtime).to receive(:spawn)
+        allow(runtime).to receive(:system)
       end
 
-      context "without arguments" do
-        subject(:launch) { runtime.launch }
+      context "with async: true" do
+        context "without arguments" do
+          subject(:launch) { runtime.launch(async: true) }
 
-        it "launches the game" do
-          launch
-          expect(runtime).to have_received(:spawn).with(["/path/to/factorio", "factorio"], out: IO::NULL)
+          it "launches the game asynchronously" do
+            launch
+            expect(runtime).to have_received(:spawn).with(["/path/to/factorio", "factorio"], out: IO::NULL)
+          end
+
+          it "does not use system for asynchronous launch" do
+            launch
+            expect(runtime).not_to have_received(:system)
+          end
+        end
+
+        context "with arguments" do
+          subject(:launch) { runtime.launch("--start-server", "save.zip", async: true) }
+
+          it "launches the game asynchronously with arguments" do
+            launch
+            expect(runtime).to have_received(:spawn).with(["/path/to/factorio", "factorio"], "--start-server", "save.zip", out: IO::NULL)
+          end
+
+          it "does not use system for asynchronous launch with arguments" do
+            launch
+            expect(runtime).not_to have_received(:system)
+          end
         end
       end
 
-      context "with arguments" do
-        subject(:launch) { runtime.launch("--start-server", "save.zip") }
+      context "with async: false" do
+        context "without arguments" do
+          subject(:launch) { runtime.launch(async: false) }
 
-        it "launches the game with arguments" do
-          launch
-          expect(runtime).to have_received(:spawn).with(["/path/to/factorio", "factorio"], "--start-server", "save.zip", out: IO::NULL)
+          it "launches the game synchronously" do
+            launch
+            expect(runtime).to have_received(:system).with(["/path/to/factorio", "factorio"], out: IO::NULL)
+          end
+
+          it "does not use spawn for synchronous launch" do
+            launch
+            expect(runtime).not_to have_received(:spawn)
+          end
+        end
+
+        context "with arguments" do
+          subject(:launch) { runtime.launch("--start-server", "save.zip", async: false) }
+
+          it "launches the game synchronously with arguments" do
+            launch
+            expect(runtime).to have_received(:system).with(["/path/to/factorio", "factorio"], "--start-server", "save.zip", out: IO::NULL)
+          end
+
+          it "does not use spawn for synchronous launch with arguments" do
+            launch
+            expect(runtime).not_to have_received(:spawn)
+          end
         end
       end
     end
@@ -144,7 +187,7 @@ RSpec.describe Factorix::Runtime do
       end
 
       it "raises AlreadyRunning" do
-        expect { runtime.launch }.to raise_error(Factorix::Runtime::AlreadyRunning)
+        expect { runtime.launch(async: true) }.to raise_error(Factorix::Runtime::AlreadyRunning)
       end
     end
   end

--- a/spec/mocks/sys/proctable.rb
+++ b/spec/mocks/sys/proctable.rb
@@ -18,4 +18,4 @@ end
 # Struct for mocking Sys::ProcTable.ps
 #
 # This is a mock of the Struct returned by Sys::ProcTable.ps
-Struct::ProcTableStruct = Struct.new(:pid, :name)
+Struct::ProcTableStruct = Struct.new(:pid, :cmdline)


### PR DESCRIPTION
This PR adds CLI functionality to factorix using dry-cli framework.

## Features
- Add CLI infrastructure with dry-cli
- Add enable/disable commands for MOD management
- Add launch command with runtime support

These changes provide a command-line interface for managing Factorio mods and launching the game.