### PR TITLE
:arrow_up: Update Ruby versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.2", "3.3", "3.4"]
+        ruby: ["3.2", "3.3", "3.4", "4.0"]
 
     steps:
       - uses: actions/checkout@v5


### PR DESCRIPTION
Automated update of maintained Ruby versions from Ruby's official branches.yml.

This PR updates:
- `.github/workflows/ci.yml` test matrix to include all maintained Ruby versions
- `.github/workflows/release-*.yml` ruby-version to match the minimum Ruby version
- `.rubocop.yml` TargetRubyVersion to match the minimum Ruby version
- `*.gemspec` required_ruby_version to match the minimum Ruby version
- `mise.toml` ruby version to match the minimum Ruby version
