### PR TITLE
:new: Add Credential class

### DIFF
--- a/lib/factorix.rb
+++ b/lib/factorix.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require_relative "factorix/credential"
 require_relative "factorix/errors"
 require_relative "factorix/mod"
 require_relative "factorix/mod_list"

--- a/lib/factorix/credential.rb
+++ b/lib/factorix/credential.rb
@@ -1,0 +1,35 @@
+# frozen_string_literal: true
+
+require "json"
+require_relative "runtime"
+
+module Factorix
+  # Manages Factorio service credentials
+  class Credential
+    # Return the service username
+    # @return [String] the service username
+    def username
+      env_value = ENV.fetch("FACTORIO_SERVICE_USERNAME", nil)
+      return player_data.fetch("service-username") if env_value.nil? || env_value.empty?
+
+      env_value
+    end
+
+    # Return the service token
+    # @return [String] the service token
+    def token
+      env_value = ENV.fetch("FACTORIO_SERVICE_TOKEN", nil)
+      return player_data.fetch("service-token") if env_value.nil? || env_value.empty?
+
+      env_value
+    end
+
+    private def runtime
+      Runtime.runtime
+    end
+
+    private def player_data
+      @player_data ||= JSON.parse(runtime.player_data_path.read)
+    end
+  end
+end

--- a/lib/factorix/runtime.rb
+++ b/lib/factorix/runtime.rb
@@ -56,6 +56,12 @@ module Factorix
       mods_dir + "mod-settings.dat"
     end
 
+    # Return the path of the player-data.json file
+    # @return [Pathname] the path of the player-data.json file
+    def player_data_path
+      user_dir + "player-data.json"
+    end
+
     # Launch the game
     # @return [void]
     # @raise [RuntimeError] if the game is already running

--- a/sig/factorix/credential.rbs
+++ b/sig/factorix/credential.rbs
@@ -1,0 +1,18 @@
+module Factorix
+  # Manages Factorio service credentials
+  class Credential
+    # Return the service username
+    # @return [String] the service username
+    def username: () -> String
+
+    # Return the service token
+    # @return [String] the service token
+    def token: () -> String
+
+    private
+
+    def runtime: () -> Runtime
+
+    def player_data: () -> Hash[String, String]
+  end
+end

--- a/sig/factorix/runtime.rbs
+++ b/sig/factorix/runtime.rbs
@@ -56,5 +56,9 @@ module Factorix
     # Return the data directory of Factorio
     # @return [Pathname] the data directory of Factorio
     def data_dir: () -> Pathname
+
+    # Return the path of the player-data.json file
+    # @return [Pathname] the path of the player-data.json file
+    def player_data_path: () -> Pathname
   end
 end

