### PR TITLE
Add RBS type definitions for existing code

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -187,6 +187,13 @@ identify the purpose of each change.
 - Minimize and explicitly manage dependencies
 - Follow existing error handling patterns
 - Consider performance and memory usage
+- When creating RBS type definitions:
+  - Use per-method `private` keyword instead of section-based approach
+  - Create directory structures that mirror the implementation code
+  - Validate syntax using the `rbs validate` command after creation
+  - Ensure consistency between YARD documentation and type definitions
+  - Take special care when defining types for classes using Data.define
+  - Consider type definitions for external libraries when necessary
 
 ---
 

--- a/sig/factorix.rbs
+++ b/sig/factorix.rbs
@@ -1,4 +1,6 @@
 module Factorix
   VERSION: String
-  # See the writing guide of rbs: https://github.com/ruby/rbs#guides
+
+  # Factorix is a Factorio mod management and development tool.
+  # This module serves as the namespace for all Factorix functionality.
 end

--- a/sig/factorix/cli.rbs
+++ b/sig/factorix/cli.rbs
@@ -1,0 +1,21 @@
+module Factorix
+  # Command-line interface for Factorix
+  class CLI
+    extend Dry::CLI::Registry
+
+    # Register the info command
+    def self.register: (String, singleton(Factorix::CLI::Commands::Info)) -> void
+
+    # Register the launch command
+    def self.register: (String, singleton(Factorix::CLI::Commands::Launch)) -> void
+
+    # Register the mod disable command
+    def self.register: (String, singleton(Factorix::CLI::Commands::Mod::Disable)) -> void
+
+    # Register the mod enable command
+    def self.register: (String, singleton(Factorix::CLI::Commands::Mod::Enable)) -> void
+
+    # Register the mod list command
+    def self.register: (String, singleton(Factorix::CLI::Commands::Mod::List)) -> void
+  end
+end

--- a/sig/factorix/cli/commands/info.rbs
+++ b/sig/factorix/cli/commands/info.rbs
@@ -9,16 +9,14 @@ module Factorix
         # Display runtime information
         def call: (**untyped) -> void
 
-        private
-
         # Display runtime information
-        def display_runtime_info: (Factorix::Runtime runtime) -> void
+        private def display_runtime_info: (Factorix::Runtime runtime) -> void
 
         # Return a hash of information items
-        def info_items: (Factorix::Runtime runtime) -> Hash[String, Pathname]
+        private def info_items: (Factorix::Runtime runtime) -> Hash[String, Pathname]
 
         # Display a single information item
-        def display_item: (String label, untyped value) -> void
+        private def display_item: (String label, untyped value) -> void
       end
     end
   end

--- a/sig/factorix/cli/commands/info.rbs
+++ b/sig/factorix/cli/commands/info.rbs
@@ -3,9 +3,6 @@ module Factorix
     module Commands
       # Command for the info subcommand
       class Info < Dry::CLI::Command
-        # Display information about the Factorio runtime environment
-        desc "Display information about the Factorio runtime environment"
-
         # Display runtime information
         def call: (**untyped) -> void
 

--- a/sig/factorix/cli/commands/info.rbs
+++ b/sig/factorix/cli/commands/info.rbs
@@ -1,0 +1,25 @@
+module Factorix
+  class CLI
+    module Commands
+      # Command for the info subcommand
+      class Info < Dry::CLI::Command
+        # Display information about the Factorio runtime environment
+        desc "Display information about the Factorio runtime environment"
+
+        # Display runtime information
+        def call: (**untyped) -> void
+
+        private
+
+        # Display runtime information
+        def display_runtime_info: (Factorix::Runtime runtime) -> void
+
+        # Return a hash of information items
+        def info_items: (Factorix::Runtime runtime) -> Hash[String, Pathname]
+
+        # Display a single information item
+        def display_item: (String label, untyped value) -> void
+      end
+    end
+  end
+end

--- a/sig/factorix/cli/commands/launch.rbs
+++ b/sig/factorix/cli/commands/launch.rbs
@@ -3,12 +3,6 @@ module Factorix
     module Commands
       # Command for the launch subcommand
       class Launch < Dry::CLI::Command
-        # Display description for the launch command
-        desc "Launch the game"
-
-        # Define options for the launch command
-        option :wait, type: :boolean, default: false, alias: ["w"], desc: "Wait for the game to finish"
-
         # Launch the game
         # @param args [Array<String>] Additional arguments to pass to the game
         # @param options [Hash] Options for the command

