### PR TITLE
:hammer: Standardize exception raising style

### DIFF
--- a/lib/factorix/cli/commands/mod/download.rb
+++ b/lib/factorix/cli/commands/mod/download.rb
@@ -80,7 +80,7 @@ module Factorix
             raise DirectoryNotWritableError, "Directory is not writable: #{output_dir}" unless output_dir.writable?
 
             output_path = output_dir / filename
-            raise FileExistsError, output_path if output_path.exist?
+            raise FileExistsError, "File already exists: #{output_path}" if output_path.exist?
 
             output_path
           end
@@ -127,7 +127,7 @@ module Factorix
             return if actual_sha1 == expected_sha1
 
             path.unlink
-            raise SHA1MismatchError.new(path, expected: expected_sha1, actual: actual_sha1)
+            raise SHA1MismatchError, "SHA1 hash mismatch for #{path}: expected #{expected_sha1}, got #{actual_sha1}"
           end
         end
       end

--- a/lib/factorix/cli/error.rb
+++ b/lib/factorix/cli/error.rb
@@ -5,18 +5,10 @@ module Factorix
     class Error < StandardError; end
 
     # Raised when trying to download a mod to a path that already exists
-    class FileExistsError < Error
-      def initialize(path)
-        super("File already exists: #{path}")
-      end
-    end
+    class FileExistsError < Error; end
 
     # Raised when downloaded file's SHA1 hash does not match the expected value
-    class SHA1MismatchError < Error
-      def initialize(path, expected:, actual:)
-        super("SHA1 hash mismatch for #{path}: expected #{expected}, got #{actual}")
-      end
-    end
+    class SHA1MismatchError < Error; end
 
     # Raised when output directory does not exist
     class DirectoryNotFoundError < Error; end


### PR DESCRIPTION
Standardize exception raising style

Removed initialize methods from error classes and standardized exception raising to use the standard form (raise class, message).

## Changes

- Remove initialize methods from FileExistsError and SHA1MismatchError
- Standardize exception raising to use 'raise class, message' form

## Review Points

- Are exception messages appropriate?
- Is exception raising style consistent?
