### PR TITLE
Fix MOD terminology in documentation

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -9,9 +9,9 @@ Factorix is a Ruby library and CLI for Factorio mod management.
 
 ## Code Architecture
 
-- **Mod**: Base class for modules
-- **ModList**: Manages module collections
-- **ModState**: Tracks module states
+- **Mod**: Base class for MODs
+- **ModList**: Manages MOD collections
+- **ModState**: Tracks MOD states
 - **Runtime**: OS-specific environments
 - **CLI**: Command-line interface
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -34,6 +34,7 @@ Factorix is a Ruby library and CLI for Factorio mod management.
 
 ## Documentation
 
+- Use English for all documentation and comments
 - YARD format for public APIs
 - Document class purpose, method inputs/outputs/side effects
 - Use infinitive form for verbs

--- a/MEMORY_BANK.md
+++ b/MEMORY_BANK.md
@@ -142,6 +142,23 @@ end
 - Use `:inbox_tray:` (📥) emoji prefix for merge commits
 - Format merge commit messages as `:inbox_tray: Merge pull request #N: [PR title]`
 
+### Pull Request Merging Process
+
+When merging PRs, AI assistants should follow this process:
+
+1. **Pre-merge Checks**
+   - Verify all CI checks have passed
+   - Confirm required reviews are completed
+   - Ensure there are no merge conflicts
+
+2. **Merge Method**
+   - Use standard merge (`--merge`) as the default approach
+   - Commit message will follow the format: `:inbox_tray: Merge pull request #N: [PR title]`
+
+3. **Post-merge Cleanup**
+   - Delete the branch after merging (`gh pr merge --delete-branch`)
+   - Switch back to the main branch if needed (`git checkout main`)
+
 ## AI Guidelines
 
 When generating or modifying code for this project:

--- a/MEMORY_BANK.md
+++ b/MEMORY_BANK.md
@@ -11,9 +11,9 @@ This document serves as a structured knowledge base for the Factorix project, de
 
 ## Code Architecture
 
-- **Mod**: Base class representing modules
-- **ModList**: Manages collections of modules
-- **ModState**: Tracks module states (enabled/disabled)
+- **Mod**: Base class representing MODs
+- **ModList**: Manages collections of MODs
+- **ModState**: Tracks MOD states (enabled/disabled)
 - **Runtime**: Provides runtime environments for different OS environments (Linux, macOS, Windows, WSL)
 - **CLI**: Command-line interface and command implementations
 
@@ -23,7 +23,7 @@ This document serves as a structured knowledge base for the Factorix project, de
 lib/factorix/                 # Main code
 ├── cli/                      # CLI command implementations
 │   └── commands/             # Individual commands
-│       └── mod/              # Module-related commands
+│       └── mod/              # MOD-related commands
 ├── runtime/                  # OS-specific implementations
 sig/                          # Type definitions (RBS)
 spec/                         # Test code (RSpec)