--- a/sig/factorix/cli/commands/launch.rbs
+++ b/sig/factorix/cli/commands/launch.rbs
@@ -15,12 +15,10 @@ module Factorix
         # @option options [Boolean] :wait Whether to wait for the game to finish
         def call: (?args: Array[String], **untyped options) -> void
 
-        private
-
         # Wait while the given block returns true
         # @yield Block to evaluate
         # @return [void]
-        def wait_while: () { () -> bool } -> void
+        private def wait_while: () { () -> bool } -> void
       end
     end
   end

--- a/sig/factorix/cli/commands/launch.rbs
+++ b/sig/factorix/cli/commands/launch.rbs
@@ -1,0 +1,27 @@
+module Factorix
+  class CLI
+    module Commands
+      # Command for the launch subcommand
+      class Launch < Dry::CLI::Command
+        # Display description for the launch command
+        desc "Launch the game"
+
+        # Define options for the launch command
+        option :wait, type: :boolean, default: false, alias: ["w"], desc: "Wait for the game to finish"
+
+        # Launch the game
+        # @param args [Array<String>] Additional arguments to pass to the game
+        # @param options [Hash] Options for the command
+        # @option options [Boolean] :wait Whether to wait for the game to finish
+        def call: (?args: Array[String], **untyped options) -> void
+
+        private
+
+        # Wait while the given block returns true
+        # @yield Block to evaluate
+        # @return [void]
+        def wait_while: () { () -> bool } -> void
+      end
+    end
+  end
+end

--- a/sig/factorix/cli/commands/mod/disable.rbs
+++ b/sig/factorix/cli/commands/mod/disable.rbs
@@ -1,0 +1,25 @@
+module Factorix
+  class CLI
+    module Commands
+      module Mod
+        # Command for disabling a mod
+        class Disable < Dry::CLI::Command
+          # Display description for the disable command
+          desc "Disable a MOD"
+
+          # Define arguments for the disable command
+          argument :mod, required: true, desc: "The MOD to disable"
+
+          # Define options for the disable command
+          option :verbose, type: :boolean, default: false, desc: "Print more information"
+
+          # Disable a MOD
+          # @param mod [String] The MOD to disable
+          # @param options [Hash] The options for the command
+          # @option options [Boolean] :verbose Print more information
+          def call: (mod: String, **untyped options) -> void
+        end
+      end
+    end
+  end
+end

--- a/sig/factorix/cli/commands/mod/disable.rbs
+++ b/sig/factorix/cli/commands/mod/disable.rbs
@@ -4,15 +4,6 @@ module Factorix
       module Mod
         # Command for disabling a mod
         class Disable < Dry::CLI::Command
-          # Display description for the disable command
-          desc "Disable a MOD"
-
-          # Define arguments for the disable command
-          argument :mod, required: true, desc: "The MOD to disable"
-
-          # Define options for the disable command
-          option :verbose, type: :boolean, default: false, desc: "Print more information"
-
           # Disable a MOD
           # @param mod [String] The MOD to disable
           # @param options [Hash] The options for the command

--- a/sig/factorix/cli/commands/mod/enable.rbs
+++ b/sig/factorix/cli/commands/mod/enable.rbs
@@ -1,0 +1,25 @@
+module Factorix
+  class CLI
+    module Commands
+      module Mod
+        # Command for enabling a mod
+        class Enable < Dry::CLI::Command
+          # Display description for the enable command
+          desc "Enable a MOD"
+
+          # Define arguments for the enable command
+          argument :mod, required: true, desc: "The MOD to enable"
+
+          # Define options for the enable command
+          option :verbose, type: :boolean, default: false, desc: "Print more information"
+
+          # Enable a MOD
+          # @param mod [String] The MOD to enable
+          # @param options [Hash] The options for the command
+          # @option options [Boolean] :verbose Print more information
+          def call: (mod: String, **untyped options) -> void
+        end
+      end
+    end
+  end
+end

--- a/sig/factorix/cli/commands/mod/enable.rbs
+++ b/sig/factorix/cli/commands/mod/enable.rbs
@@ -4,15 +4,6 @@ module Factorix
       module Mod
         # Command for enabling a mod
         class Enable < Dry::CLI::Command
-          # Display description for the enable command
-          desc "Enable a MOD"
-
-          # Define arguments for the enable command
-          argument :mod, required: true, desc: "The MOD to enable"
-
-          # Define options for the enable command
-          option :verbose, type: :boolean, default: false, desc: "Print more information"
-
           # Enable a MOD
           # @param mod [String] The MOD to enable
           # @param options [Hash] The options for the command

