### PR TITLE
:hammer: Refactor error classes

### DIFF
--- a/lib/factorix/deserializer.rb
+++ b/lib/factorix/deserializer.rb
@@ -171,7 +171,7 @@ module Factorix
         # @see https://wiki.factorio.com/Property_tree
         read_unsigned_long
       else
-        raise Factorix::UnknownPropertyType, type
+        raise Factorix::UnknownPropertyType, "Unknown property type: #{type}"
       end
     end
 

--- a/lib/factorix/errors.rb
+++ b/lib/factorix/errors.rb
@@ -5,30 +5,14 @@ module Factorix
   class Error < StandardError; end
 
   # Raised when a MOD is not found.
-  class ModNotFoundError < Error
-    def initialize(mod)
-      super("MOD not found: #{mod}")
-    end
-  end
+  class ModNotFoundError < Error; end
 
   # Raised when an unknown property type is encountered during serialization/deserialization.
-  class UnknownPropertyType < Error
-    def initialize(type)
-      super("Unknown property type: #{type}")
-    end
-  end
+  class UnknownPropertyType < Error; end
 
   # Raised when an invalid section name is encountered in mod settings.
-  class InvalidModSectionError < Error
-    def initialize(section_name)
-      super("Invalid mod section name: #{section_name}")
-    end
-  end
+  class InvalidModSectionError < Error; end
 
   # Raised when a section is not found in mod settings.
-  class ModSectionNotFoundError < Error
-    def initialize(section_name)
-      super("Mod section not found: #{section_name}")
-    end
-  end
+  class ModSectionNotFoundError < Error; end
 end

--- a/lib/factorix/mod_list.rb
+++ b/lib/factorix/mod_list.rb
@@ -10,11 +10,7 @@ module Factorix
     include Enumerable
 
     # Raised when a MOD is not found.
-    class ModNotInListError < Factorix::ModNotFoundError
-      def initialize(mod)
-        super("MOD not in the list: #{mod}")
-      end
-    end
+    class ModNotInListError < Factorix::ModNotFoundError; end
 
     # Load the MOD list from the given file.
     # @param from [Pathname] the path to the file to load the MOD list from.
@@ -110,7 +106,7 @@ module Factorix
     # @return [Boolean] true if the MOD is enabled, false otherwise.
     # @raise [Factorix::ModList::ModNotInListError] if the MOD is not in the list.
     def enabled?(mod)
-      raise ModNotInListError, mod unless exist?(mod)
+      raise ModNotInListError, "MOD not in the list: #{mod}" unless exist?(mod)
 
       @mods[mod].enabled
     end
@@ -120,7 +116,7 @@ module Factorix
     # @return [String, nil] the version of the MOD, or nil if not specified.
     # @raise [Factorix::ModList::ModNotInListError] if the MOD is not in the list.
     def version(mod)
-      raise ModNotInListError, mod unless exist?(mod)
+      raise ModNotInListError, "MOD not in the list: #{mod}" unless exist?(mod)
 
       @mods[mod].version
     end
@@ -130,7 +126,7 @@ module Factorix
     # @return [void]
     # @raise [Factorix::ModList::ModNotInListError] if the MOD is not in the list.
     def enable(mod)
-      raise ModNotInListError, mod unless exist?(mod)
+      raise ModNotInListError, "MOD not in the list: #{mod}" unless exist?(mod)
 
       # Create a new ModState with enabled=true and the same version
       current_state = @mods[mod]
@@ -144,7 +140,7 @@ module Factorix
     # @raise [Factorix::ModList::ModNotInListError] if the MOD is not in the list.
     def disable(mod)
       raise ArgumentError, "can't disable the base MOD" if mod.base?
-      raise ModNotInListError, mod unless exist?(mod)
+      raise ModNotInListError, "MOD not in the list: #{mod}" unless exist?(mod)
 
       # Create a new ModState with enabled=false and the same version
       current_state = @mods[mod]

--- a/lib/factorix/mod_settings.rb
+++ b/lib/factorix/mod_settings.rb
@@ -14,7 +14,7 @@ module Factorix
       # @raise [InvalidModSectionError] If the section name is invalid
       def initialize(name)
         unless VALID_SECTIONS.include?(name)
-          raise InvalidModSectionError, name
+          raise InvalidModSectionError, "Invalid mod section name: #{name}"
         end
 
         @name = name
@@ -70,12 +70,12 @@ module Factorix
     # @raise [ModSectionNotFoundError] If the section is not found
     def [](name)
       unless VALID_SECTIONS.include?(name)
-        raise InvalidModSectionError, name
+        raise InvalidModSectionError, "Invalid mod section name: #{name}"
       end
 
       section = @sections[name]
       unless section
-        raise ModSectionNotFoundError, name
+        raise ModSectionNotFoundError, "Mod section not found: #{name}"
       end
 
       section
@@ -126,7 +126,7 @@ module Factorix
     private def process_raw_settings(raw_settings)
       raw_settings.each do |section_name, section_settings|
         unless VALID_SECTIONS.include?(section_name)
-          raise InvalidModSectionError, section_name
+          raise InvalidModSectionError, "Invalid mod section name: #{section_name}"
         end
 
         section = @sections[section_name] ||= Section.new(section_name)

--- a/lib/factorix/runtime.rb
+++ b/lib/factorix/runtime.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative "errors"
 require_relative "runtime/linux"
 require_relative "runtime/mac_os"
 require_relative "runtime/windows"
@@ -9,10 +10,10 @@ module Factorix
   # Factorio runtime environment
   class Runtime
     # Raised when run on unsupported platform
-    class UnsupportedPlatform < StandardError; end
+    class UnsupportedPlatform < Error; end
 
     # Raised when the game is already running and an attempt to launch the game is made
-    class AlreadyRunning < StandardError; end
+    class AlreadyRunning < Error; end
 
     # Return the platform the script is running on
     # @return [Runtime] the runtime environment

--- a/lib/factorix/serializer.rb
+++ b/lib/factorix/serializer.rb
@@ -211,7 +211,7 @@ module Factorix
           write_long(obj)
         end
       else
-        raise Factorix::UnknownPropertyType, obj.class
+        raise Factorix::UnknownPropertyType, "Unknown property type: #{obj.class}"
       end
     end
   end


### PR DESCRIPTION
## Changes

1. Improved exception class structure
   - Changed `Factorix::Runtime::UnsupportedPlatform` and `Factorix::Runtime::AlreadyRunning` to inherit from `Factorix::Error` instead of `StandardError`
   - Added `require_relative "errors"` to `runtime.rb` to reference `Factorix::Error`

2. Removed custom `initialize` methods
   - Removed custom `initialize` methods from:
     - `Factorix::ModNotFoundError`
     - `Factorix::UnknownPropertyType`
     - `Factorix::InvalidModSectionError`
     - `Factorix::ModSectionNotFoundError`
     - `Factorix::ModList::ModNotInListError`

3. Changed how exception messages are specified
   - Modified code to specify messages directly when raising exceptions
   - Example: `raise ModNotInListError, "MOD not in the list: #{mod}"`