@@ -74,11 +74,11 @@ Example:
 ```ruby
 # Create MOD
 #
-# @param name [String] Module name
+# @param name [String] MOD name
 # @param version [String] Version in semantic versioning format
-# @param dependencies [Array<String>] Array of dependent module names
+# @param dependencies [Array<String>] Array of dependent MOD names
 # @return [Mod] Created Mod object
-# @raise [InvalidModError] If module definition is invalid
+# @raise [InvalidModError] If MOD definition is invalid
 def create_mod(name, version, dependencies = [])
   # Implementation...
 end
@@ -101,7 +101,7 @@ end
 
 ## Performance
 
-- Efficiently handle large numbers of modules
+- Efficiently handle large numbers of MODs
 - Minimize memory usage
 - Report progress for long-running operations
 - Consider buffering and async processing for I/O operations

--- a/lib/factorix/cli/commands/mod/disable.rb
+++ b/lib/factorix/cli/commands/mod/disable.rb
@@ -6,7 +6,7 @@ module Factorix
   class CLI
     module Commands
       module Mod
-        # Command for disabling a mod
+        # Command for disabling a MOD
         class Disable < Dry::CLI::Command
           desc "Disable a MOD"
 

--- a/lib/factorix/cli/commands/mod/enable.rb
+++ b/lib/factorix/cli/commands/mod/enable.rb
@@ -6,7 +6,7 @@ module Factorix
   class CLI
     module Commands
       module Mod
-        # Command for enabling a mod
+        # Command for enabling a MOD
         class Enable < Dry::CLI::Command
           desc "Enable a MOD"
 

--- a/lib/factorix/cli/commands/mod/list.rb
+++ b/lib/factorix/cli/commands/mod/list.rb
@@ -9,7 +9,7 @@ module Factorix
   class CLI
     module Commands
       module Mod
-        # Command for listing mods
+        # Command for listing MODs
         class List < Dry::CLI::Command
           desc "List all MODs"
 
@@ -31,16 +31,16 @@ module Factorix
             end
           end
 
-          # Output the mod list in default format (names only)
-          # @param list [Factorix::ModList] The mod list
+          # Output the MOD list in default format (names only)
+          # @param list [Factorix::ModList] The MOD list
           private def output_default(list)
             list.each_mod do |mod|
               puts mod.name
             end
           end
 
-          # Output the mod list in CSV format
-          # @param list [Factorix::ModList] The mod list
+          # Output the MOD list in CSV format
+          # @param list [Factorix::ModList] The MOD list
           private def output_csv(list)
             CSV do |csv|
               csv << %w[Name Enabled Version]
@@ -51,8 +51,8 @@ module Factorix
             end
           end
 
-          # Output the mod list in Markdown table format
-          # @param list [Factorix::ModList] The mod list
+          # Output the MOD list in Markdown table format
+          # @param list [Factorix::ModList] The MOD list
           private def output_markdown(list)
             labels = %w[Name Enabled Version]
             data = list.map {|mod, state|

--- a/lib/factorix/mod.rb
+++ b/lib/factorix/mod.rb
@@ -6,22 +6,22 @@ module Factorix
     include Comparable
 
     # @!attribute [r] name
-    #   @return [String] the name of the mod
+    #   @return [String] the name of the MOD
 
-    # Return true if this mod is the base mod
-    # @return [Boolean] true if this mod is the base mod
-    # @note The check is case-sensitive, only "base" (not "BASE" or "Base") is considered the base mod
+    # Return true if this MOD is the base MOD
+    # @return [Boolean] true if this MOD is the base MOD
+    # @note The check is case-sensitive, only "base" (not "BASE" or "Base") is considered the base MOD
     def base? = name == "base"
 
-    # Return the name of the mod
-    # @return [String] the name of the mod
+    # Return the name of the MOD
+    # @return [String] the name of the MOD
     def to_s = name
 
-    # Compare this mod with another mod by name.
-    # @param other [Mod] the other mod
-    # @return [Integer] -1 if this mod precedes the other, 0 if they are equal, 1 if this mod follows the other
-    # @note Comparison is case-sensitive for mod names.
-    # @note The base mod (exactly "base", case-sensitive) always comes before any other mod.
+    # Compare this MOD with another MOD by name.
+    # @param other [Mod] the other MOD
+    # @return [Integer] -1 if this MOD precedes the other, 0 if they are equal, 1 if this MOD follows the other
+    # @note Comparison is case-sensitive for MOD names.
+    # @note The base MOD (exactly "base", case-sensitive) always comes before any other MOD.
     def <=>(other) = (base? && (other.base? ? 0 : -1)) || (other.base? ? 1 : name <=> other.name)
   }
 end

--- a/lib/factorix/mod_list.rb
+++ b/lib/factorix/mod_list.rb
@@ -16,16 +16,16 @@ module Factorix
       end
     end
 
-    # Load the mod list from the given file.
-    # @param from [Pathname] the path to the file to load the mod list from.
-    # @return [Factorix::ModList] the loaded mod list.
+    # Load the MOD list from the given file.
+    # @param from [Pathname] the path to the file to load the MOD list from.
+    # @return [Factorix::ModList] the loaded MOD list.
     def self.load(from: Factorix::Runtime.runtime.mod_list_path)
       raw_data = JSON.parse(from.read, symbolize_names: true)
       new(raw_data[:mods].to_h {|e| [Mod[name: e[:name]], ModState[enabled: e[:enabled], version: e[:version]]] })
     end
 
-    # Initialize the mod list.
-    # @param mods [Hash{Factorix::Mod => ModState}] the mods and their state.
+    # Initialize the MOD list.
+    # @param mods [Hash{Factorix::Mod => ModState}] the MODs and their state.
     # @return [void]
     def initialize(mods={})
       @mods = {}
@@ -34,8 +34,8 @@ module Factorix
       end
     end
 
-    # Save the mod list to the given file.
-    # @param to [Pathname] the path to the file to save the mod list to.
+    # Save the MOD list to the given file.
+    # @param to [Pathname] the path to the file to save the MOD list to.
     # @return [void]
     def save(to: Factorix::Runtime.runtime.mod_list_path)
       mods_data = @mods.map {|mod, state|
@@ -47,9 +47,9 @@ module Factorix
       to.write(JSON.pretty_generate({mods: mods_data}))
     end
 
-    # Iterate through all mod-state pairs.
-    # @yieldparam mod [Factorix::Mod] the mod.
-    # @yieldparam state [Factorix::ModState] the mod state.
+    # Iterate through all MOD-state pairs.
+    # @yieldparam mod [Factorix::Mod] the MOD.
+    # @yieldparam state [Factorix::ModState] the MOD state.
     # @return [Enumerator] if no block is given.
     # @return [Factorix::ModList] if a block is given.
     def each
@@ -60,8 +60,8 @@ module Factorix
       end
     end
 
-    # Iterate through all mods.
-    # @yieldparam mod [Factorix::Mod] the mod.
+    # Iterate through all MODs.
+    # @yieldparam mod [Factorix::Mod] the MOD.
     # @return [Enumerator] if no block is given.
     # @return [Factorix::ModList] if a block is given.
     def each_mod
@@ -73,62 +73,62 @@ module Factorix
     end
 
     # Alias for each_mod
-    # @yieldparam mod [Factorix::Mod] the mod.
+    # @yieldparam mod [Factorix::Mod] the MOD.
     # @return [Enumerator] if no block is given.
     # @return [Factorix::ModList] if a block is given.
     alias each_key each_mod
 
-    # Add the mod to the list.
-    # @param mod [Factorix::Mod] the mod to add.
+    # Add the MOD to the list.
+    # @param mod [Factorix::Mod] the MOD to add.
     # @param enabled [Boolean] the enabled status. Default to true.
-    # @param version [String, nil] the version of the mod. Default to nil.
+    # @param version [String, nil] the version of the MOD. Default to nil.
     # @return [void]
-    # @raise [ArgumentError] if the mod is the base mod and the enabled status is false.
+    # @raise [ArgumentError] if the MOD is the base MOD and the enabled status is false.
     def add(mod, enabled: true, version: nil)
-      raise ArgumentError, "can't disable the base mod" if mod.base? && enabled == false
+      raise ArgumentError, "can't disable the base MOD" if mod.base? && enabled == false
 
       @mods[mod] = ModState[enabled:, version:]
     end
 
-    # Remove the mod from the list.
-    # @param mod [Factorix::Mod] the mod to remove.
+    # Remove the MOD from the list.
+    # @param mod [Factorix::Mod] the MOD to remove.
     # @return [void]
-    # @raise [ArgumentError] if the mod is the base mod.
+    # @raise [ArgumentError] if the MOD is the base MOD.
     def remove(mod)
-      raise ArgumentError, "can't remove the base mod" if mod.base?
+      raise ArgumentError, "can't remove the base MOD" if mod.base?
 
       @mods.delete(mod)
     end
 
-    # Check if the mod is in the list.
-    # @param mod [Factorix::Mod] the mod to check.
-    # @return [Boolean] true if the mod is in the list, false otherwise.
+    # Check if the MOD is in the list.
+    # @param mod [Factorix::Mod] the MOD to check.
+    # @return [Boolean] true if the MOD is in the list, false otherwise.
     def exist?(mod) = @mods.key?(mod)
 
-    # Check if the mod is enabled.
-    # @param mod [Factorix::Mod] the mod to check.
-    # @return [Boolean] true if the mod is enabled, false otherwise.
-    # @raise [Factorix::ModList::ModNotInListError] if the mod is not in the list.
+    # Check if the MOD is enabled.
+    # @param mod [Factorix::Mod] the MOD to check.
+    # @return [Boolean] true if the MOD is enabled, false otherwise.
+    # @raise [Factorix::ModList::ModNotInListError] if the MOD is not in the list.
     def enabled?(mod)
       raise ModNotInListError, mod unless exist?(mod)
 
       @mods[mod].enabled
     end
 
-    # Get the version of the mod.
-    # @param mod [Factorix::Mod] the mod to check.
-    # @return [String, nil] the version of the mod, or nil if not specified.
-    # @raise [Factorix::ModList::ModNotInListError] if the mod is not in the list.
+    # Get the version of the MOD.
+    # @param mod [Factorix::Mod] the MOD to check.
+    # @return [String, nil] the version of the MOD, or nil if not specified.
+    # @raise [Factorix::ModList::ModNotInListError] if the MOD is not in the list.
     def version(mod)
       raise ModNotInListError, mod unless exist?(mod)
 
       @mods[mod].version
     end
 
-    # Enable the mod.
-    # @param mod [Factorix::Mod] the mod to enable.
+    # Enable the MOD.
+    # @param mod [Factorix::Mod] the MOD to enable.
     # @return [void]
-    # @raise [Factorix::ModList::ModNotInListError] if the mod is not in the list.
+    # @raise [Factorix::ModList::ModNotInListError] if the MOD is not in the list.
     def enable(mod)
       raise ModNotInListError, mod unless exist?(mod)
 
@@ -137,13 +137,13 @@ module Factorix
       @mods[mod] = ModState[enabled: true, version: current_state.version]
     end
 
-    # Disable the mod.
-    # @param mod [Factorix::Mod] the mod to disable.
+    # Disable the MOD.
+    # @param mod [Factorix::Mod] the MOD to disable.
     # @return [void]
-    # @raise [ArgumentError] if the mod is the base mod.
-    # @raise [Factorix::ModList::ModNotInListError] if the mod is not in the list.
+    # @raise [ArgumentError] if the MOD is the base MOD.
+    # @raise [Factorix::ModList::ModNotInListError] if the MOD is not in the list.
     def disable(mod)
-      raise ArgumentError, "can't disable the base mod" if mod.base?
+      raise ArgumentError, "can't disable the base MOD" if mod.base?
       raise ModNotInListError, mod unless exist?(mod)
 
       # Create a new ModState with enabled=false and the same version

--- a/lib/factorix/mod_state.rb
+++ b/lib/factorix/mod_state.rb
@@ -1,19 +1,19 @@
 # frozen_string_literal: true
 
 module Factorix
-  # Represent the state of a MOD in a mod list
+  # Represent the state of a MOD in a MOD list
   ModState = Data.define(:enabled, :version) {
     # Initialize a new ModState
-    # @param enabled [Boolean] whether the mod is enabled
-    # @param version [String, nil] the version of the mod (optional)
+    # @param enabled [Boolean] whether the MOD is enabled
+    # @param version [String, nil] the version of the MOD (optional)
     def initialize(enabled:, version: nil)
       super
     end
 
     # !attribute [r] enabled
-    #  @return [Boolean] whether the mod is enabled
+    #  @return [Boolean] whether the MOD is enabled
 
     # !attribute [r] version
-    #  @return [String, nil] the version of the mod, or nil if the version is not specified
+    #  @return [String, nil] the version of the MOD, or nil if the version is not specified
   }
 end

--- a/sig/factorix/mod.rbs
+++ b/sig/factorix/mod.rbs
@@ -4,7 +4,7 @@ module Factorix
     include Comparable
 
     # @!attribute [r] name
-    #   @return [String] the name of the mod
+    #   @return [String] the name of the MOD
     attr_reader name: String
 
     # Constructor for Mod
@@ -13,20 +13,20 @@ module Factorix
     # Factory method for creating Mod instances
     def self.[]: (name: String) -> Mod
 
-    # Return true if this mod is the base mod
-    # @return [Boolean] true if this mod is the base mod
-    # @note The check is case-sensitive, only "base" (not "BASE" or "Base") is considered the base mod
+    # Return true if this MOD is the base MOD
+    # @return [Boolean] true if this MOD is the base MOD
+    # @note The check is case-sensitive, only "base" (not "BASE" or "Base") is considered the base MOD
     def base?: -> bool
 
-    # Return the name of the mod
-    # @return [String] the name of the mod
+    # Return the name of the MOD
+    # @return [String] the name of the MOD
     def to_s: -> String
 
-    # Compare this mod with another mod by name.
-    # @param other [Mod] the other mod
-    # @return [Integer] -1 if this mod precedes the other, 0 if they are equal, 1 if this mod follows the other
-    # @note Comparison is case-sensitive for mod names.
-    # @note The base mod (exactly "base", case-sensitive) always comes before any other mod.
+    # Compare this MOD with another MOD by name.
+    # @param other [Mod] the other MOD
+    # @return [Integer] -1 if this MOD precedes the other, 0 if they are equal, 1 if this MOD follows the other
+    # @note Comparison is case-sensitive for MOD names.
+    # @note The base MOD (exactly "base", case-sensitive) always comes before any other MOD.
     def <=>: (Mod other) -> Integer
   end
 end

--- a/sig/factorix/mod_list.rbs
+++ b/sig/factorix/mod_list.rbs
@@ -8,84 +8,84 @@ module Factorix
       def initialize: (Mod mod) -> void
     end
 
-    # Load the mod list from the given file.
-    # @param from [Pathname] the path to the file to load the mod list from.
-    # @return [Factorix::ModList] the loaded mod list.
+    # Load the MOD list from the given file.
+    # @param from [Pathname] the path to the file to load the MOD list from.
+    # @return [Factorix::ModList] the loaded MOD list.
     def self.load: (?from: Pathname) -> ModList
 
-    # Initialize the mod list.
-    # @param mods [Hash{Factorix::Mod => ModState}] the mods and their state.
+    # Initialize the MOD list.
+    # @param mods [Hash{Factorix::Mod => ModState}] the MODs and their state.
     # @return [void]
     def initialize: (?mods: Hash[Mod, ModState]) -> void
 
-    # Save the mod list to the given file.
-    # @param to [Pathname] the path to the file to save the mod list to.
+    # Save the MOD list to the given file.
+    # @param to [Pathname] the path to the file to save the MOD list to.
     # @return [void]
     def save: (?to: Pathname) -> void
 
-    # Iterate through all mod-state pairs.
-    # @yieldparam mod [Factorix::Mod] the mod.
-    # @yieldparam state [Factorix::ModState] the mod state.
+    # Iterate through all MOD-state pairs.
+    # @yieldparam mod [Factorix::Mod] the MOD.
+    # @yieldparam state [Factorix::ModState] the MOD state.
     # @return [Enumerator] if no block is given.
     # @return [Factorix::ModList] if a block is given.
     def each: () { (Mod, ModState) -> void } -> ModList
             | () -> Enumerator[[Mod, ModState]]
 
-    # Iterate through all mods.
-    # @yieldparam mod [Factorix::Mod] the mod.
+    # Iterate through all MODs.
+    # @yieldparam mod [Factorix::Mod] the MOD.
     # @return [Enumerator] if no block is given.
     # @return [Factorix::ModList] if a block is given.
     def each_mod: () { (Mod) -> void } -> ModList
                 | () -> Enumerator[Mod]
 
     # Alias for each_mod
-    # @yieldparam mod [Factorix::Mod] the mod.
+    # @yieldparam mod [Factorix::Mod] the MOD.
     # @return [Enumerator] if no block is given.
     # @return [Factorix::ModList] if a block is given.
     alias each_key each_mod
 
-    # Add the mod to the list.
-    # @param mod [Factorix::Mod] the mod to add.
+    # Add the MOD to the list.
+    # @param mod [Factorix::Mod] the MOD to add.
     # @param enabled [Boolean] the enabled status. Default to true.
-    # @param version [String, nil] the version of the mod. Default to nil.
+    # @param version [String, nil] the version of the MOD. Default to nil.
     # @return [void]
-    # @raise [ArgumentError] if the mod is the base mod and the enabled status is false.
+    # @raise [ArgumentError] if the MOD is the base MOD and the enabled status is false.
     def add: (Mod mod, ?enabled: bool, ?version: String?) -> void
 
-    # Remove the mod from the list.
-    # @param mod [Factorix::Mod] the mod to remove.
+    # Remove the MOD from the list.
+    # @param mod [Factorix::Mod] the MOD to remove.
     # @return [void]
-    # @raise [ArgumentError] if the mod is the base mod.
+    # @raise [ArgumentError] if the MOD is the base MOD.
     def remove: (Mod mod) -> void
 
-    # Check if the mod is in the list.
-    # @param mod [Factorix::Mod] the mod to check.
-    # @return [Boolean] true if the mod is in the list, false otherwise.
+    # Check if the MOD is in the list.
+    # @param mod [Factorix::Mod] the MOD to check.
+    # @return [Boolean] true if the MOD is in the list, false otherwise.
     def exist?: (Mod mod) -> bool
 
-    # Check if the mod is enabled.
-    # @param mod [Factorix::Mod] the mod to check.
-    # @return [Boolean] true if the mod is enabled, false otherwise.
-    # @raise [Factorix::ModList::ModNotInListError] if the mod is not in the list.
+    # Check if the MOD is enabled.
+    # @param mod [Factorix::Mod] the MOD to check.
+    # @return [Boolean] true if the MOD is enabled, false otherwise.
+    # @raise [Factorix::ModList::ModNotInListError] if the MOD is not in the list.
     def enabled?: (Mod mod) -> bool
 
-    # Get the version of the mod.
-    # @param mod [Factorix::Mod] the mod to check.
-    # @return [String, nil] the version of the mod, or nil if not specified.
-    # @raise [Factorix::ModList::ModNotInListError] if the mod is not in the list.
+    # Get the version of the MOD.
+    # @param mod [Factorix::Mod] the MOD to check.
+    # @return [String, nil] the version of the MOD, or nil if not specified.
+    # @raise [Factorix::ModList::ModNotInListError] if the MOD is not in the list.
     def version: (Mod mod) -> String?
 
-    # Enable the mod.
-    # @param mod [Factorix::Mod] the mod to enable.
+    # Enable the MOD.
+    # @param mod [Factorix::Mod] the MOD to enable.
     # @return [void]
-    # @raise [Factorix::ModList::ModNotInListError] if the mod is not in the list.
+    # @raise [Factorix::ModList::ModNotInListError] if the MOD is not in the list.
     def enable: (Mod mod) -> void
 
-    # Disable the mod.
-    # @param mod [Factorix::Mod] the mod to disable.
+    # Disable the MOD.
+    # @param mod [Factorix::Mod] the MOD to disable.
     # @return [void]
-    # @raise [ArgumentError] if the mod is the base mod.
-    # @raise [Factorix::ModList::ModNotInListError] if the mod is not in the list.
+    # @raise [ArgumentError] if the MOD is the base MOD.
+    # @raise [Factorix::ModList::ModNotInListError] if the MOD is not in the list.
     def disable: (Mod mod) -> void
   end
 end

--- a/sig/factorix/mod_state.rbs
+++ b/sig/factorix/mod_state.rbs
@@ -1,17 +1,17 @@
 module Factorix
-  # Represent the state of a MOD in a mod list
+  # Represent the state of a MOD in a MOD list
   class ModState < Data
     # !attribute [r] enabled
-    #  @return [Boolean] whether the mod is enabled
+    #  @return [Boolean] whether the MOD is enabled
     attr_reader enabled: bool
 
     # !attribute [r] version
-    #  @return [String, nil] the version of the mod, or nil if the version is not specified
+    #  @return [String, nil] the version of the MOD, or nil if the version is not specified
     attr_reader version: String?
 
     # Initialize a new ModState
-    # @param enabled [Boolean] whether the mod is enabled
-    # @param version [String, nil] the version of the mod (optional)
+    # @param enabled [Boolean] whether the MOD is enabled
+    # @param version [String, nil] the version of the MOD (optional)
     def initialize: (enabled: bool, ?version: String?) -> void
 
     # Factory method for creating ModState instances


### PR DESCRIPTION
This PR fixes instances where MOD is incorrectly referred to as 'module' in documentation and comments. It standardizes the terminology to use 'MOD' (all uppercase) in documentation and comments, while preserving 'Mod' (first letter capitalized) in code references.