--- a/sig/factorix/cli/commands/mod/list.rbs
+++ b/sig/factorix/cli/commands/mod/list.rbs
@@ -4,12 +4,6 @@ module Factorix
       module Mod
         # Command for listing mods
         class List < Dry::CLI::Command
-          # Display description for the list command
-          desc "List all MODs"
-
-          # Define options for the list command
-          option :format, type: :string, values: %w[csv markdown], desc: "Output format"
-
           # List all MODs
           # @param options [Hash] The options for the command
           # @option options [String] :format Output format

--- a/sig/factorix/cli/commands/mod/list.rbs
+++ b/sig/factorix/cli/commands/mod/list.rbs
@@ -15,19 +15,17 @@ module Factorix
           # @option options [String] :format Output format
           def call: (**untyped options) -> void
 
-          private
-
           # Output the mod list in default format (names only)
           # @param list [Factorix::ModList] The mod list
-          def output_default: (Factorix::ModList list) -> void
+          private def output_default: (Factorix::ModList list) -> void
 
           # Output the mod list in CSV format
           # @param list [Factorix::ModList] The mod list
-          def output_csv: (Factorix::ModList list) -> void
+          private def output_csv: (Factorix::ModList list) -> void
 
           # Output the mod list in Markdown table format
           # @param list [Factorix::ModList] The mod list
-          def output_markdown: (Factorix::ModList list) -> void
+          private def output_markdown: (Factorix::ModList list) -> void
         end
       end
     end

--- a/sig/factorix/cli/commands/mod/list.rbs
+++ b/sig/factorix/cli/commands/mod/list.rbs
@@ -1,0 +1,35 @@
+module Factorix
+  class CLI
+    module Commands
+      module Mod
+        # Command for listing mods
+        class List < Dry::CLI::Command
+          # Display description for the list command
+          desc "List all MODs"
+
+          # Define options for the list command
+          option :format, type: :string, values: %w[csv markdown], desc: "Output format"
+
+          # List all MODs
+          # @param options [Hash] The options for the command
+          # @option options [String] :format Output format
+          def call: (**untyped options) -> void
+
+          private
+
+          # Output the mod list in default format (names only)
+          # @param list [Factorix::ModList] The mod list
+          def output_default: (Factorix::ModList list) -> void
+
+          # Output the mod list in CSV format
+          # @param list [Factorix::ModList] The mod list
+          def output_csv: (Factorix::ModList list) -> void
+
+          # Output the mod list in Markdown table format
+          # @param list [Factorix::ModList] The mod list
+          def output_markdown: (Factorix::ModList list) -> void
+        end
+      end
+    end
+  end
+end

--- a/sig/factorix/errors.rbs
+++ b/sig/factorix/errors.rbs
@@ -1,0 +1,10 @@
+module Factorix
+  # Base error class for Factorix.
+  class Error < StandardError
+  end
+
+  # Raised when a MOD is not found.
+  class ModNotFoundError < Error
+    def initialize: (untyped mod) -> void
+  end
+end

--- a/sig/factorix/mod.rbs
+++ b/sig/factorix/mod.rbs
@@ -1,0 +1,32 @@
+module Factorix
+  # Represent MOD
+  class Mod < Data
+    include Comparable
+
+    # @!attribute [r] name
+    #   @return [String] the name of the mod
+    attr_reader name: String
+
+    # Constructor for Mod
+    def initialize: (name: String) -> void
+
+    # Factory method for creating Mod instances
+    def self.[]: (name: String) -> Mod
+
+    # Return true if this mod is the base mod
+    # @return [Boolean] true if this mod is the base mod
+    # @note The check is case-sensitive, only "base" (not "BASE" or "Base") is considered the base mod
+    def base?: -> bool
+
+    # Return the name of the mod
+    # @return [String] the name of the mod
+    def to_s: -> String
+
+    # Compare this mod with another mod by name.
+    # @param other [Mod] the other mod
+    # @return [Integer] -1 if this mod precedes the other, 0 if they are equal, 1 if this mod follows the other
+    # @note Comparison is case-sensitive for mod names.
+    # @note The base mod (exactly "base", case-sensitive) always comes before any other mod.
+    def <=>: (Mod other) -> Integer
+  end
+end

