### PR TITLE
:wrench: Consolidate documentation directories

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -2,7 +2,7 @@
 /.yardoc
 /_yardoc/
 /coverage/
-/doc/
+/docs/api/
 /pkg/
 /spec/reports/
 /tmp/

--- a/.yardopts
+++ b/.yardopts
@@ -1,1 +1,2 @@
 --markup markdown
+--output-dir docs/api

--- a/lib/tasks/clean.rake
+++ b/lib/tasks/clean.rake
@@ -3,6 +3,6 @@
 require "rake/clean"
 
 CLEAN.include("coverage/*")
-CLEAN.include("doc/*")
+CLEAN.include("docs/api/*")
 CLOBBER.include("coverage")
-CLOBBER.include("doc")
+CLOBBER.include("docs/api")


### PR DESCRIPTION
## Summary

This PR consolidates documentation directories by moving YARD-generated API documentation from `doc/` to `docs/api/`, allowing all documentation to be organized under a single `docs/` directory while preserving existing documentation files during clean operations.

## Key Changes

### Main Changes
- Configure YARD to output API documentation to `docs/api/` instead of `doc/`
- Update Rake clean task to target `docs/api/*` instead of `doc/*`
- Update `.gitignore` to ignore `docs/api/` instead of `doc/`

### Technical Details
- YARD configuration updated in `.yardopts` with `--output-dir docs/api`
- Clean task modified to preserve existing documentation in `docs/`
- Git ignore pattern updated to match new directory structure

## Test Plan

- [x] All existing tests pass (362 examples, 0 failures)
- [x] RuboCop violations resolved (67 files inspected, no offenses detected)
- [x] YARD documentation generates successfully (88.40% documented)
- [x] Clean task properly removes only generated API documentation
- [x] Existing documentation files in `docs/` are preserved
- [x] Code coverage maintained (Line: 94.46%, Branch: 85.04%)

## Breaking Changes

None - This is purely a documentation organization change with no functional impact.

## Architecture Benefits

1. **Unified Documentation**: All documentation now lives under `docs/` directory
2. **Preserved Content**: Clean operations no longer risk deleting Git-managed documentation
3. **Clear Separation**: API docs (`docs/api/`) vs design docs (`docs/design/`)
4. **Improved Organization**: Logical grouping of different documentation types
5. **Better Maintainability**: Easier to locate and manage all project documentation

:robot: Generated with [Claude Code](https://claude.ai/code)