### PR TITLE
Make Mod#<=> case-sensitive

### DIFF
--- a/lib/factorix/mod.rb
+++ b/lib/factorix/mod.rb
@@ -7,6 +7,7 @@ module Factorix
 
     # Return true if this mod is the base mod
     # @return [Boolean] true if this mod is the base mod
+    # @note The check is case-sensitive, only "base" (not "BASE" or "Base") is considered the base mod
     def base? = name == "base"
 
     # Return the name of the mod
@@ -16,6 +17,8 @@ module Factorix
     # Compare this mod with another mod
     # @param other [Mod] the other mod
     # @return [Integer] -1 if this mod precedes the other, 0 if they are equal, 1 if this mod follows the other
-    def <=>(other) = (base? && (other.base? ? 0 : -1)) || (other.base? ? 1 : name.casecmp(other.name))
+    # @note Comparison is case-sensitive for mod names.
+    # @note The base mod (exactly "base", case-sensitive) always comes before any other mod.
+    def <=>(other) = (base? && (other.base? ? 0 : -1)) || (other.base? ? 1 : name <=> other.name)
   }
 end

--- a/spec/factorix/mod_spec.rb
+++ b/spec/factorix/mod_spec.rb
@@ -4,11 +4,27 @@ require "factorix/mod"
 
 RSpec.describe Factorix::Mod do
   describe "#base?" do
-    context "when it is the base" do
+    context "when it is the base with exact case 'base'" do
       subject(:mod) { Factorix::Mod[name: "base"] }
 
       it "is truthy" do
         expect(mod).to be_base
+      end
+    end
+
+    context "when it has the name 'BASE' (uppercase)" do
+      subject(:mod) { Factorix::Mod[name: "BASE"] }
+
+      it "is falsy" do
+        expect(mod).not_to be_base
+      end
+    end
+
+    context "when it has the name 'Base' (capitalized)" do
+      subject(:mod) { Factorix::Mod[name: "Base"] }
+
+      it "is falsy" do
+        expect(mod).not_to be_base
       end
     end
 
@@ -22,31 +38,75 @@ RSpec.describe Factorix::Mod do
   end
 
   describe "#<=>" do
-    it "compares BAR and foo" do
-      expect(Factorix::Mod[name: "BAR"]).to be < Factorix::Mod[name: "foo"]
-    end
+    context "when comparing by alphabetical order" do
+      it "correctly orders a before b" do
+        expect(Factorix::Mod[name: "a"]).to be < Factorix::Mod[name: "b"]
+      end
 
-    it "compares foo and Foo" do
-      expect(Factorix::Mod[name: "foo"]).to eq Factorix::Mod[name: "Foo"]
-    end
+      it "correctly orders b after a" do
+        expect(Factorix::Mod[name: "b"]).to be > Factorix::Mod[name: "a"]
+      end
 
-    it "compares foo and bar" do
-      expect(Factorix::Mod[name: "foo"]).not_to eq Factorix::Mod[name: "bar"]
-    end
+      it "correctly identifies different mods as not equal" do
+        expect(Factorix::Mod[name: "foo"]).not_to eq Factorix::Mod[name: "bar"]
+      end
 
-    it "compares foo and Bar" do
-      expect(Factorix::Mod[name: "foo"]).to be > Factorix::Mod[name: "Bar"]
-    end
-
-    context "when self is base" do
-      it "comes always before non-base" do
-        expect(Factorix::Mod[name: "base"]).to be < Factorix::Mod[name: "a"]
+      it "correctly orders mods with special characters" do
+        expect(Factorix::Mod[name: "a-mod"]).to be < Factorix::Mod[name: "b-mod"]
       end
     end
 
-    context "when self is non-base" do
-      it "is always bigger than base" do
+    context "when comparing with case sensitivity" do
+      it "considers uppercase letters to come before lowercase" do
+        expect(Factorix::Mod[name: "A"]).to be < Factorix::Mod[name: "a"]
+      end
+
+      it "considers same name with different case as not equal" do
+        expect(Factorix::Mod[name: "foo"]).not_to eq Factorix::Mod[name: "Foo"]
+      end
+
+      it "correctly orders uppercase before lowercase" do
+        expect(Factorix::Mod[name: "FOO"]).to be < Factorix::Mod[name: "foo"]
+      end
+
+      it "correctly orders mixed case according to ASCII order" do
+        expect(Factorix::Mod[name: "Foo"]).to be < Factorix::Mod[name: "foo"]
+      end
+    end
+
+    context "when comparing with base mod" do
+      it "places base mod before any non-base mod" do
+        expect(Factorix::Mod[name: "base"]).to be < Factorix::Mod[name: "a"]
+      end
+
+      it "places base mod before non-base mod even if alphabetically later" do
+        expect(Factorix::Mod[name: "base"]).to be < Factorix::Mod[name: "a-mod"]
+      end
+
+      it "places non-base mod after base mod" do
         expect(Factorix::Mod[name: "a"]).to be > Factorix::Mod[name: "base"]
+      end
+
+      it "places non-base mod after base mod even if alphabetically earlier" do
+        expect(Factorix::Mod[name: "a-mod"]).to be > Factorix::Mod[name: "base"]
+      end
+
+      it "considers two base mods with same name equal" do
+        mod1 = Factorix::Mod[name: "base"]
+        mod2 = Factorix::Mod[name: "base"]
+        expect(mod1).to eq mod2
+      end
+
+      it "considers base mod with different case as not equal to base mod" do
+        expect(Factorix::Mod[name: "base"]).not_to eq Factorix::Mod[name: "BASE"]
+      end
+
+      it "compares Base and base normally (Base is not considered the base mod)" do
+        expect(Factorix::Mod[name: "Base"]).to be > Factorix::Mod[name: "base"]
+      end
+
+      it "compares BASE and base normally (BASE is not considered the base mod)" do
+        expect(Factorix::Mod[name: "BASE"]).to be > Factorix::Mod[name: "base"]
       end
     end
   end


### PR DESCRIPTION
This PR changes the Mod#<=> method to use case-sensitive comparison as per the specifications:

1. Names are compared case-sensitively (changed from case-insensitive)
2. The base mod (exactly 'base', case-sensitive) always comes before any other mod
3. Added comprehensive tests to verify the behavior
4. Added documentation notes about case-sensitivity

All tests are passing and there are no RuboCop offenses.