--- a/sig/factorix/mod_list.rbs
+++ b/sig/factorix/mod_list.rbs
@@ -1,0 +1,91 @@
+module Factorix
+  # Represent a list of MODs and their enabled status.
+  class ModList
+    include Enumerable[[Mod, ModState]]
+
+    # Raised when a MOD is not found.
+    class ModNotInListError < Factorix::ModNotFoundError
+      def initialize: (Mod mod) -> void
+    end
+
+    # Load the mod list from the given file.
+    # @param from [Pathname] the path to the file to load the mod list from.
+    # @return [Factorix::ModList] the loaded mod list.
+    def self.load: (?from: Pathname) -> ModList
+
+    # Initialize the mod list.
+    # @param mods [Hash{Factorix::Mod => ModState}] the mods and their state.
+    # @return [void]
+    def initialize: (?mods: Hash[Mod, ModState]) -> void
+
+    # Save the mod list to the given file.
+    # @param to [Pathname] the path to the file to save the mod list to.
+    # @return [void]
+    def save: (?to: Pathname) -> void
+
+    # Iterate through all mod-state pairs.
+    # @yieldparam mod [Factorix::Mod] the mod.
+    # @yieldparam state [Factorix::ModState] the mod state.
+    # @return [Enumerator] if no block is given.
+    # @return [Factorix::ModList] if a block is given.
+    def each: () { (Mod, ModState) -> void } -> ModList
+            | () -> Enumerator[[Mod, ModState]]
+
+    # Iterate through all mods.
+    # @yieldparam mod [Factorix::Mod] the mod.
+    # @return [Enumerator] if no block is given.
+    # @return [Factorix::ModList] if a block is given.
+    def each_mod: () { (Mod) -> void } -> ModList
+                | () -> Enumerator[Mod]
+
+    # Alias for each_mod
+    # @yieldparam mod [Factorix::Mod] the mod.
+    # @return [Enumerator] if no block is given.
+    # @return [Factorix::ModList] if a block is given.
+    alias each_key each_mod
+
+    # Add the mod to the list.
+    # @param mod [Factorix::Mod] the mod to add.
+    # @param enabled [Boolean] the enabled status. Default to true.
+    # @param version [String, nil] the version of the mod. Default to nil.
+    # @return [void]
+    # @raise [ArgumentError] if the mod is the base mod and the enabled status is false.
+    def add: (Mod mod, ?enabled: bool, ?version: String?) -> void
+
+    # Remove the mod from the list.
+    # @param mod [Factorix::Mod] the mod to remove.
+    # @return [void]
+    # @raise [ArgumentError] if the mod is the base mod.
+    def remove: (Mod mod) -> void
+
+    # Check if the mod is in the list.
+    # @param mod [Factorix::Mod] the mod to check.
+    # @return [Boolean] true if the mod is in the list, false otherwise.
+    def exist?: (Mod mod) -> bool
+
+    # Check if the mod is enabled.
+    # @param mod [Factorix::Mod] the mod to check.
+    # @return [Boolean] true if the mod is enabled, false otherwise.
+    # @raise [Factorix::ModList::ModNotInListError] if the mod is not in the list.
+    def enabled?: (Mod mod) -> bool
+
+    # Get the version of the mod.
+    # @param mod [Factorix::Mod] the mod to check.
+    # @return [String, nil] the version of the mod, or nil if not specified.
+    # @raise [Factorix::ModList::ModNotInListError] if the mod is not in the list.
+    def version: (Mod mod) -> String?
+
+    # Enable the mod.
+    # @param mod [Factorix::Mod] the mod to enable.
+    # @return [void]
+    # @raise [Factorix::ModList::ModNotInListError] if the mod is not in the list.
+    def enable: (Mod mod) -> void
+
+    # Disable the mod.
+    # @param mod [Factorix::Mod] the mod to disable.
+    # @return [void]
+    # @raise [ArgumentError] if the mod is the base mod.
+    # @raise [Factorix::ModList::ModNotInListError] if the mod is not in the list.
+    def disable: (Mod mod) -> void
+  end
+end

--- a/sig/factorix/mod_state.rbs
+++ b/sig/factorix/mod_state.rbs
@@ -1,0 +1,20 @@
+module Factorix
+  # Represent the state of a MOD in a mod list
+  class ModState < Data
+    # !attribute [r] enabled
+    #  @return [Boolean] whether the mod is enabled
+    attr_reader enabled: bool
+
+    # !attribute [r] version
+    #  @return [String, nil] the version of the mod, or nil if the version is not specified
+    attr_reader version: String?
+
+    # Initialize a new ModState
+    # @param enabled [Boolean] whether the mod is enabled
+    # @param version [String, nil] the version of the mod (optional)
+    def initialize: (enabled: bool, ?version: String?) -> void
+
+    # Factory method for creating ModState instances
+    def self.[]: (enabled: bool, ?version: String?) -> ModState
+  end
+end