--- a/spec/factorix/credential_spec.rb
+++ b/spec/factorix/credential_spec.rb
@@ -1,0 +1,196 @@
+# frozen_string_literal: true
+
+require "pathname"
+require_relative "../../lib/factorix/credential"
+
+RSpec.describe Factorix::Credential do
+  let(:credential) { Factorix::Credential.new }
+  let(:runtime) { instance_double(Factorix::Runtime) }
+  let(:player_data_path) { Pathname("path/to/player-data.json") }
+  let(:player_data_content) do
+    {
+      "service-username" => "json-username",
+      "service-token" => "json-token"
+    }.to_json
+  end
+
+  before do
+    allow(Factorix::Runtime).to receive(:runtime).and_return(runtime)
+    allow(runtime).to receive(:player_data_path).and_return(player_data_path)
+    allow(player_data_path).to receive(:read).and_return(player_data_content)
+  end
+
+  shared_examples "when player-data.json does not exist" do
+    before do
+      allow(player_data_path).to receive(:read).and_raise(Errno::ENOENT.new("No such file or directory"))
+    end
+
+    context "when environment variable is not set" do
+      before do
+        ENV.delete(env_name)
+      end
+
+      it "raises Errno::ENOENT" do
+        expect { subject }.to raise_error(Errno::ENOENT, /No such file or directory/)
+      end
+    end
+
+    context "when environment variable is empty" do
+      before do
+        ENV[env_name] = ""
+      end
+
+      after do
+        ENV.delete(env_name)
+      end
+
+      it "raises Errno::ENOENT" do
+        expect { subject }.to raise_error(Errno::ENOENT, /No such file or directory/)
+      end
+    end
+
+    context "when environment variable is set" do
+      before do
+        ENV[env_name] = env_value
+      end
+
+      after do
+        ENV.delete(env_name)
+      end
+
+      it "returns value from environment variable" do
+        expect(subject).to eq env_value
+      end
+    end
+  end
+
+  describe "#username" do
+    subject(:username) { credential.username }
+
+    context "when environment variable is not set" do
+      before do
+        ENV.delete("FACTORIO_SERVICE_USERNAME")
+      end
+
+      it "returns username from player-data.json" do
+        expect(username).to eq "json-username"
+      end
+    end
+
+    context "when environment variable is empty" do
+      before do
+        ENV["FACTORIO_SERVICE_USERNAME"] = ""
+      end
+
+      after do
+        ENV.delete("FACTORIO_SERVICE_USERNAME")
+      end
+
+      it "returns username from player-data.json" do
+        expect(username).to eq "json-username"
+      end
+    end
+
+    context "when environment variable is set" do
+      before do
+        ENV["FACTORIO_SERVICE_USERNAME"] = "env-username"
+      end
+
+      after do
+        ENV.delete("FACTORIO_SERVICE_USERNAME")
+      end
+
+      it "returns username from environment variable" do
+        expect(username).to eq "env-username"
+      end
+    end
+
+    context "when username is missing in player-data.json" do
+      let(:player_data_content) do
+        {
+          "service-token" => "json-token"
+        }.to_json
+      end
+
+      before do
+        ENV.delete("FACTORIO_SERVICE_USERNAME")
+      end
+
+      it "raises KeyError" do
+        expect { username }.to raise_error(KeyError, /service-username/)
+      end
+    end
+
+    context "when player-data.json does not exist" do
+      let(:env_name) { "FACTORIO_SERVICE_USERNAME" }
+      let(:env_value) { "env-username" }
+
+      include_examples "when player-data.json does not exist"
+    end
+  end
+
+  describe "#token" do
+    subject(:token) { credential.token }
+
+    context "when environment variable is not set" do
+      before do
+        ENV.delete("FACTORIO_SERVICE_TOKEN")
+      end
+
+      it "returns token from player-data.json" do
+        expect(token).to eq "json-token"
+      end
+    end
+
+    context "when environment variable is empty" do
+      before do
+        ENV["FACTORIO_SERVICE_TOKEN"] = ""
+      end
+
+      after do
+        ENV.delete("FACTORIO_SERVICE_TOKEN")
+      end
+
+      it "returns token from player-data.json" do
+        expect(token).to eq "json-token"
+      end
+    end
+
+    context "when environment variable is set" do
+      before do
+        ENV["FACTORIO_SERVICE_TOKEN"] = "env-token"
+      end
+
+      after do
+        ENV.delete("FACTORIO_SERVICE_TOKEN")
+      end
+
+      it "returns token from environment variable" do
+        expect(token).to eq "env-token"
+      end
+    end
+
+    context "when token is missing in player-data.json" do
+      let(:player_data_content) do
+        {
+          "service-username" => "json-username"
+        }.to_json
+      end
+
+      before do
+        ENV.delete("FACTORIO_SERVICE_TOKEN")
+      end
+
+      it "raises KeyError" do
+        expect { token }.to raise_error(KeyError, /service-token/)
+      end
+    end
+
+    context "when player-data.json does not exist" do
+      let(:env_name) { "FACTORIO_SERVICE_TOKEN" }
+      let(:env_value) { "env-token" }
+
+      include_examples "when player-data.json does not exist"
+    end
+  end
+end

--- a/spec/factorix/runtime_spec.rb
+++ b/spec/factorix/runtime_spec.rb
@@ -71,7 +71,7 @@ RSpec.describe Factorix::Runtime do
   describe "#mods_dir" do
     subject(:mods_dir) { runtime.mods_dir }
 
