### PR TITLE
Add mod list command

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -5,3 +5,8 @@
 # one by one as the offenses are removed from the code base.
 # Note that changes in the inspected code, or installation of new
 # versions of RuboCop, may require this file to be generated again.
+
+# Configuration parameters: AllowSubject, Max.
+RSpec/MultipleMemoizedHelpers:
+  Exclude:
+    - 'spec/factorix/cli/commands/mod/list_spec.rb'

--- a/factorix.gemspec
+++ b/factorix.gemspec
@@ -35,5 +35,6 @@ Gem::Specification.new do |spec|
   spec.add_dependency "csv", ">= 3.2.8"
   spec.add_dependency "dry-cli", ">= 1.2.0"
   spec.add_dependency "dry-core", ">= 1.1.0"
+  spec.add_dependency "markdown-tables", ">= 1.1.1"
   spec.add_dependency "sys-proctable", ">= 1.3.0"
 end

--- a/factorix.gemspec
+++ b/factorix.gemspec
@@ -32,6 +32,7 @@ Gem::Specification.new do |spec|
   spec.executables = spec.files.grep(%r{\Aexe/}) {|f| File.basename(f) }
   spec.require_paths = ["lib"]
 
+  spec.add_dependency "csv", ">= 3.2.8"
   spec.add_dependency "dry-cli", ">= 1.2.0"
   spec.add_dependency "dry-core", ">= 1.1.0"
   spec.add_dependency "sys-proctable", ">= 1.3.0"

--- a/lib/factorix/cli.rb
+++ b/lib/factorix/cli.rb
@@ -6,6 +6,7 @@ require_relative "cli/commands/info"
 require_relative "cli/commands/launch"
 require_relative "cli/commands/mod/disable"
 require_relative "cli/commands/mod/enable"
+require_relative "cli/commands/mod/list"
 
 module Factorix
   # Command-line interface for Factorix
@@ -16,5 +17,6 @@ module Factorix
     register "launch", Factorix::CLI::Commands::Launch
     register "mod disable", Factorix::CLI::Commands::Mod::Disable
     register "mod enable", Factorix::CLI::Commands::Mod::Enable
+    register "mod list", Factorix::CLI::Commands::Mod::List
   end
 end

--- a/lib/factorix/cli/commands/mod/list.rb
+++ b/lib/factorix/cli/commands/mod/list.rb
@@ -3,6 +3,7 @@
 require "dry/cli"
 require "factorix"
 require "csv"
+require "markdown-tables"
 
 module Factorix
   class CLI
@@ -53,11 +54,15 @@ module Factorix
           # Output the mod list in Markdown table format
           # @param list [Factorix::ModList] The mod list
           private def output_markdown(list)
-            puts "| Name | Enabled | Version |"
-            puts "| ---- | ------- | ------- |"
+            labels = %w[Name Enabled Version]
+            data = []
+
             list.each do |mod, state|
-              puts "| #{mod.name} | #{state.enabled} | #{state.version || ""} |"
+              data << [mod.name, state.enabled, state.version || ""]
             end
+
+            table = MarkdownTables.make_table(labels, data, is_rows: true)
+            puts table
           end
         end
       end

--- a/lib/factorix/cli/commands/mod/list.rb
+++ b/lib/factorix/cli/commands/mod/list.rb
@@ -1,8 +1,8 @@
 # frozen_string_literal: true
 
+require "csv"
 require "dry/cli"
 require "factorix"
-require "csv"
 require "markdown-tables"
 
 module Factorix
@@ -34,7 +34,7 @@ module Factorix
           # Output the mod list in default format (names only)
           # @param list [Factorix::ModList] The mod list
           private def output_default(list)
-            list.each do |mod, _state|
+            list.each_key do |mod|
               puts mod.name
             end
           end
@@ -55,11 +55,9 @@ module Factorix
           # @param list [Factorix::ModList] The mod list
           private def output_markdown(list)
             labels = %w[Name Enabled Version]
