### PR TITLE
:new: Add mod download command

### DIFF
--- a/.rubocop_todo.yml
+++ b/.rubocop_todo.yml
@@ -49,14 +49,8 @@ RSpec/MultipleExpectations:
 # Configuration parameters: AllowSubject, Max.
 RSpec/MultipleMemoizedHelpers:
   Exclude:
+    - 'spec/factorix/cli/commands/mod/download_spec.rb'
     - 'spec/factorix/cli/commands/mod/list_spec.rb'
-
-# Configuration parameters: Max, AllowedGroups.
-RSpec/NestedGroups:
-  Exclude:
-    - 'spec/factorix/downloader_spec.rb'
-    - 'spec/factorix/http_client_spec.rb'
-    - 'spec/factorix/ser_des/deserializer_spec.rb'
 
 # Configuration parameters: AllowedAddresses.
 # AllowedAddresses: ::

--- a/lib/factorix/cli.rb
+++ b/lib/factorix/cli.rb
@@ -5,9 +5,11 @@ require "dry/cli"
 require_relative "cli/commands/info"
 require_relative "cli/commands/launch"
 require_relative "cli/commands/mod/disable"
+require_relative "cli/commands/mod/download"
 require_relative "cli/commands/mod/enable"
 require_relative "cli/commands/mod/list"
 require_relative "cli/commands/mod/settings/dump"
+require_relative "cli/error"
 
 module Factorix
   # Command-line interface for Factorix
@@ -20,5 +22,6 @@ module Factorix
     register "mod enable", Factorix::CLI::Commands::Mod::Enable
     register "mod list", Factorix::CLI::Commands::Mod::List
     register "mod settings dump", Factorix::CLI::Commands::Mod::Settings::Dump
+    register "mod download", Factorix::CLI::Commands::Mod::Download
   end
 end

--- a/lib/factorix/cli/commands/mod/download.rb
+++ b/lib/factorix/cli/commands/mod/download.rb
@@ -75,8 +75,11 @@ module Factorix
           private def determine_output_path(mod_name, version, output_directory)
             filename = "#{mod_name}_#{version}.zip"
             output_dir = Pathname(output_directory || Dir.pwd)
-            output_path = output_dir / filename
 
+            raise DirectoryNotFoundError, "Directory does not exist: #{output_dir}" unless output_dir.exist?
+            raise DirectoryNotWritableError, "Directory is not writable: #{output_dir}" unless output_dir.writable?
+
+            output_path = output_dir / filename
             raise FileExistsError, output_path if output_path.exist?
 
             output_path

--- a/lib/factorix/cli/commands/mod/download.rb
+++ b/lib/factorix/cli/commands/mod/download.rb
@@ -106,7 +106,7 @@ module Factorix
             downloader = Factorix::Downloader.new(
               http_client: Factorix::HttpClient.new(
                 # U+2699 GEAR + U+FE0F VARIATION SELECTOR-16
-                progress: quiet ? nil : Progress::Bar.new(title: "\u2699\uFE0F #{output_path.basename}")
+                progress: quiet ? nil : Factorix::Progress::Bar.new(title: "\u2699\uFE0F #{output_path.basename}")
               )
             )
             downloader.download(download_url, output_path)

