### PR TITLE
:wrench: Update supported Ruby versions to latest patch levels

### DIFF
--- a/.github/workflows/main.yml
+++ b/.github/workflows/main.yml
@@ -14,9 +14,9 @@ jobs:
     strategy:
       matrix:
         ruby:
-          - '3.4.2'
-          - '3.3.7'
-          - '3.2.8'
+          - '3.4.5'
+          - '3.3.9'
+          - '3.2.9'
 
     steps:
       - uses: actions/checkout@v4

--- a/factorix.gemspec
+++ b/factorix.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description = "factorix"
   spec.homepage = "https://github.com/sakuro/factorix"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 3.2.8"
+  spec.required_ruby_version = ">= 3.2.9"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "#{spec.homepage}.git"

--- a/mise.toml
+++ b/mise.toml
@@ -2,4 +2,4 @@
 _.path = ["bin", "exe"]
 
 [tools]
-ruby = "3.2.8"
+ruby = "3.2.9"


### PR DESCRIPTION
Update Ruby version support to use the latest patch versions of the most recent 3 minor versions:
- Ruby 3.2.9
- Ruby 3.3.9
- Ruby 3.4.5

Updated configurations:
- gemspec: Set required_ruby_version to >= 3.2.9
- GitHub Actions: Test against 3.2.9, 3.3.9, and 3.4.5

🤖 Generated with [Claude Code](https://claude.ai/code)