### PR TITLE
:lipstick: Remove non-ASCII characters and add GitHub emoji guidelines

### DIFF
--- a/.claude/commit-pr-workflow-guide.md
+++ b/.claude/commit-pr-workflow-guide.md
@@ -96,6 +96,8 @@ Co-Authored-By: Claude <noreply@anthropic.com>
 
 **Important**: Always use GitHub emoji notation (`:emoji:`) in commit messages, not raw Unicode emojis (:no_entry_sign:). This ensures consistency and compatibility across different Git tools and platforms.
 
+**GitHub Emoji Guidelines**: Only use emojis that are part of GitHub's official emoji set when writing commit messages. Non-GitHub emojis should be avoided or replaced with appropriate GitHub emoji alternatives.
+
 #### Emoji Guide
 
 - `:new:` - New feature - Adding a new feature or capability

--- a/.claude/commit-pr-workflow-guide.md
+++ b/.claude/commit-pr-workflow-guide.md
@@ -94,30 +94,30 @@ Use bullet points for multiple changes:
 Co-Authored-By: Claude <noreply@anthropic.com>
 ```
 
-**Important**: Always use GitHub emoji notation (`:emoji:`) in commit messages, not raw Unicode emojis (🚫). This ensures consistency and compatibility across different Git tools and platforms.
+**Important**: Always use GitHub emoji notation (`:emoji:`) in commit messages, not raw Unicode emojis (:no_entry_sign:). This ensures consistency and compatibility across different Git tools and platforms.
 
 #### Emoji Guide
 
-- `:new:` - New feature – Adding a new feature or capability
-- `:beetle:` - Bug fix – Fixing an issue or bug
-- `:memo:` - Documentation – Writing or updating documentation
-- `:lipstick:` - Style – Code style changes (formatting, linting)
-- `:hammer:` - Refactor – Code changes that neither fix a bug nor add a feature
-- `:zap:` - Performance – Improving performance
-- `:test_tube:` - Tests – Adding or updating tests
-- `:recycle:` - Remove – Removing code or files
-- `:bookmark:` - Release – Tagging for release
-- `:wrench:` - Config – Configuration or build system changes
-- `:gem:` - Dependency – Adding or updating dependencies (Ruby)
-- `:package:` - Dependency – Adding or updating dependencies (non Ruby)
-- `:rewind:` - Revert – Reverting changes
-- `:rocket:` - Deploy – Deploying stuff
-- `:inbox_tray:` - Merge – Merging branches
-- `:truck:` - Move – Moving or renaming files
-- `:bulb:` - Idea – Idea or proposal
-- `:construction:` - WIP – Work in progress
-- `:computer:` - Terminal operation – Result of invoking some commands
-- `:tada:` - Initial – Initial commit
+- `:new:` - New feature - Adding a new feature or capability
+- `:beetle:` - Bug fix - Fixing an issue or bug
+- `:memo:` - Documentation - Writing or updating documentation
+- `:lipstick:` - Style - Code style changes (formatting, linting)
+- `:hammer:` - Refactor - Code changes that neither fix a bug nor add a feature
+- `:zap:` - Performance - Improving performance
+- `:test_tube:` - Tests - Adding or updating tests
+- `:recycle:` - Remove - Removing code or files
+- `:bookmark:` - Release - Tagging for release
+- `:wrench:` - Config - Configuration or build system changes
+- `:gem:` - Dependency - Adding or updating dependencies (Ruby)
+- `:package:` - Dependency - Adding or updating dependencies (non Ruby)
+- `:rewind:` - Revert - Reverting changes
+- `:rocket:` - Deploy - Deploying stuff
+- `:inbox_tray:` - Merge - Merging branches
+- `:truck:` - Move - Moving or renaming files
+- `:bulb:` - Idea - Idea or proposal
+- `:construction:` - WIP - Work in progress
+- `:computer:` - Terminal operation - Result of invoking some commands
+- `:tada:` - Initial - Initial commit
 
 ## PR Creation and Management
 


### PR DESCRIPTION
## Summary

Remove non-ASCII characters from the commit workflow guide and add explicit guidelines for using GitHub emoji notation to ensure ASCII-only compatibility.

## Key Changes

### Main Changes
- Replace Unicode emoji with GitHub notation (:no_entry_sign:)
- Replace em dash characters with regular hyphens in emoji guide descriptions
- Add explicit GitHub emoji guidelines for commit messages

### Technical Details
- Ensures all documentation uses ASCII-only characters for better compatibility
- Provides clear guidance on using only GitHub's official emoji set
- Maintains consistency across different Git tools and platforms

## Test Plan

- [x] All existing tests pass
- [x] RuboCop violations resolved
- [x] Documentation contains only ASCII characters
- [x] GitHub emoji guidelines clearly specified
- [x] No Unicode emojis or em dashes remain in the guide

## Breaking Changes

None

## Architecture Benefits

1. **Compatibility**: ASCII-only characters ensure compatibility across all Git tools and platforms
2. **Consistency**: Standardized emoji usage with GitHub's official emoji set
3. **Clarity**: Clear guidelines prevent future introduction of non-ASCII characters
4. **Maintainability**: Easier to work with files that use standard ASCII character set

:robot: Generated with [Claude Code](https://claude.ai/code)