--- a/lib/factorix/cli/commands/mod/download.rb
+++ b/lib/factorix/cli/commands/mod/download.rb
@@ -1,0 +1,133 @@
+# frozen_string_literal: true
+
+require "digest"
+require "pathname"
+require "uri"
+
+require_relative "../../../../factorix"
+require_relative "../../../credential"
+require_relative "../../../downloader"
+require_relative "../../../mod_portal/api"
+require_relative "../../../progress/bar"
+require_relative "../../error"
+
+module Factorix
+  class CLI
+    module Commands
+      module Mod
+        # Command to download a mod from Factorio Mod Portal
+        class Download < Dry::CLI::Command
+          desc "Download a mod from Factorio Mod Portal"
+
+          argument :mod_name, required: true, desc: "Name of the mod to download"
+          option :version, desc: "Version of the mod to download (default: latest)"
+          option :output_directory,
+            aliases: ["-d"],
+            desc: "Directory to save the downloaded mod (default: current directory)"
+          option :quiet, type: :boolean, default: false, desc: "Suppress progress and completion messages"
+
+          example [
+            "alien-biomes",
+            "alien-biomes --version 1.1.16",
+            "alien-biomes -d mods"
+          ]
+
+          # Download a mod from Factorio Mod Portal
+          #
+          # @param mod_name [String] Name of the mod to download
+          # @param options [Hash] Command options
+          # @option options [String] :version Version of the mod to download (default: latest)
+          # @option options [String] :output_directory Directory to save the downloaded mod (default: current directory)
+          # @option options [Boolean] :quiet Suppress progress and completion messages (default: false)
+          # @raise [Factorix::ModPortal::Error] when API request fails
+          # @raise [Factorix::DownloadError] when download fails
+          # @raise [Factorix::CLI::FileExistsError] when output file already exists
+          # @raise [Factorix::CLI::SHA1MismatchError] when SHA1 hash does not match
+          def call(mod_name:, **options)
+            release = find_mod_release(mod_name, options[:version])
+            output_path = determine_output_path(mod_name, release.version, options[:output_directory])
+            download_url = build_download_url(release.download_url)
+
+            download_mod(download_url, output_path, release.sha1, options[:quiet])
+          rescue Factorix::ModPortal::Error, Factorix::DownloadError => e
+            output_path.unlink if output_path&.exist?
+            raise e
+          end
+
+          private def find_mod_release(mod_name, version)
+            api = Factorix::ModPortal::API.new
+            mod = api.mod(mod_name)
+
+            release = find_release(mod.releases, version)
+            raise Factorix::CLI::Error, "No matching release found for version #{version}" if release.nil?
+
+            release
+          end
+
+          private def find_release(releases, version)
+            if version
+              releases.find {|r| r.version == version }
+            else
+              releases.max_by {|r| Gem::Version.new(r.version) }
+            end
+          end
+
+          private def determine_output_path(mod_name, version, output_directory)
+            filename = "#{mod_name}_#{version}.zip"
+            output_dir = Pathname(output_directory || Dir.pwd)
+            output_path = output_dir / filename
+
+            raise FileExistsError, output_path if output_path.exist?
+
+            output_path
+          end
+
+          private def build_download_url(base_url)
+            credential = Factorix::Credential.new
+            download_url = base_url.dup
+            query_params = URI.decode_www_form(download_url.query || "").to_h
+            query_params[:username] = credential.username
+            query_params[:token] = credential.token
+            download_url.query = URI.encode_www_form(query_params)
+            download_url
+          end
+
+          private def download_mod(download_url, output_path, expected_sha1, quiet)
+            puts "Downloading #{output_path.basename}..." unless quiet
+
+            download_file(download_url, output_path, quiet)
+            verify_and_report(output_path, expected_sha1, quiet)
+          end
+
+          private def download_file(download_url, output_path, quiet)
+            downloader = Factorix::Downloader.new(
+              http_client: Factorix::HttpClient.new(
+                # U+2699 GEAR + U+FE0F VARIATION SELECTOR-16
+                progress: quiet ? nil : Progress::Bar.new(title: "\u2699\uFE0F #{output_path.basename}")
+              )
+            )
+            downloader.download(download_url, output_path)
+          end
+
+          private def verify_and_report(output_path, expected_sha1, quiet)
+            unless quiet
+              puts "Downloaded to #{output_path}"
+              puts "Verifying SHA1 hash..."
+            end
+
+            verify_sha1(output_path, expected_sha1)
+            puts "SHA1 hash verified" unless quiet
+          end
+
+          private def verify_sha1(path, expected_sha1)
+            actual_sha1 = Digest::SHA1.file(path).hexdigest
+            return if actual_sha1 == expected_sha1
+
+            path.unlink
+            raise SHA1MismatchError.new(path, expected: expected_sha1, actual: actual_sha1)
+          end
+        end
+      end
+    end
+  end
+end

--- a/lib/factorix/cli/error.rb
+++ b/lib/factorix/cli/error.rb
@@ -1,0 +1,21 @@
+# frozen_string_literal: true
+
+module Factorix
+  class CLI
+    class Error < StandardError; end
+
+    # Raised when trying to download a mod to a path that already exists
+    class FileExistsError < Error
+      def initialize(path)
+        super("File already exists: #{path}")
+      end
+    end
+
+    # Raised when downloaded file's SHA1 hash does not match the expected value
+    class SHA1MismatchError < Error
+      def initialize(path, expected:, actual:)
+        super("SHA1 hash mismatch for #{path}: expected #{expected}, got #{actual}")
+      end
+    end
+  end
+end

--- a/lib/factorix/cli/error.rb
+++ b/lib/factorix/cli/error.rb
@@ -17,5 +17,11 @@ module Factorix
         super("SHA1 hash mismatch for #{path}: expected #{expected}, got #{actual}")
       end
     end
+
+    # Raised when output directory does not exist
+    class DirectoryNotFoundError < Error; end
+
+    # Raised when output directory is not writable
+    class DirectoryNotWritableError < Error; end
   end
 end

