### PR TITLE
:hammer: Remove redundant File::SEPARATOR check

### DIFF
--- a/lib/factorix/cli/commands/mod/new.rb
+++ b/lib/factorix/cli/commands/mod/new.rb
@@ -72,18 +72,6 @@ module Factorix
               raise ValidationError, "MOD name must be between 4 and 49 characters long"
             end
 
-            if mod_name.include?("..")
-              raise ValidationError, "MOD name cannot contain relative path indicators"
-            end
-
-            if mod_name.include?(File::SEPARATOR)
-              raise ValidationError, "MOD name cannot contain path separators"
-            end
-
-            if File::ALT_SEPARATOR && mod_name.include?(File::ALT_SEPARATOR)
-              raise ValidationError, "MOD name cannot contain path separators"
-            end
-
             return if mod_name.match?(/\A[a-zA-Z0-9_-]+\z/)
 
             raise ValidationError, "MOD name can only contain alphanumeric characters, underscores, and hyphens"

--- a/spec/factorix/cli/commands/mod/new_spec.rb
+++ b/spec/factorix/cli/commands/mod/new_spec.rb
@@ -266,20 +266,8 @@ RSpec.describe Factorix::CLI::Commands::Mod::New do
 
       it "raises ValidationError for invalid characters in MOD name" do
         expect {
-          command.call(mod_name: "test@mod", directory: @tmpdir.to_s)
+          command.call(mod_name: "test@mod..test/mod", directory: @tmpdir.to_s)
         }.to raise_error(Factorix::ValidationError, /can only contain alphanumeric characters/)
-      end
-
-      it "raises ValidationError for MOD name with relative path indicators" do
-        expect {
-          command.call(mod_name: "test..mod", directory: @tmpdir.to_s)
-        }.to raise_error(Factorix::ValidationError, /cannot contain relative path indicators/)
-      end
-
-      it "raises ValidationError for MOD name with path separators" do
-        expect {
-          command.call(mod_name: "test/mod", directory: @tmpdir.to_s)
-        }.to raise_error(Factorix::ValidationError, /cannot contain path separators/)
       end
 
       it "raises ValidationError for invalid factorio version" do


### PR DESCRIPTION
File::SEPARATOR and File::ALT_SEPARATOR are redundant because these characters are also invalid with alphanumeric check.