--- a/sig/factorix/runtime.rbs
+++ b/sig/factorix/runtime.rbs
@@ -1,0 +1,56 @@
+module Factorix
+  # Factorio runtime environment
+  class Runtime
+    # Raised when run on unsupported platform
+    class UnsupportedPlatform < StandardError
+    end
+
+    # Raised when the game is already running and an attempt to launch the game is made
+    class AlreadyRunning < StandardError
+    end
+
+    # Return the platform the script is running on
+    # @return [Runtime] the runtime environment
+    # @raise [UnsupportedPlatform] if the platform is not supported
+    def self.runtime: () -> Runtime
+
+    # Return the mods directory of Factorio
+    # @return [Pathname] the mods directory of Factorio
+    def mods_dir: () -> Pathname
+
+    # Return the script-output directory of Factorio
+    # @return [Pathname] the script-output directory of Factorio
+    def script_output_dir: () -> Pathname
+
+    # Return the path of the mod-list.json file
+    # @return [Pathname] the path of the mod-list.json file
+    def mod_list_path: () -> Pathname
+
+    # Launch the game
+    # @return [void]
+    # @raise [RuntimeError] if the game is already running
+    def launch: (*untyped, async: bool) -> void
+
+    # Check if the game is running
+    #
+    # Becasuse the game becomes daemonized on launch, we cannot use the process ID nor Process groups
+    # to check if the game is running.  Instead, we check if the game is running by external means.
+    # (e.g. polling the process list periodically)
+    #
+    # Note: Subclasses should implement this method
+    # @return [Boolean] true if the game is running, false otherwise
+    def running?: () -> bool
+
+    # Return the user directory of Factorio
+    # @return [Pathname] the user directory of Factorio
+    def user_dir: () -> Pathname
+
+    # Return the executable path of Factorio
+    # @return [Pathname] the executable path of Factorio
+    def executable: () -> Pathname
+
+    # Return the data directory of Factorio
+    # @return [Pathname] the data directory of Factorio
+    def data_dir: () -> Pathname
+  end
+end

--- a/sig/factorix/runtime/linux.rbs
+++ b/sig/factorix/runtime/linux.rbs
@@ -1,0 +1,18 @@
+module Factorix
+  class Runtime
+    # Linux runtime environment
+    class Linux < Runtime
+      # Return the path to the Factorio executable
+      # @return [Pathname] path to the Factorio executable
+      def executable: () -> Pathname
+
+      # Return the path to the user's Factorio directory
+      # @return [Pathname] path to the user's Factorio directory
+      def user_dir: () -> Pathname
+
+      # Return the path to the Factorio data directory
+      # @return [Pathname] path to the Factorio data directory
+      def data_dir: () -> Pathname
+    end
+  end
+end

--- a/sig/factorix/runtime/mac_os.rbs
+++ b/sig/factorix/runtime/mac_os.rbs
@@ -18,11 +18,9 @@ module Factorix
       # @return [Boolean] true if the game is running, false otherwise
       def running?: () -> bool
 
-      private
-
       # Return the path to the user's home directory
       # @return [Pathname] path to the user's home directory
-      def home_dir: () -> Pathname
+      private def home_dir: () -> Pathname
     end
   end
 end

--- a/sig/factorix/runtime/mac_os.rbs
+++ b/sig/factorix/runtime/mac_os.rbs
@@ -1,0 +1,28 @@
+module Factorix
+  class Runtime
+    # MacOS runtime environment
+    class MacOS < Runtime
+      # Return the path to the Factorio executable
+      # @return [Pathname] path to the Factorio executable
+      def executable: () -> Pathname
+
+      # Return the path to the user's Factorio directory
+      # @return [Pathname] path to the user's Factorio directory
+      def user_dir: () -> Pathname
+
+      # Return the path to the Factorio data directory
+      # @return [Pathname] path to the Factorio data directory
+      def data_dir: () -> Pathname
+
+      # Check if the game is running
+      # @return [Boolean] true if the game is running, false otherwise
+      def running?: () -> bool
+
+      private
+
+      # Return the path to the user's home directory
+      # @return [Pathname] path to the user's home directory
+      def home_dir: () -> Pathname
+    end
+  end
+end