--- a/spec/factorix/cli/commands/mod/download_spec.rb
+++ b/spec/factorix/cli/commands/mod/download_spec.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+require "digest"
+require "dry/cli"
+require "fileutils"
+require "pathname"
+require "tempfile"
+
+require_relative "../../../../../lib/factorix/cli/commands/mod/download"
+
+RSpec.describe Factorix::CLI::Commands::Mod::Download do
+  subject(:command) { Factorix::CLI::Commands::Mod::Download.new }
+
+  let(:api) { instance_double(Factorix::ModPortal::API) }
+  let(:mod) { instance_double(Factorix::ModPortal::Types::Mod) }
+  let(:release) do
+    instance_double(
+      Factorix::ModPortal::Types::Release,
+      version: "1.2.3",
+      download_url: URI("https://mods.factorio.com/api/downloads/foo_1.2.3.zip"),
+      sha1: "0123456789abcdef0123456789abcdef01234567"
+    )
+  end
+  let(:credential) { instance_double(Factorix::Credential, username: "user", token: "token") }
+  let(:downloader) { instance_double(Factorix::Downloader) }
+  let(:http_client) { instance_double(Factorix::HttpClient) }
+  let(:progress_bar) { instance_double(Factorix::Progress::Bar) }
+  let(:sha1_digest) { instance_double(Digest::SHA1, hexdigest: release.sha1) }
+
+  before do
+    allow(Factorix::ModPortal::API).to receive(:new).and_return(api)
+    allow(api).to receive(:mod).with("foo").and_return(mod)
+    allow(mod).to receive(:releases).and_return([release])
+    allow(Factorix::Credential).to receive(:new).and_return(credential)
+    allow(Factorix::Downloader).to receive(:new).and_return(downloader)
+    allow(Factorix::HttpClient).to receive(:new).and_return(http_client)
+    allow(Factorix::Progress::Bar).to receive(:new).and_return(progress_bar)
+  end
+
+  describe "#call" do
+    let(:output_dir) { Pathname(Dir.mktmpdir) }
+    let(:output_path) { output_dir / "foo_1.2.3.zip" }
+
+    after do
+      FileUtils.remove_entry output_dir
+    end
+
+    context "when downloading a mod" do
+      before do
+        allow(downloader).to receive(:download) do |_url, path|
+          File.write(path, "dummy data")
+        end
+        allow(Digest::SHA1).to receive(:file).with(output_path).and_return(sha1_digest)
+      end
+
+      it "downloads the mod" do
+        expect { command.call(mod_name: "foo", output_directory: output_dir) }.not_to raise_error
+      end
+
+      it "creates the output file" do
+        command.call(mod_name: "foo", output_directory: output_dir)
+        expect(output_path).to exist
+      end
+
+      it "downloads without error when version is specified" do
+        expect { command.call(mod_name: "foo", version: "1.2.3", output_directory: output_dir) }.not_to raise_error
+      end
+
+      it "creates the output file when version is specified" do
+        command.call(mod_name: "foo", version: "1.2.3", output_directory: output_dir)
+        expect(output_path).to exist
+      end
+
+      # rubocop:disable RSpec/ExampleLength
+      it "adds authentication parameters to download URL" do
+        expected_url = release.download_url.dup
+        expected_url.query = URI.encode_www_form(username: "user", token: "token")
+        allow(downloader).to receive(:download).with(expected_url, output_path) do |_url, path|
+          File.write(path, "dummy data")
+        end
+
+        command.call(mod_name: "foo", output_directory: output_dir)
+        expect(downloader).to have_received(:download).with(expected_url, output_path)
+      end
+      # rubocop:enable RSpec/ExampleLength
+
+      context "with quiet option" do
+        it "suppresses output messages" do
+          expect { command.call(mod_name: "foo", output_directory: output_dir, quiet: true) }.not_to output.to_stdout
+        end
+      end
+    end
+
+    context "when the file already exists" do
+      before do
+        FileUtils.touch(output_path)
+      end
+
+      it "raises FileExistsError" do
+        expect { command.call(mod_name: "foo", output_directory: output_dir) }
+          .to raise_error(Factorix::CLI::FileExistsError, "File already exists: #{output_path}")
+      end
+    end
+
+    context "when SHA1 hash does not match" do
+      let(:sha1_digest) { instance_double(Digest::SHA1, hexdigest: "wrong_hash") }
+
+      before do
+        allow(downloader).to receive(:download) do |_url, path|
+          File.write(path, "wrong data")
+        end
+        allow(Digest::SHA1).to receive(:file).with(output_path).and_return(sha1_digest)
+      end
+
+      it "raises SHA1MismatchError" do
+        expect { command.call(mod_name: "foo", output_directory: output_dir) }
+          .to raise_error(Factorix::CLI::SHA1MismatchError)
+      end
+
+      it "removes the downloaded file" do
+        command.call(mod_name: "foo", output_directory: output_dir)
+      rescue Factorix::CLI::SHA1MismatchError
+        expect(output_path).not_to exist
+      end
+    end
+
+    context "when download fails" do
+      before do
+        allow(downloader).to receive(:download) do |_url, path|
+          File.write(path, "partial data")
+          raise Factorix::DownloadError, "Download failed"
+        end
+      end
+
+      it "raises the error" do
+        expect { command.call(mod_name: "foo", output_directory: output_dir) }
+          .to raise_error(Factorix::DownloadError, "Download failed")
+      end
+
+      it "removes the partially downloaded file" do
+        command.call(mod_name: "foo", output_directory: output_dir)
+      rescue Factorix::DownloadError
+        expect(output_path).not_to exist
+      end
+    end
+
+    context "when specified version does not exist" do
+      it "raises an error" do
+        expect { command.call(mod_name: "foo", version: "9.9.9", output_directory: output_dir) }
+          .to raise_error("No matching release found for version 9.9.9")
+      end
+    end
+  end
+end

