### PR TITLE
:memo: Update documentation guidelines

### DIFF
--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -54,16 +54,94 @@ Factorix is a Ruby library and CLI for Factorio mod management.
 
 - Follow Semantic Versioning (semver.org)
 
-## Commit Messages
+## Commit Messages and PR Descriptions
 
 Format: Emoji prefix + concise present tense description
 
+Start description with a verb (Add, Fix, Update, etc.)
+
 Common prefixes:
-- `:new:` - New feature
-- `:beetle:` - Bug fix
-- `:memo:` - Documentation
-- `:hammer:` - Refactor
-- `:test_tube:` - Tests
+- `:new:` (🆕) - New feature
+- `:beetle:` (🪲) - Bug fix
+- `:memo:` (📝) - Documentation
+- `:hammer:` (🔨) - Refactor
+- `:test_tube:` (🧪) - Tests
+- `:robot:` (🤖) - MEMORY_BANK.md updates
+- `:inbox_tray:` (📥) - Merge commits (format: `:inbox_tray: Merge pull request #N: [PR title]`)
+
+### Command Line Usage for Messages
+
+The following guidelines apply to both git commit messages and GitHub PR descriptions.
+
+When creating messages with multiple lines or special characters:
+
+- Be cautious with double quotes as they allow shell interpretation
+- Consider using single quotes or heredocs for complex messages
+- For messages with Markdown formatting, avoid backticks in double-quoted strings
+- When possible, use stdin or file input for multi-line messages
+
+#### Git Commit Examples
+
+Example using BASH dollar-quoted string (not heredoc):
+```bash
+git commit -m $'First line\nSecond line with `code`'
+```
+
+Example using heredoc:
+```bash
+git commit <<EOF
+:memo: Update documentation
+
+- Add new section about X
+- Improve examples for Y
+- Fix typos in Z section
+EOF
+```
+
+Example using stdin:
+```bash
+git commit -F- <<EOF
+:new: Add new feature
+
+- Implement X functionality
+- Fix Y issue
+EOF
+```
+
+#### GitHub PR Examples
+
+Example using heredoc for PR creation:
+```bash
+gh pr create --title ":new: Add new feature" --body <<EOF
+This PR implements a new feature that:
+
+- Adds X functionality
+- Improves Y performance
+- Fixes Z issue
+
+## Testing
+- [x] Unit tests added
+- [x] Integration tests passed
+EOF
+```
+
+Example using a file for PR body:
+```bash
+# First create a file with the PR description
+cat > pr-description.md <<EOF
+:hammer: Refactor serialization code
+
+- Move classes to dedicated namespace
+- Improve error handling
+- Add comprehensive documentation
+
+## Breaking Changes
+None
+EOF
+
+# Then use the file for PR creation
+gh pr create --title ":hammer: Refactor serialization code" --body-file pr-description.md
+```
 
 ## RBS Type Definitions
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -129,10 +129,9 @@ This PR implements a new feature that:
 EOF
 ```
 
-Example using a file for PR body:
+Example using --body-file with standard input:
 ```bash
-# First create a file with the PR description
-cat > pr-description.md <<EOF
+gh pr create --title ":hammer: Refactor serialization code" --body-file - <<EOF
 :hammer: Refactor serialization code
 
 - Move classes to dedicated namespace
@@ -142,10 +141,10 @@ cat > pr-description.md <<EOF
 ## Breaking Changes
 None
 EOF
-
-# Then use the file for PR creation
-gh pr create --title ":hammer: Refactor serialization code" --body-file pr-description.md
 ```
+
+# The - after --body-file tells gh to read from standard input
+# This is cleaner than using temporary files and avoids cleanup
 
 ## RBS Type Definitions
 

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -98,7 +98,7 @@ git commit <<EOF
 EOF
 ```
 