-            data = []
-
-            list.each do |mod, state|
-              data << [mod.name, state.enabled, state.version || ""]
-            end
+            data = list.map {|mod, state|
+              [mod.name, state.enabled, state.version || ""]
+            }
 
             table = MarkdownTables.make_table(labels, data, is_rows: true)
             puts table

--- a/lib/factorix/cli/commands/mod/list.rb
+++ b/lib/factorix/cli/commands/mod/list.rb
@@ -34,7 +34,7 @@ module Factorix
           # Output the mod list in default format (names only)
           # @param list [Factorix::ModList] The mod list
           private def output_default(list)
-            list.each_key do |mod|
+            list.each_mod do |mod|
               puts mod.name
             end
           end

--- a/lib/factorix/cli/commands/mod/list.rb
+++ b/lib/factorix/cli/commands/mod/list.rb
@@ -1,6 +1,7 @@
 # frozen_string_literal: true
 
 require "dry/cli"
+require "factorix"
 
 module Factorix
   class CLI

--- a/lib/factorix/cli/commands/mod/list.rb
+++ b/lib/factorix/cli/commands/mod/list.rb
@@ -59,7 +59,8 @@ module Factorix
               [mod.name, state.enabled, state.version || ""]
             }
 
-            table = MarkdownTables.make_table(labels, data, is_rows: true)
+            # Use left alignment for all columns
+            table = MarkdownTables.make_table(labels, data, is_rows: true, align: "l")
             puts table
           end
         end

--- a/lib/factorix/cli/commands/mod/list.rb
+++ b/lib/factorix/cli/commands/mod/list.rb
@@ -13,11 +13,11 @@ module Factorix
         class List < Dry::CLI::Command
           desc "List all MODs"
 
-          option :format, type: :string, desc: "Output format (csv, markdown)"
+          option :format, type: :string, values: %w[csv markdown], desc: "Output format"
 
           # List all MODs
           # @param options [Hash] The options for the command
-          # @option options [String] :format Output format (csv, markdown)
+          # @option options [String] :format Output format
           def call(**options)
             list = Factorix::ModList.load
 

--- a/lib/factorix/cli/commands/mod/list.rb
+++ b/lib/factorix/cli/commands/mod/list.rb
@@ -1,0 +1,61 @@
+# frozen_string_literal: true
+
+require "dry/cli"
+
+module Factorix
+  class CLI
+    module Commands
+      module Mod
+        # Command for listing mods
+        class List < Dry::CLI::Command
+          desc "List all MODs"
+
+          option :format, type: :string, desc: "Output format (csv, markdown)"
+
+          # List all MODs
+          # @param options [Hash] The options for the command
+          # @option options [String] :format Output format (csv, markdown)
+          def call(**options)
+            list = Factorix::ModList.load
+
+            case options[:format]
+            when "csv"
+              output_csv(list)
+            when "markdown"
+              output_markdown(list)
+            else
+              output_default(list)
+            end
+          end
+
+          # Output the mod list in default format (names only)
+          # @param list [Factorix::ModList] The mod list
+          private def output_default(list)
+            list.each do |mod, _state|
+              puts mod.name
+            end
+          end
+
+          # Output the mod list in CSV format
+          # @param list [Factorix::ModList] The mod list
+          private def output_csv(list)
+            puts "Name,Enabled,Version"
+            list.each do |mod, state|
+              puts "#{mod.name},#{state.enabled},#{state.version || ""}"
+            end
+          end
+
+          # Output the mod list in Markdown table format
+          # @param list [Factorix::ModList] The mod list
+          private def output_markdown(list)
+            puts "| Name | Enabled | Version |"
+            puts "| ---- | ------- | ------- |"
+            list.each do |mod, state|
+              puts "| #{mod.name} | #{state.enabled} | #{state.version || ""} |"
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/factorix/cli/commands/mod/list.rb
+++ b/lib/factorix/cli/commands/mod/list.rb
@@ -2,6 +2,7 @@
 
 require "dry/cli"
 require "factorix"
+require "csv"
 
 module Factorix
   class CLI