-    let(:runtime) { Factorix::Runtime.runtime }
+    let(:runtime) { Factorix::Runtime.new }
 
     before do
       allow(runtime).to receive(:user_dir).and_return(Pathname.new("/user_dir"))
@@ -85,7 +85,7 @@ RSpec.describe Factorix::Runtime do
   describe "#script_output_dir" do
     subject(:script_output_dir) { runtime.script_output_dir }
 
-    let(:runtime) { Factorix::Runtime.runtime }
+    let(:runtime) { Factorix::Runtime.new }
 
     before do
       allow(runtime).to receive(:user_dir).and_return(Pathname.new("/user_dir"))
@@ -99,7 +99,7 @@ RSpec.describe Factorix::Runtime do
   describe "#mod_list_path" do
     subject(:mod_list_path) { runtime.mod_list_path }
 
-    let(:runtime) { Factorix::Runtime.runtime }
+    let(:runtime) { Factorix::Runtime.new }
 
     before do
       allow(runtime).to receive(:user_dir).and_return(Pathname.new("/user_dir"))
@@ -113,7 +113,7 @@ RSpec.describe Factorix::Runtime do
   describe "#mod_settings_path" do
     subject(:mod_settings_path) { runtime.mod_settings_path }
 
-    let(:runtime) { Factorix::Runtime.runtime }
+    let(:runtime) { Factorix::Runtime.new }
 
     before do
       allow(runtime).to receive(:mods_dir).and_return(Pathname.new("/user_dir/mods"))
@@ -124,8 +124,22 @@ RSpec.describe Factorix::Runtime do
     end
   end
 
+  describe "#player_data_path" do
+    subject(:player_data_path) { runtime.player_data_path }
+
+    let(:runtime) { Factorix::Runtime.new }
+
+    before do
+      allow(runtime).to receive(:user_dir).and_return(Pathname.new("/user_dir"))
+    end
+
+    it "returns the path of the player-data.json file" do
+      expect(player_data_path).to eq(Pathname.new("/user_dir/player-data.json"))
+    end
+  end
+
   describe "#launch" do
-    let(:runtime) { Factorix::Runtime.runtime }
+    let(:runtime) { Factorix::Runtime.new }
 
     describe "when the game is not running, async: true, without arguments" do
       subject(:launch) { runtime.launch(async: true) }
@@ -231,7 +245,7 @@ RSpec.describe Factorix::Runtime do
   end
 
   describe "#with_only_mod_enabled" do
-    let(:runtime) { Factorix::Runtime.runtime }
+    let(:runtime) { Factorix::Runtime.new }
     let(:mod_list) { instance_double(Factorix::ModList) }
     let(:mod_context) { instance_double(Factorix::ModContext) }
 
@@ -274,7 +288,7 @@ RSpec.describe Factorix::Runtime do
   end
 
   describe "#with_only_mod_enabled integration", :integration do
-    let(:runtime) { Factorix::Runtime.runtime }
+    let(:runtime) { Factorix::Runtime.new }
     let(:mod_list_path) { Pathname("spec/fixtures/mod-list/list.json") }
     let(:base_mod) { Factorix::Mod[name: "base"] }
     let(:enabled_mod) { Factorix::Mod[name: "enabled-mod"] }


### PR DESCRIPTION
:new: Add Credential class

Add Credential class to manage Factorio service credentials.

## Features

- Add player_data_path method to Runtime class to get path to player-data.json
- Add Credential class to manage Factorio service credentials
  - username: Get from FACTORIO_SERVICE_USERNAME or player-data.json
  - token: Get from FACTORIO_SERVICE_TOKEN or player-data.json
  - Environment variables take precedence over player-data.json values
  - Empty environment variables are treated as unset

## Implementation

- Runtime class
  - Add player_data_path method to return path to player-data.json
  - Add type signature and tests
  - Replace Runtime.runtime with Runtime.new in tests for better practices

- Credential class
  - Implement username and token methods
  - Handle missing player-data.json and missing keys in JSON
  - Add type signature and comprehensive tests