-Example using stdin:
+Example using -F option with standard input (recommended for AI assistants):
 ```bash
 git commit -F- <<EOF
 :new: Add new feature
@@ -106,6 +106,10 @@ git commit -F- <<EOF
 - Implement X functionality
 - Fix Y issue
 EOF
+```
+
+# The -F- syntax tells git to read from standard input
+# This is cleaner than using temporary files and avoids cleanup
 ```
 
 #### GitHub PR Examples

--- a/MEMORY_BANK.md
+++ b/MEMORY_BANK.md
@@ -274,6 +274,10 @@ See the [Commit Messages and PR Descriptions](DEVELOPMENT.md#commit-messages-and
 - **Code Comments**:
   - During planning phase: Use the user's native language
   - In actual code implementation/modification: Use English
+- **Command Execution**:
+  - Use English for all command line operations
+  - This includes commit messages, PR descriptions, and other command outputs
+  - Exception: When the command output is intended to be displayed to the user, use the user's native language
 
 ---
 

--- a/MEMORY_BANK.md
+++ b/MEMORY_BANK.md
@@ -257,8 +257,16 @@ When executing commands that require multi-line text input (such as commit messa
 - Prefer using one of these safer alternatives:
   - Single quotes (which prevent shell interpretation)
   - Heredocs (for complex multi-line content)
-  - File input (creating a temporary file and passing it to the command)
-- When working with GitHub CLI (`gh`), consider using the `--body-file` option for PR descriptions
+  - File input with `-F` option (creating a temporary file and passing it to the command)
+- For git commit messages:
+  - Use `-F-` option to read from standard input (recommended for AI assistants)
+  - Example: `git commit -F- <<EOF ... EOF`
+  - The hyphen after `-F` tells git to read from standard input instead of a file
+- When working with GitHub CLI (`gh`):
+  - Use the `--body-file` option for PR descriptions
+  - Example: `gh pr create --title "Title" --body-file pr-body.txt`
+
+See the [Commit Messages and PR Descriptions](DEVELOPMENT.md#commit-messages-and-pr-descriptions) section in DEVELOPMENT.md for detailed examples.
 
 ### Language Usage
 

--- a/MEMORY_BANK.md
+++ b/MEMORY_BANK.md
@@ -113,17 +113,9 @@ end
 - **Minor**: Backward-compatible features
 - **Patch**: Backward-compatible fixes
 
-## Commit Messages
+## Commit Messages and PR Descriptions
 
-- Format: Emoji prefix + concise present tense description
-- Start description with a verb (Add, Fix, Update, etc.)
-- Common emoji prefixes:
-  - `:new:` (🆕) - New feature
-  - `:beetle:` (🪲) - Bug fix
-  - `:memo:` (📝) - Documentation
-  - `:hammer:` (🔨) - Refactor
-  - `:test_tube:` (🧪) - Tests
-  - `:robot:` (🤖) - MEMORY_BANK.md updates
+For detailed guidelines on commit message and PR description formatting, including examples of command line usage, refer to the [Commit Messages and PR Descriptions](DEVELOPMENT.md#commit-messages-and-pr-descriptions) section in DEVELOPMENT.md.
 
 ## RBS Type Definitions
 
@@ -243,6 +235,8 @@ If changes to a submodule are needed:
 
 ## AI Guidelines
 
+### Code Generation and Modification
+
 When generating or modifying code for this project:
 
 - Match existing patterns and styles
@@ -252,6 +246,26 @@ When generating or modifying code for this project:
 - Minimize dependencies
 - Follow established error handling patterns
 - Consider performance implications
+
+### Command Line Operations with Multi-line Text
+
+When executing commands that require multi-line text input (such as commit messages, PR descriptions, etc.):
+
+- Avoid using double quotes for text containing shell-interpretable characters
+  - Shell may interpret characters like `$`, `` ` ``, `\`, etc. within double quotes
+  - This is especially problematic when including Markdown code blocks with backticks
+- Prefer using one of these safer alternatives:
+  - Single quotes (which prevent shell interpretation)
+  - Heredocs (for complex multi-line content)
+  - File input (creating a temporary file and passing it to the command)
+- When working with GitHub CLI (`gh`), consider using the `--body-file` option for PR descriptions
+
+### Language Usage
+
+- **Chat Interactions**: Use the user's native language regardless of the language used in the user's input
+- **Code Comments**:
+  - During planning phase: Use the user's native language
+  - In actual code implementation/modification: Use English
 
 ---
 

--- a/MEMORY_BANK.md
+++ b/MEMORY_BANK.md
@@ -263,8 +263,9 @@ When executing commands that require multi-line text input (such as commit messa
   - Example: `git commit -F- <<EOF ... EOF`
   - The hyphen after `-F` tells git to read from standard input instead of a file
 - When working with GitHub CLI (`gh`):
-  - Use the `--body-file` option for PR descriptions
-  - Example: `gh pr create --title "Title" --body-file pr-body.txt`
+  - Use the `--body-file -` option to read PR descriptions from standard input
+  - Example: `gh pr create --title "Title" --body-file - <<EOF ... EOF`
+  - The hyphen after `--body-file` tells gh to read from standard input instead of a file
 
 See the [Commit Messages and PR Descriptions](DEVELOPMENT.md#commit-messages-and-pr-descriptions) section in DEVELOPMENT.md for detailed examples.
 


### PR DESCRIPTION
This PR updates the documentation guidelines:

- Reorganize commit message guidelines between DEVELOPMENT.md and MEMORY_BANK.md
- Add detailed guidelines for commit message formatting and emoji usage
- Add notes and examples for handling multi-line text in commands
- Add examples for GitHub PR creation
- Recommend using -F- option for git commit by AI assistants
- Add guidelines for language usage by AI assistants
- Specify that English should be used for all command line operations

## Changes

- Move detailed commit message guidelines from MEMORY_BANK.md to DEVELOPMENT.md
- Expand "Commit Messages" section to "Commit Messages and PR Descriptions" in DEVELOPMENT.md
- Expand AI guidelines section with command operation and language usage guidelines
- Update examples to use standard input instead of temporary files