@@ -40,9 +41,12 @@ module Factorix
           # Output the mod list in CSV format
           # @param list [Factorix::ModList] The mod list
           private def output_csv(list)
-            puts "Name,Enabled,Version"
-            list.each do |mod, state|
-              puts "#{mod.name},#{state.enabled},#{state.version || ""}"
+            CSV do |csv|
+              csv << %w[Name Enabled Version]
+              list.each do |mod, state|
+                version = state.version.nil? ? nil : state.version
+                csv << [mod.name, state.enabled, version]
+              end
             end
           end
 

--- a/lib/factorix/mod_list.rb
+++ b/lib/factorix/mod_list.rb
@@ -60,6 +60,18 @@ module Factorix
       end
     end
 
+    # Iterate through all mods.
+    # @yieldparam mod [Factorix::Mod] the mod.
+    # @return [Enumerator] if no block is given.
+    # @return [Factorix::ModList] if a block is given.
+    def each_key
+      return @mods.keys.to_enum unless block_given?
+
+      @mods.each_key do |mod|
+        yield(mod)
+      end
+    end
+
     # Add the mod to the list.
     # @param mod [Factorix::Mod] the mod to add.
     # @param enabled [Boolean] the enabled status. Default to true.

--- a/lib/factorix/mod_list.rb
+++ b/lib/factorix/mod_list.rb
@@ -64,7 +64,7 @@ module Factorix
     # @yieldparam mod [Factorix::Mod] the mod.
     # @return [Enumerator] if no block is given.
     # @return [Factorix::ModList] if a block is given.
-    def each_key
+    def each_mod
       return @mods.keys.to_enum unless block_given?
 
       @mods.each_key do |mod|
@@ -72,11 +72,11 @@ module Factorix
       end
     end
 
-    # Alias for each_key
+    # Alias for each_mod
     # @yieldparam mod [Factorix::Mod] the mod.
     # @return [Enumerator] if no block is given.
     # @return [Factorix::ModList] if a block is given.
-    alias each_mod each_key
+    alias each_key each_mod
 
     # Add the mod to the list.
     # @param mod [Factorix::Mod] the mod to add.

--- a/lib/factorix/mod_list.rb
+++ b/lib/factorix/mod_list.rb
@@ -72,6 +72,12 @@ module Factorix
       end
     end
 
+    # Alias for each_key
+    # @yieldparam mod [Factorix::Mod] the mod.
+    # @return [Enumerator] if no block is given.
+    # @return [Factorix::ModList] if a block is given.
+    alias each_mod each_key
+
     # Add the mod to the list.
     # @param mod [Factorix::Mod] the mod to add.
     # @param enabled [Boolean] the enabled status. Default to true.

