### PR TITLE
:bug: Allow nil value for completion shell argument

### DIFF
--- a/lib/factorix/cli/commands/completion.rb
+++ b/lib/factorix/cli/commands/completion.rb
@@ -30,7 +30,7 @@ module Factorix
         argument :shell,
           type: :string,
           required: false,
-          values: SUPPORTED_SHELLS.keys,
+          values: [nil] + SUPPORTED_SHELLS.keys,
           desc: "Shell type. Defaults to current shell from $SHELL"
 
         example [


### PR DESCRIPTION
## Summary

Fix validation error when running `completion` command without arguments after dry-cli 1.4.0 update.

## Changes

- Add `nil` to allowed `values` for shell argument to support omitted optional argument

## Root Cause

In dry-cli 1.4.0, `values` validation is applied even when `required: false` and the argument is omitted.

Fixes #4