--- a/spec/factorix/cli/commands/mod/download_spec.rb
+++ b/spec/factorix/cli/commands/mod/download_spec.rb
@@ -146,5 +146,29 @@ RSpec.describe Factorix::CLI::Commands::Mod::Download do
           .to raise_error("No matching release found for version 9.9.9")
       end
     end
+
+    context "when output directory does not exist" do
+      let(:non_existent_dir) { Pathname(output_dir) / "non_existent" }
+
+      it "raises DirectoryNotFoundError" do
+        expect { command.call(mod_name: "foo", output_directory: non_existent_dir) }
+          .to raise_error(Factorix::CLI::DirectoryNotFoundError, "Directory does not exist: #{non_existent_dir}")
+      end
+    end
+
+    context "when output directory is not writable" do
+      before do
+        FileUtils.chmod(0444, output_dir)
+      end
+
+      after do
+        FileUtils.chmod(0755, output_dir)
+      end
+
+      it "raises DirectoryNotWritableError" do
+        expect { command.call(mod_name: "foo", output_directory: output_dir) }
+          .to raise_error(Factorix::CLI::DirectoryNotWritableError, "Directory is not writable: #{output_dir}")
+      end
+    end
   end
 end

--- a/spec/factorix/cli/commands/mod/download_spec.rb
+++ b/spec/factorix/cli/commands/mod/download_spec.rb
@@ -112,15 +112,13 @@ RSpec.describe Factorix::CLI::Commands::Mod::Download do
         allow(Digest::SHA1).to receive(:file).with(output_path).and_return(sha1_digest)
       end
 
-      it "raises SHA1MismatchError" do
-        expect { command.call(mod_name: "foo", output_directory: output_dir) }
-          .to raise_error(Factorix::CLI::SHA1MismatchError)
-      end
-
-      it "removes the downloaded file" do
-        command.call(mod_name: "foo", output_directory: output_dir)
-      rescue Factorix::CLI::SHA1MismatchError
-        expect(output_path).not_to exist
+      it "raises SHA1MismatchError and removes the downloaded file" do
+        aggregate_failures do
+          expect {
+            command.call(mod_name: "foo", output_directory: output_dir)
+          }.to raise_error(Factorix::CLI::SHA1MismatchError)
+          expect(output_path).not_to exist
+        end
       end
     end
 
@@ -132,15 +130,13 @@ RSpec.describe Factorix::CLI::Commands::Mod::Download do
         end
       end
 
-      it "raises the error" do
-        expect { command.call(mod_name: "foo", output_directory: output_dir) }
-          .to raise_error(Factorix::DownloadError, "Download failed")
-      end
-
-      it "removes the partially downloaded file" do
-        command.call(mod_name: "foo", output_directory: output_dir)
-      rescue Factorix::DownloadError
-        expect(output_path).not_to exist
+      it "raises DownloadError and removes the partially downloaded file" do
+        aggregate_failures do
+          expect {
+            command.call(mod_name: "foo", output_directory: output_dir)
+          }.to raise_error(Factorix::DownloadError, "Download failed")
+          expect(output_path).not_to exist
+        end
       end
     end
 


### PR DESCRIPTION
Add download command to download mods from Factorio Mod Portal.

## Changes

- Add `mod download` command to download mods from Factorio Mod Portal
  - Support version specification
  - Support output directory specification
  - Support quiet mode
  - Verify SHA1 hash after download
  - Handle authentication with username and token
- Add error classes for file operations
  - `FileExistsError`: When the output file already exists
  - `SHA1MismatchError`: When the downloaded file's SHA1 hash does not match

## Testing

- Added comprehensive test cases for the download command
- All test cases pass with good coverage
- RuboCop violations are fixed or explicitly disabled with comments