--- a/spec/factorix/cli/commands/mod/list_spec.rb
+++ b/spec/factorix/cli/commands/mod/list_spec.rb
@@ -1,0 +1,134 @@
+# frozen_string_literal: true
+
+require "factorix/cli/commands/mod/list"
+require "tempfile"
+
+RSpec.describe Factorix::CLI::Commands::Mod::List do
+  let(:command) { Factorix::CLI::Commands::Mod::List.new }
+  let(:mod_list) { instance_double(Factorix::ModList) }
+  let(:base_mod) { Factorix::Mod[name: "base"] }
+  let(:enabled_mod) { Factorix::Mod[name: "enabled-mod"] }
+  let(:disabled_mod) { Factorix::Mod[name: "disabled-mod"] }
+  let(:base_state) { Factorix::ModState[enabled: true, version: nil] }
+  let(:enabled_state) { Factorix::ModState[enabled: true, version: "1.0.0"] }
+  let(:disabled_state) { Factorix::ModState[enabled: false, version: nil] }
+
+  before do
+    allow(Factorix::ModList).to receive(:load).and_return(mod_list)
+    allow(mod_list).to receive(:each).and_yield(base_mod, base_state)
+      .and_yield(enabled_mod, enabled_state)
+      .and_yield(disabled_mod, disabled_state)
+  end
+
+  describe "#call with default format" do
+    let(:options) { {} }
+
+    it "outputs mod names only" do
+      expected_output = <<~OUTPUT
+        base
+        enabled-mod
+        disabled-mod
+      OUTPUT
+      expect { command.call(**options) }.to output(expected_output).to_stdout
+    end
+  end
+
+  describe "#call with csv format" do
+    let(:options) { {format: "csv"} }
+
+    it "outputs CSV with headers and mod data" do
+      expected_output = <<~OUTPUT
+        Name,Enabled,Version
+        base,true,
+        enabled-mod,true,1.0.0
+        disabled-mod,false,
+      OUTPUT
+      expect { command.call(**options) }.to output(expected_output).to_stdout
+    end
+  end
+
+  describe "#call with markdown format" do
+    let(:options) { {format: "markdown"} }
+
+    it "outputs markdown table with headers and mod data" do
+      expected_output = <<~OUTPUT
+        | Name | Enabled | Version |
+        | ---- | ------- | ------- |
+        | base | true |  |
+        | enabled-mod | true | 1.0.0 |
+        | disabled-mod | false |  |
+      OUTPUT
+      expect { command.call(**options) }.to output(expected_output).to_stdout
+    end
+  end
+
+  describe "#call with actual file operations" do
+    let(:options) { {} }
+    let(:mod_list_content) do
+      {
+        mods: [
+          {name: "base", enabled: true},
+          {name: "enabled-mod", enabled: true, version: "1.0.0"},
+          {name: "disabled-mod", enabled: false}
+        ]
+      }
+    end
+    let(:temp_file) { Tempfile.new(["mod-list-", ".json"]) }
+    let(:mod_list_path) { Pathname(temp_file.path) }
+    let(:runtime) { instance_double(Factorix::Runtime) }
+
+    before do
+      temp_file.write(JSON.pretty_generate(mod_list_content))
+      temp_file.flush
+
+      # Allow the real ModList.load to be called
+      allow(Factorix::ModList).to receive(:load).and_call_original
+
+      allow(Factorix::Runtime).to receive(:runtime).and_return(runtime)
+      allow(runtime).to receive(:mod_list_path).and_return(mod_list_path)
+    end
+
+    after do
+      temp_file.close
+      temp_file.unlink
+    end
+
+    it "reads from the mod-list.json file" do
+      expected_output = <<~OUTPUT
+        base
+        enabled-mod
+        disabled-mod
+      OUTPUT
+      expect { command.call(**options) }.to output(expected_output).to_stdout
+    end
+
+    context "with csv format" do
+      let(:options) { {format: "csv"} }
+
+      it "outputs CSV with headers and mod data" do
+        expected_output = <<~OUTPUT
+          Name,Enabled,Version
+          base,true,
+          enabled-mod,true,1.0.0
+          disabled-mod,false,
+        OUTPUT
+        expect { command.call(**options) }.to output(expected_output).to_stdout
+      end
+    end
+
+    context "with markdown format" do
+      let(:options) { {format: "markdown"} }
+
+      it "outputs markdown table with headers and mod data" do
+        expected_output = <<~OUTPUT
+          | Name | Enabled | Version |
+          | ---- | ------- | ------- |
+          | base | true |  |
+          | enabled-mod | true | 1.0.0 |
+          | disabled-mod | false |  |
+        OUTPUT
+        expect { command.call(**options) }.to output(expected_output).to_stdout
+      end
+    end
+  end
+end

--- a/spec/factorix/cli/commands/mod/list_spec.rb
+++ b/spec/factorix/cli/commands/mod/list_spec.rb
@@ -18,6 +18,14 @@ RSpec.describe Factorix::CLI::Commands::Mod::List do
     allow(mod_list).to receive(:each).and_yield(base_mod, base_state)
       .and_yield(enabled_mod, enabled_state)
       .and_yield(disabled_mod, disabled_state)
