### PR TITLE
Add info command to display runtime information

### DIFF
--- a/lib/factorix/cli.rb
+++ b/lib/factorix/cli.rb
@@ -4,6 +4,7 @@ require "dry/cli"
 
 require_relative "cli/commands/disable"
 require_relative "cli/commands/enable"
+require_relative "cli/commands/info"
 require_relative "cli/commands/launch"
 
 module Factorix
@@ -13,6 +14,7 @@ module Factorix
 
     register "enable", Factorix::CLI::Commands::Enable
     register "disable", Factorix::CLI::Commands::Disable
+    register "info", Factorix::CLI::Commands::Info
     register "launch", Factorix::CLI::Commands::Launch
   end
 end

--- a/lib/factorix/cli/commands/info.rb
+++ b/lib/factorix/cli/commands/info.rb
@@ -25,7 +25,6 @@ module Factorix
 
         private def info_items(runtime)
           {
-            "Platform" => runtime.platform,
             "Executable" => runtime.executable,
             "User directory" => runtime.user_dir,
             "Data directory" => runtime.data_dir,

--- a/lib/factorix/cli/commands/info.rb
+++ b/lib/factorix/cli/commands/info.rb
@@ -14,12 +14,28 @@ module Factorix
         # Display runtime information
         def call(**)
           runtime = Factorix::Runtime.runtime
-          puts "Platform: %p" % runtime.platform.to_s
-          puts "Executable: %p" % runtime.executable.to_s
-          puts "User directory: %p" % runtime.user_dir.to_s
-          puts "Data directory: %p" % runtime.data_dir.to_s
-          puts "Mod directory: %p" % runtime.mods_dir.to_s
-          puts "Script output directory: %p" % runtime.script_output_dir.to_s
+          display_runtime_info(runtime)
+        end
+
+        private def display_runtime_info(runtime)
+          info_items(runtime).each do |label, value|
+            display_item(label, value)
+          end
+        end
+
+        private def info_items(runtime)
+          {
+            "Platform" => runtime.platform.to_s,
+            "Executable" => runtime.executable.to_s,
+            "User directory" => runtime.user_dir.to_s,
+            "Data directory" => runtime.data_dir.to_s,
+            "Mod directory" => runtime.mods_dir.to_s,
+            "Script output directory" => runtime.script_output_dir.to_s
+          }
+        end
+
+        private def display_item(label, value)
+          puts "#{label}: %p" % value
         end
       end
     end

--- a/lib/factorix/cli/commands/info.rb
+++ b/lib/factorix/cli/commands/info.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+require "dry/cli"
+
+require_relative "../../runtime"
+
+module Factorix
+  class CLI
+    module Commands
+      # Command for the info subcommand
+      class Info < Dry::CLI::Command
+        desc "Display information about the Factorio runtime environment"
+
+        # Display runtime information
+        def call(**)
+          runtime = Factorix::Runtime.runtime
+          puts "Platform: %p" % runtime.platform.to_s
+          puts "Executable: %p" % runtime.executable.to_s
+          puts "User directory: %p" % runtime.user_dir.to_s
+          puts "Data directory: %p" % runtime.data_dir.to_s
+          puts "Mod directory: %p" % runtime.mods_dir.to_s
+          puts "Script output directory: %p" % runtime.script_output_dir.to_s
+        end
+      end
+    end
+  end
+end

--- a/lib/factorix/cli/commands/info.rb
+++ b/lib/factorix/cli/commands/info.rb
@@ -25,17 +25,17 @@ module Factorix
 
         private def info_items(runtime)
           {
-            "Platform" => runtime.platform.to_s,
-            "Executable" => runtime.executable.to_s,
-            "User directory" => runtime.user_dir.to_s,
-            "Data directory" => runtime.data_dir.to_s,
-            "Mod directory" => runtime.mods_dir.to_s,
-            "Script output directory" => runtime.script_output_dir.to_s
+            "Platform" => runtime.platform,
+            "Executable" => runtime.executable,
+            "User directory" => runtime.user_dir,
+            "Data directory" => runtime.data_dir,
+            "Mod directory" => runtime.mods_dir,
+            "Script output directory" => runtime.script_output_dir
           }
         end
 
         private def display_item(label, value)
-          puts "#{label}: %p" % value
+          puts "#{label}: %s" % value
         end
       end
     end

--- a/spec/factorix/cli/commands/info_spec.rb
+++ b/spec/factorix/cli/commands/info_spec.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "factorix/cli/commands/info"
+
+RSpec.describe Factorix::CLI::Commands::Info do
+  let(:runtime) { Factorix::Runtime.new }
+  let(:command) { Factorix::CLI::Commands::Info.new }
+
+  before do
+    allow(Factorix::Runtime).to receive(:runtime).and_return(runtime)
+    allow(runtime).to receive_messages(
+      platform: "test_platform",
+      executable: Pathname("/path/to/factorio"),
+      user_dir: Pathname("/path/to/user_dir"),
+      data_dir: Pathname("/path/to/data_dir"),
+      mods_dir: Pathname("/path/to/mods_dir"),
+      script_output_dir: Pathname("/path/to/script_output_dir")
+    )
+  end
+
+  describe "#call" do
+    subject(:call) { command.call }
+
+    it "outputs runtime information" do
+      expect { call }.to output(<<~OUTPUT).to_stdout
+        Platform: "test_platform"
+        Executable: "/path/to/factorio"
+        User directory: "/path/to/user_dir"
+        Data directory: "/path/to/data_dir"
+        Mod directory: "/path/to/mods_dir"
+        Script output directory: "/path/to/script_output_dir"
+      OUTPUT
+    end
+  end
+end

--- a/spec/factorix/cli/commands/info_spec.rb
+++ b/spec/factorix/cli/commands/info_spec.rb
@@ -23,12 +23,12 @@ RSpec.describe Factorix::CLI::Commands::Info do
 
     it "outputs runtime information" do
       expect { call }.to output(<<~OUTPUT).to_stdout
-        Platform: "test_platform"
-        Executable: "/path/to/factorio"
-        User directory: "/path/to/user_dir"
-        Data directory: "/path/to/data_dir"
-        Mod directory: "/path/to/mods_dir"
-        Script output directory: "/path/to/script_output_dir"
+        Platform: test_platform
+        Executable: /path/to/factorio
+        User directory: /path/to/user_dir
+        Data directory: /path/to/data_dir
+        Mod directory: /path/to/mods_dir
+        Script output directory: /path/to/script_output_dir
       OUTPUT
     end
   end

--- a/spec/factorix/cli/commands/info_spec.rb
+++ b/spec/factorix/cli/commands/info_spec.rb
@@ -9,7 +9,6 @@ RSpec.describe Factorix::CLI::Commands::Info do
   before do
     allow(Factorix::Runtime).to receive(:runtime).and_return(runtime)
     allow(runtime).to receive_messages(
-      platform: "test_platform",
       executable: Pathname("/path/to/factorio"),
       user_dir: Pathname("/path/to/user_dir"),
       data_dir: Pathname("/path/to/data_dir"),
@@ -23,7 +22,6 @@ RSpec.describe Factorix::CLI::Commands::Info do
 
     it "outputs runtime information" do
       expect { call }.to output(<<~OUTPUT).to_stdout
-        Platform: test_platform
         Executable: /path/to/factorio
         User directory: /path/to/user_dir
         Data directory: /path/to/data_dir


### PR DESCRIPTION
This PR adds a new 'info' command to the Factorix CLI that displays information about the Factorio runtime environment.

## Changes
- Added new factorix info command that shows:
  - Executable path
  - User directory
  - Data directory
  - Mod directory
  - Script output directory
- Added tests for the info command
- Registered the command in the CLI class

## Commits
- Initial implementation of the info command
- Refactoring to fix RuboCop offenses
- Updated command to use %s format and removed to_s calls
- Removed platform from info command output