### PR TITLE
:bug: fix(cli): fix error on CLI invocation by loading correct errors file

### DIFF
--- a/lib/factorix/cli.rb
+++ b/lib/factorix/cli.rb
@@ -9,7 +9,7 @@ require_relative "cli/commands/mod/download"
 require_relative "cli/commands/mod/enable"
 require_relative "cli/commands/mod/list"
 require_relative "cli/commands/mod/settings/dump"
-require_relative "cli/error"
+require_relative "errors"
 
 module Factorix
   # Command-line interface for Factorix


### PR DESCRIPTION
Fix incorrect require path in lib/factorix/cli.rb so that bundle exec exe/factorix -h prints help instead of raising LoadError.