--- a/sig/factorix/runtime/windows.rbs
+++ b/sig/factorix/runtime/windows.rbs
@@ -12,19 +12,13 @@ module Factorix
         # @return [Pathname] path to the Program Files (x86) directory
         def program_files_x86: () -> Pathname
 
-        private
-
-        def convert_env_path: (String name) -> Pathname
+        private def convert_env_path: (String name) -> Pathname
       end
 
       # Initialize Windows runtime environment
       def initialize: (?path: WindowsPath) -> void
 
-      private
-
-      attr_reader path: WindowsPath
-
-      public
+      private attr_reader path: WindowsPath
 
       # Return the path to the Factorio executable
       # @return [Pathname] path to the Factorio executable

--- a/sig/factorix/runtime/windows.rbs
+++ b/sig/factorix/runtime/windows.rbs
@@ -1,0 +1,42 @@
+module Factorix
+  class Runtime
+    # Windows runtime environment
+    class Windows < Runtime
+      # Windows specific path handling
+      class WindowsPath
+        # Return the path to the user's AppData directory
+        # @return [Pathname] path to the user's AppData directory
+        def app_data: () -> Pathname
+
+        # Return the path to the Program Files (x86) directory
+        # @return [Pathname] path to the Program Files (x86) directory
+        def program_files_x86: () -> Pathname
+
+        private
+
+        def convert_env_path: (String name) -> Pathname
+      end
+
+      # Initialize Windows runtime environment
+      def initialize: (?path: WindowsPath) -> void
+
+      private
+
+      attr_reader path: WindowsPath
+
+      public
+
+      # Return the path to the Factorio executable
+      # @return [Pathname] path to the Factorio executable
+      def executable: () -> Pathname
+
+      # Return the path to the user's Factorio directory
+      # @return [Pathname] path to the user's Factorio directory
+      def user_dir: () -> Pathname
+
+      # Return the path to the Factorio data directory
+      # @return [Pathname] path to the Factorio data directory
+      def data_dir: () -> Pathname
+    end
+  end
+end

--- a/sig/factorix/runtime/wsl.rbs
+++ b/sig/factorix/runtime/wsl.rbs
@@ -1,0 +1,38 @@
+module Factorix
+  class Runtime
+    # WSL runtime environment
+    class WSL < Windows
+      # WSL specific path handling
+      class WSLPath
+        extend Dry::Core::Cache
+
+        # Return the path to the user's AppData directory
+        # @return [Pathname] path to the user's AppData directory
+        def app_data: () -> Pathname
+
+        # Return the path to the Program Files (x86) directory
+        # @return [Pathname] path to the Program Files (x86) directory
+        def program_files_x86: () -> Pathname
+
+        private
+
+        def cmd_echo: (String name) -> String
+        def wslvar: (String name) -> String
+        def wslpath: (String path) -> String
+      end
+
+      # Initialize WSL runtime environment
+      def initialize: (?path: WSLPath) -> void
+
+      private
+
+      attr_reader path: WSLPath
+
+      public
+
+      # Check if the game is running
+      # @return [Boolean] true if the game is running, false otherwise
+      def running?: () -> bool
+    end
+  end
+end

--- a/sig/factorix/runtime/wsl.rbs
+++ b/sig/factorix/runtime/wsl.rbs
@@ -14,21 +14,15 @@ module Factorix
         # @return [Pathname] path to the Program Files (x86) directory
         def program_files_x86: () -> Pathname
 
-        private
-
-        def cmd_echo: (String name) -> String
-        def wslvar: (String name) -> String
-        def wslpath: (String path) -> String
+        private def cmd_echo: (String name) -> String
+        private def wslvar: (String name) -> String
+        private def wslpath: (String path) -> String
       end
 
       # Initialize WSL runtime environment
       def initialize: (?path: WSLPath) -> void
 
-      private
-
-      attr_reader path: WSLPath
-
-      public
+      private attr_reader path: WSLPath
 
       # Check if the game is running
       # @return [Boolean] true if the game is running, false otherwise

--- a/sig/factorix/version.rbs
+++ b/sig/factorix/version.rbs
@@ -1,0 +1,4 @@
+module Factorix
+  # Version of the Factorix gem
+  VERSION: String
+end


### PR DESCRIPTION
This PR adds RBS type definitions for the existing code base. It includes:

1. Type definitions for all major classes and modules
2. Removal of non-RBS elements from RBS files
3. Update of RBS files to use per-method private keyword
4. Addition of RBS type definition guidelines to DEVELOPMENT.md

These changes improve code safety and readability, and enhance IDE code completion capabilities.