+    allow(mod_list).to receive(:each_key).and_yield(base_mod)
+      .and_yield(enabled_mod)
+      .and_yield(disabled_mod)
+    allow(mod_list).to receive(:map).and_return([
+                                                  [base_mod.name, base_state.enabled, base_state.version],
+                                                  [enabled_mod.name, enabled_state.enabled, enabled_state.version],
+                                                  [disabled_mod.name, disabled_state.enabled, disabled_state.version]
+                                                ])
   end
 
   describe "#call with default format" do

--- a/spec/factorix/cli/commands/mod/list_spec.rb
+++ b/spec/factorix/cli/commands/mod/list_spec.rb
@@ -51,12 +51,13 @@ RSpec.describe Factorix::CLI::Commands::Mod::List do
     let(:options) { {format: "markdown"} }
 
     it "outputs markdown table with headers and mod data" do
+      # The markdown-tables gem formats tables with centered alignment by default
       expected_output = <<~OUTPUT
-        | Name | Enabled | Version |
-        | ---- | ------- | ------- |
-        | base | true |  |
-        | enabled-mod | true | 1.0.0 |
-        | disabled-mod | false |  |
+        |Name|Enabled|Version|
+        |:-:|:-:|:-:|
+        |base|true||
+        |enabled-mod|true|1.0.0|
+        |disabled-mod|false||
       OUTPUT
       expect { command.call(**options) }.to output(expected_output).to_stdout
     end
@@ -120,12 +121,13 @@ RSpec.describe Factorix::CLI::Commands::Mod::List do
       let(:options) { {format: "markdown"} }
 
       it "outputs markdown table with headers and mod data" do
+        # The markdown-tables gem formats tables with centered alignment by default
         expected_output = <<~OUTPUT
-          | Name | Enabled | Version |
-          | ---- | ------- | ------- |
-          | base | true |  |
-          | enabled-mod | true | 1.0.0 |
-          | disabled-mod | false |  |
+          |Name|Enabled|Version|
+          |:-:|:-:|:-:|
+          |base|true||
+          |enabled-mod|true|1.0.0|
+          |disabled-mod|false||
         OUTPUT
         expect { command.call(**options) }.to output(expected_output).to_stdout
       end

--- a/spec/factorix/cli/commands/mod/list_spec.rb
+++ b/spec/factorix/cli/commands/mod/list_spec.rb
@@ -18,7 +18,7 @@ RSpec.describe Factorix::CLI::Commands::Mod::List do
     allow(mod_list).to receive(:each).and_yield(base_mod, base_state)
       .and_yield(enabled_mod, enabled_state)
       .and_yield(disabled_mod, disabled_state)
-    allow(mod_list).to receive(:each_key).and_yield(base_mod)
+    allow(mod_list).to receive(:each_mod).and_yield(base_mod)
       .and_yield(enabled_mod)
       .and_yield(disabled_mod)
     allow(mod_list).to receive(:map).and_return([

--- a/spec/factorix/cli/commands/mod/list_spec.rb
+++ b/spec/factorix/cli/commands/mod/list_spec.rb
@@ -59,10 +59,10 @@ RSpec.describe Factorix::CLI::Commands::Mod::List do
     let(:options) { {format: "markdown"} }
 
     it "outputs markdown table with headers and mod data" do
-      # The markdown-tables gem formats tables with centered alignment by default
+      # Use left alignment for all columns
       expected_output = <<~OUTPUT
         |Name|Enabled|Version|
-        |:-:|:-:|:-:|
+        |:-|:-|:-|
         |base|true||
         |enabled-mod|true|1.0.0|
         |disabled-mod|false||
@@ -129,10 +129,10 @@ RSpec.describe Factorix::CLI::Commands::Mod::List do
       let(:options) { {format: "markdown"} }
 
       it "outputs markdown table with headers and mod data" do
-        # The markdown-tables gem formats tables with centered alignment by default
+        # Use left alignment for all columns
         expected_output = <<~OUTPUT
           |Name|Enabled|Version|
-          |:-:|:-:|:-:|
+          |:-|:-|:-|
           |base|true||
           |enabled-mod|true|1.0.0|
           |disabled-mod|false||


### PR DESCRIPTION
This PR adds a new command 'mod list' that can list mods in different formats (default, CSV, markdown).