### PR TITLE
:beetle: Correct wrong --data-dump with --dump-data

### DIFF
--- a/README.md
+++ b/README.md
@@ -49,8 +49,7 @@ Options:
 You can pass additional arguments to the Factorio executable by adding them after `--`:
 
 ```bash
-factorix launch -- --help
-factorix launch -- --data-dump
+factorix launch -- --dump-icon-sprites
 factorix launch --wait -- --mod-directory /path/to/mods
 ```
 

--- a/lib/factorix/cli/commands/launch.rb
+++ b/lib/factorix/cli/commands/launch.rb
@@ -9,7 +9,12 @@ module Factorix
     module Commands
       # Command for the launch subcommand
       class Launch < Dry::CLI::Command
-        SYNCHRONOUS_OPTIONS = %w[--data-dump --help].freeze
+        SYNCHRONOUS_OPTIONS = %w[
+          --dump-data
+          --dump-icon-sprites
+          --dump-prototype-locale
+          --help
+        ].freeze
         private_constant :SYNCHRONOUS_OPTIONS
 
         desc "Launch the game"

--- a/spec/factorix/cli/commands/launch_spec.rb
+++ b/spec/factorix/cli/commands/launch_spec.rb
@@ -78,11 +78,11 @@ RSpec.describe Factorix::CLI::Commands::Launch do
         allow(runtime).to receive(:running?).and_return(false, true, false)
       end
 
-      let(:args) { %w[--data-dump] }
+      let(:args) { %w[--dump-data] }
 
       it "launches the game synchronously" do
         call
-        expect(runtime).to have_received(:launch).with("--data-dump", async: false)
+        expect(runtime).to have_received(:launch).with("--dump-data", async: false)
       end
     end
 
@@ -91,7 +91,7 @@ RSpec.describe Factorix::CLI::Commands::Launch do
         allow(runtime).to receive(:running?).and_return(false, true, false)
       end
 
-      let(:args) { %w[--data-dump] }
+      let(:args) { %w[--dump-data] }
       let(:options) { {wait: true} }
 
       it "does not wait for the game" do


### PR DESCRIPTION
Add more asyncrous options:
- --dump-icon-graphics
- --dump-prototype-locale

Removed --help since the launcher won't output anything.
