### PR TITLE
:recycle: Rename Application to Container

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## [Unreleased]
 
+### Changed
+
+- Rename `Factorix::Application` to `Factorix::Container` to avoid naming conflicts when used as a library (#7)
+
+### Deprecated
+
+- `Factorix::Application` still works but emits a deprecation warning; will be removed in v1.0
+
 ## [0.5.1] - 2026-01-13
 
 ### Fixed

--- a/DEVELOPMENT.md
+++ b/DEVELOPMENT.md
@@ -278,7 +278,7 @@ bundle exec exe/factorix path
 
 **Accessing log paths programmatically:**
 ```ruby
-runtime = Factorix::Application[:runtime]
+runtime = Factorix::Container[:runtime]
 runtime.factorix_log_path    # Factorix log file
 runtime.current_log_path     # Factorio current log
 runtime.previous_log_path    # Factorio previous log

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ $EDITOR ~/.config/factorix/config.rb
 
 **Example configuration:**
 ```ruby
-Factorix::Application.configure do |config|
+Factorix::Container.configure do |config|
   config.runtime.executable_path = "/Applications/Factorio.app/Contents/MacOS/factorio"
   config.runtime.user_dir = "#{Dir.home}/Library/Application Support/factorio"
   config.runtime.data_dir = "/Applications/Factorio.app/Contents/data"

--- a/doc/architecture.md
+++ b/doc/architecture.md
@@ -116,7 +116,7 @@ Factorix/
 │
 ├── ServiceCredential          # username + token (for MOD downloads)
 ├── APICredential              # api_key (for Portal API)
-├── Application                # dry-core Container + dry-configurable
+├── Container                  # dry-core Container + dry-configurable
 │
 └── Error                      # Simple error hierarchy
 ```

--- a/doc/components/api-portal.md
+++ b/doc/components/api-portal.md
@@ -212,7 +212,7 @@ Forwards all arguments to `MODPortalAPI#get_mods` and converts results to `API::
 
 **Usage**:
 ```ruby
-portal = Factorix::Application[:portal]
+portal = Factorix::Container[:portal]
 
 # List all mods
 portal.list_mods

--- a/doc/components/cli.md
+++ b/doc/components/cli.md
@@ -23,7 +23,7 @@ The following options are available for all commands:
 |----------|-------------|
 | `FACTORIX_CONFIG` | Path to configuration file. Overrides the default location. |
 
-See [Application Configuration](application.md) for configuration file loading priority.
+See [Container Configuration](container.md) for configuration file loading priority.
 
 ## Command List
 

--- a/doc/components/container.md
+++ b/doc/components/container.md
@@ -1,6 +1,6 @@
-# Application Configuration and DI
+# Container Configuration and DI
 
-Component that manages dependency management and configuration for the entire application.
+Component that manages dependency injection and configuration for the library.
 
 ## Structure
 
@@ -68,7 +68,7 @@ Configuration file is resolved in the following order:
 ### Configuration File Format (Ruby DSL)
 
 ```ruby
-Factorix::Application.configure do |config|
+Factorix::Container.configure do |config|
   config.cache_dir = "/custom/cache/path"
   config.log_level = :debug
   config.http.open_timeout = 120
@@ -78,7 +78,7 @@ end
 ## Dependency Injection
 
 ```ruby
-Import = Dry::AutoInject(Factorix::Application)
+Import = Dry::AutoInject(Factorix::Container)
 
 class SomeClass
   include Import[:logger, cache: :api_cache]

--- a/doc/components/credentials.md
+++ b/doc/components/credentials.md
@@ -116,5 +116,5 @@ Implementation: `Factorix::HTTP::Client#mask_credentials`
 ## Related Documentation
 
 - [API/Portal Layer](api-portal.md)
-- [Application Configuration](application.md)
+- [Container Configuration](container.md)
 - [Technology Stack](../technology-stack.md)

--- a/doc/components/http.md
+++ b/doc/components/http.md
@@ -6,7 +6,7 @@ Low-level HTTP infrastructure for all network communication.
 
 ```mermaid
 graph TD
-    subgraph Application Container
+    subgraph Container Container
         api[api_http_client]
         download[download_http_client]
         upload[upload_http_client]
@@ -44,7 +44,7 @@ Core HTTP client using `Net::HTTP`.
 
 **Constraints**:
 - HTTPS only (raises `URLError` for non-HTTPS)
-- Timeouts configured via `Application.config.http`
+- Timeouts configured via `Container.config.http`
 
 ### Response
 
@@ -108,7 +108,7 @@ Adds caching for GET requests. See [`cache.md`](cache.md) for detailed cache arc
 
 ## Client Variants
 
-Registered in `Application` container with different decorator stacks:
+Registered in `Container` container with different decorator stacks:
 
 | Client | Decorators | Use Case |
 |--------|------------|----------|
@@ -133,7 +133,7 @@ graph TD
 
 ## Configuration
 
-Timeouts are configured via `Application.config.http`:
+Timeouts are configured via `Container.config.http`:
 
 - `connect_timeout` - Connection timeout (seconds)
 - `read_timeout` - Read timeout (seconds)
@@ -144,7 +144,7 @@ Timeouts are configured via `Application.config.http`:
 ### Direct Client Usage
 
 ```ruby
-client = Factorix::Application[:api_http_client]
+client = Factorix::Container[:api_http_client]
 
 # GET request
 response = client.get(URI("https://mods.factorio.com/api/mods"))
@@ -161,7 +161,7 @@ response = client.post(
 ### Streaming Download
 
 ```ruby
-client = Factorix::Application[:download_http_client]
+client = Factorix::Container[:download_http_client]
 
 client.get(download_uri) do |response|
   File.open(output_path, "wb") do |file|
@@ -175,5 +175,5 @@ end
 ## Related Documentation
 
 - [API and Portal Layers](api-portal.md)
-- [Application Container](application.md)
+- [Container Container](application.md)
 - [Cache System](cache.md)

--- a/doc/components/runtime.md
+++ b/doc/components/runtime.md
@@ -74,7 +74,7 @@ The `UserConfigurable` module is prepended to `Runtime::Base` and all its subcla
 Users can explicitly configure paths in `~/.config/factorix/config.rb` (or `$XDG_CONFIG_HOME/factorix/config.rb`):
 
 ```ruby
-Factorix::Application.configure do |config|
+Factorix::Container.configure do |config|
   config.runtime.executable_path = "/path/to/factorio"
   config.runtime.user_dir = "/path/to/factorio/user/dir"
   config.runtime.data_dir = "/path/to/factorio/data"

--- a/doc/components/transfer.md
+++ b/doc/components/transfer.md
@@ -154,7 +154,7 @@ CombinedIO.new(header_io, file_io, footer_io)
 ### Download with Progress
 
 ```ruby
-downloader = Factorix::Application[:downloader]
+downloader = Factorix::Container[:downloader]
 
 handler = ->(event) { puts "#{event[:current_size]} / #{event[:total_size]}" }
 downloader.subscribe("download.progress", &handler)
@@ -169,7 +169,7 @@ downloader.download(
 ### Upload with Additional Fields
 
 ```ruby
-uploader = Factorix::Application[:uploader]
+uploader = Factorix::Container[:uploader]
 
 uploader.upload(
   "https://mods.factorio.com/upload/...",

--- a/example/config.rb
+++ b/example/config.rb
@@ -8,7 +8,7 @@
 # Copy this file to: ~/.config/factorix/config.rb
 # Or specify with: factorix --config-path /path/to/config.rb
 
-Factorix::Application.configure do |config|
+Factorix::Container.configure do |config|
   # ============================================================================
   # Runtime Configuration
   # ============================================================================

--- a/lib/factorix.rb
+++ b/lib/factorix.rb
@@ -35,4 +35,14 @@ module Factorix
 
   Import = Dry::AutoInject(Container)
   public_constant :Import
+
+  # @deprecated Use {Container} instead of Application. Will be removed in v1.0.
+  def self.const_missing(name)
+    if name == :Application
+      warn "[factorix] Factorix::Application is deprecated, use Factorix::Container instead"
+      Container
+    else
+      super
+    end
+  end
 end

--- a/lib/factorix.rb
+++ b/lib/factorix.rb
@@ -33,6 +33,6 @@ module Factorix
   )
   loader.setup
 
-  Import = Dry::AutoInject(Application)
+  Import = Dry::AutoInject(Container)
   public_constant :Import
 end

--- a/lib/factorix/api/mod_download_api.rb
+++ b/lib/factorix/api/mod_download_api.rb
@@ -51,7 +51,7 @@ module Factorix
         return @service_credential if defined?(@service_credential)
 
         @service_credential_mutex.synchronize do
-          @service_credential ||= Application[:service_credential]
+          @service_credential ||= Container[:service_credential]
         end
       end
 

--- a/lib/factorix/api/mod_info.rb
+++ b/lib/factorix/api/mod_info.rb
@@ -114,7 +114,7 @@ module Factorix
 
           URI(value)
         rescue URI::InvalidURIError => e
-          Application[:logger].warn("Skipping invalid URI '#{value}': #{e.message}")
+          Container[:logger].warn("Skipping invalid URI '#{value}': #{e.message}")
           nil
         end
       end
@@ -145,7 +145,7 @@ module Factorix
             Release[**r]
           rescue RangeError => e
             # Skip releases with invalid version numbers
-            Application[:logger].warn("Skipping release #{name}@#{r[:version]}: #{e.message}")
+            Container[:logger].warn("Skipping release #{name}@#{r[:version]}: #{e.message}")
             nil
           end
         }

--- a/lib/factorix/api/mod_management_api.rb
+++ b/lib/factorix/api/mod_management_api.rb
@@ -208,7 +208,7 @@ module Factorix
         return @api_credential if defined?(@api_credential)
 
         @api_credential_mutex.synchronize do
-          @api_credential ||= Application[:api_credential]
+          @api_credential ||= Container[:api_credential]
         end
       end
 

--- a/lib/factorix/api_credential.rb
+++ b/lib/factorix/api_credential.rb
@@ -22,7 +22,7 @@ module Factorix
     # @return [APICredential] new instance with API key from environment
     # @raise [CredentialError] if API key is not set in environment
     def self.load
-      logger = Application["logger"]
+      logger = Container["logger"]
       logger.debug "Loading API credentials from environment"
 
       api_key = ENV.fetch(ENV_API_KEY, nil)

--- a/lib/factorix/cli/commands/cache/evict.rb
+++ b/lib/factorix/cli/commands/cache/evict.rb
@@ -95,7 +95,7 @@ module Factorix
           # @return [Array<Symbol>] resolved cache names
           # @raise [InvalidArgumentError] if unknown cache name specified
           private def resolve_cache_names(caches)
-            all_caches = Application.config.cache.values.keys
+            all_caches = Container.config.cache.values.keys
 
             return all_caches if caches.nil? || caches.empty?
 
@@ -114,7 +114,7 @@ module Factorix
           # @param expired [Boolean] remove expired entries only
           # @return [Hash] eviction result with :count and :size
           private def evict_cache(name, all:, expired:)
-            config = Application.config.cache.public_send(name)
+            config = Container.config.cache.public_send(name)
             cache_dir = config.dir
             ttl = config.ttl
 

--- a/lib/factorix/cli/commands/cache/stat.rb
+++ b/lib/factorix/cli/commands/cache/stat.rb
@@ -42,7 +42,7 @@ module Factorix
             logger.debug("Collecting cache statistics")
 
             @now = Time.now
-            cache_names = Application.config.cache.values.keys
+            cache_names = Container.config.cache.values.keys
             stats = cache_names.to_h {|name| [name, collect_stats(name)] }
 
             if json
@@ -53,7 +53,7 @@ module Factorix
           end
 
           private def collect_stats(name)
-            config = Application.config.cache.public_send(name)
+            config = Container.config.cache.public_send(name)
             cache_dir = config.dir
 
             entries = scan_entries(cache_dir, config.ttl)

--- a/lib/factorix/cli/commands/command_wrapper.rb
+++ b/lib/factorix/cli/commands/command_wrapper.rb
@@ -23,14 +23,14 @@ module Factorix
           super
         rescue Error => e
           # Expected errors (validation failures, missing dependencies, etc.)
-          log = Application[:logger]
+          log = Container[:logger]
           log.warn(e.message)
           log.debug(e)
           say "Error: #{e.message}", prefix: :error unless @quiet
           raise # Re-raise for exe/factorix to handle exit code
         rescue => e
           # Unexpected errors (bugs, system failures, etc.)
-          log = Application[:logger]
+          log = Container[:logger]
           log.error(e)
           say "Unexpected error: #{e.message}", prefix: :error unless @quiet
           raise # Re-raise for exe/factorix to handle exit code
@@ -40,7 +40,7 @@ module Factorix
           path = resolve_config_path(explicit_path)
           return unless path
 
-          Application.load_config(path)
+          Container.load_config(path)
         end
 
         # Resolves which config path to use
@@ -50,14 +50,14 @@ module Factorix
           return Pathname(explicit_path) if explicit_path
           return Pathname(ENV.fetch("FACTORIX_CONFIG")) if ENV["FACTORIX_CONFIG"]
 
-          default_path = Application[:runtime].factorix_config_path
+          default_path = Container[:runtime].factorix_config_path
           default_path.exist? ? default_path : nil
         end
 
         # Sets the application logger's level
         # @param level [String] log level (debug, info, warn, error, fatal)
         private def log_level!(level)
-          logger = Application[:logger]
+          logger = Container[:logger]
           level_constant = Logger.const_get(level.upcase)
 
           # Change only the File backend (first backend) level

--- a/lib/factorix/cli/commands/download_support.rb
+++ b/lib/factorix/cli/commands/download_support.rb
@@ -97,7 +97,7 @@ module Factorix
 
           futures = targets.map {|target|
             Concurrent::Future.execute(executor: pool) do
-              thread_portal = Application[:portal]
+              thread_portal = Container[:portal]
               thread_downloader = thread_portal.mod_download_api.downloader
 
               presenter = multi_presenter.register(

--- a/lib/factorix/cli/commands/mod/update.rb
+++ b/lib/factorix/cli/commands/mod/update.rb
@@ -195,7 +195,7 @@ module Factorix
 
             futures = targets.map {|target|
               Concurrent::Future.execute(executor: pool) do
-                thread_portal = Application[:portal]
+                thread_portal = Container[:portal]
                 thread_downloader = thread_portal.mod_download_api.downloader
 
                 presenter = multi_presenter.register(

--- a/lib/factorix/container.rb
+++ b/lib/factorix/container.rb
@@ -5,20 +5,20 @@ require "dry/core"
 require "dry/logger"
 
 module Factorix
-  # Application container and configuration
+  # DI container and configuration
   #
   # Provides dependency injection container and configuration management
   # using dry-core's Container and dry-configurable.
   #
-  # @example Configure the application
-  #   Factorix::Application.configure do |config|
+  # @example Configure the container
+  #   Factorix::Container.configure do |config|
   #     config.log_level = :debug
   #     config.http.connect_timeout = 10
   #   end
   #
   # @example Resolve dependencies
-  #   runtime = Factorix::Application[:runtime]
-  class Application
+  #   runtime = Factorix::Container[:runtime]
+  class Container
     extend Dry::Core::Container::Mixin
     extend Dry::Configurable
 

--- a/lib/factorix/dependency/parser.rb
+++ b/lib/factorix/dependency/parser.rb
@@ -128,7 +128,7 @@ module Factorix
         MODVersionRequirement[operator:, version:]
       rescue VersionParseError => e
         # Skip version requirements with out-of-range version components
-        Application[:logger].warn("Skipping version requirement '#{version_string}': #{e.message}")
+        Container[:logger].warn("Skipping version requirement '#{version_string}': #{e.message}")
         nil
       end
 

--- a/lib/factorix/http/client.rb
+++ b/lib/factorix/http/client.rb
@@ -162,9 +162,9 @@ module Factorix
         Net::HTTP.new(uri.host, uri.port).tap do |http|
           http.use_ssl = uri.scheme == "https"
           http.verify_mode = OpenSSL::SSL::VERIFY_PEER
-          http.open_timeout = Application.config.http.connect_timeout
-          http.read_timeout = Application.config.http.read_timeout
-          http.write_timeout = Application.config.http.write_timeout if http.respond_to?(:write_timeout=)
+          http.open_timeout = Container.config.http.connect_timeout
+          http.read_timeout = Container.config.http.read_timeout
+          http.write_timeout = Container.config.http.write_timeout if http.respond_to?(:write_timeout=)
         end
       end
 

--- a/lib/factorix/info_json.rb
+++ b/lib/factorix/info_json.rb
@@ -47,8 +47,8 @@ module Factorix
     # @return [InfoJSON] parsed info.json from zip
     # @raise [FileFormatError] if zip is invalid or info.json not found
     def self.from_zip(zip_path)
-      cache = Application.resolve(:info_json_cache)
-      logger = Application.resolve(:logger)
+      cache = Container.resolve(:info_json_cache)
+      logger = Container.resolve(:logger)
       cache_key = cache.key_for(zip_path.to_s)
 
       if (cached_json = cache.read(cache_key, encoding: Encoding::UTF_8))

--- a/lib/factorix/mod_list.rb
+++ b/lib/factorix/mod_list.rb
@@ -18,7 +18,7 @@ module Factorix
     # @param path [Pathname] the path to the file to load the MOD list from (default: runtime.mod_list_path)
     # @return [Factorix::MODList] the loaded MOD list
     # @raise [MODSettingsError] if the base MOD is disabled
-    def self.load(path=Application[:runtime].mod_list_path)
+    def self.load(path=Container[:runtime].mod_list_path)
       raw_data = JSON.parse(path.read, symbolize_names: true)
       mods_hash = raw_data[:mods].to_h {|entry|
         mod = MOD[name: entry[:name]]
@@ -50,7 +50,7 @@ module Factorix
     #
     # @param path [Pathname] the path to the file to save the MOD list to (default: runtime.mod_list_path)
     # @return [void]
-    def save(path=Application[:runtime].mod_list_path)
+    def save(path=Container[:runtime].mod_list_path)
       mods_data = @mods.map {|mod, state|
         data = {name: mod.name, enabled: state.enabled?}
         # Only include version in the output if it exists

--- a/lib/factorix/mod_settings.rb
+++ b/lib/factorix/mod_settings.rb
@@ -108,7 +108,7 @@ module Factorix
     #
     # @param path [Pathname] Path to the MOD settings file (default: runtime.mod_settings_path)
     # @return [MODSettings] New MODSettings instance
-    def self.load(path=Application[:runtime].mod_settings_path)
+    def self.load(path=Container[:runtime].mod_settings_path)
       path.open("rb") do |io|
         game_version, sections = load_settings_from_io(io)
         new(game_version, sections)
@@ -244,7 +244,7 @@ module Factorix
     #
     # @param path [Pathname] Path to save the MOD settings file (default: runtime.mod_settings_path)
     # @return [void]
-    def save(path=Application[:runtime].mod_settings_path)
+    def save(path=Container[:runtime].mod_settings_path)
       path.open("wb") do |file|
         serializer = SerDes::Serializer.new(file)
 

--- a/lib/factorix/runtime/user_configurable.rb
+++ b/lib/factorix/runtime/user_configurable.rb
@@ -8,10 +8,10 @@ module Factorix
     # auto-detected paths via configuration. When a configured path is available,
     # it is used instead of platform-specific auto-detection.
     #
-    # Configuration is done via Application.config:
+    # Configuration is done via Container.config:
     #
     # @example Configure paths in config file
-    #   Factorix::Application.configure do |config|
+    #   Factorix::Container.configure do |config|
     #     config.runtime.executable_path = "/opt/factorio/bin/x64/factorio"
     #     config.runtime.user_dir = "/home/user/.factorio"
     #   end
@@ -46,20 +46,20 @@ module Factorix
       def data_dir = configurable_path(:data_dir, example_path: "/path/to/factorio/data") { super }
 
       private def configurable_path(name, example_path:)
-        if (configured = Application.config.runtime.public_send(name))
-          Application[:logger].debug("Using configured #{name}", path: configured.to_s)
+        if (configured = Container.config.runtime.public_send(name))
+          Container[:logger].debug("Using configured #{name}", path: configured.to_s)
           configured
         else
-          Application[:logger].debug("No configuration for #{name}, using auto-detection")
-          yield.tap {|path| Application[:logger].debug("Auto-detected #{name}", path: path.to_s) }
+          Container[:logger].debug("No configuration for #{name}, using auto-detection")
+          yield.tap {|path| Container[:logger].debug("Auto-detected #{name}", path: path.to_s) }
         end
       rescue NotImplementedError => e
-        Application[:logger].error("Auto-detection failed and no configuration provided", error: e.message)
+        Container[:logger].error("Auto-detection failed and no configuration provided", error: e.message)
         raise ConfigurationError, <<~MESSAGE
           #{name} not configured and auto-detection is not supported for this platform.
-          Please configure it in #{Application[:runtime].factorix_config_path}:
+          Please configure it in #{Container[:runtime].factorix_config_path}:
 
-            Factorix::Application.configure do |config|
+            Factorix::Container.configure do |config|
               config.runtime.#{name} = "#{example_path}"
             end
         MESSAGE

--- a/lib/factorix/service_credential.rb
+++ b/lib/factorix/service_credential.rb
@@ -39,7 +39,7 @@ module Factorix
       elsif username_env || token_env
         raise CredentialError, "Both #{ENV_USERNAME} and #{ENV_TOKEN} must be set (or neither)"
       else
-        runtime = Application[:runtime]
+        runtime = Container[:runtime]
         from_player_data(runtime:)
       end
     end
@@ -49,7 +49,7 @@ module Factorix
     # @return [ServiceCredential] new instance with credentials from environment
     # @raise [CredentialError] if username or token is not set or empty
     def self.from_env
-      logger = Application["logger"]
+      logger = Container["logger"]
       logger.debug "Loading service credentials from environment"
 
       username = ENV.fetch(ENV_USERNAME, nil)
@@ -83,7 +83,7 @@ module Factorix
     # @raise [Errno::ENOENT] if player-data.json does not exist
     # @raise [CredentialError] if username or token is missing in player-data.json
     def self.from_player_data(runtime:)
-      logger = Application["logger"]
+      logger = Container["logger"]
       logger.debug "Loading service credentials from player-data.json"
 
       player_data_path = runtime.player_data_path

--- a/sig/factorix/container.rbs
+++ b/sig/factorix/container.rbs
@@ -3,7 +3,7 @@
 #       Only public interfaces should be documented here.
 
 module Factorix
-  class Application
+  class Container
     extend Dry::Core::Container::Mixin
     extend Dry::Configurable
 

--- a/spec/factorix/api/mod_download_api_spec.rb
+++ b/spec/factorix/api/mod_download_api_spec.rb
@@ -9,8 +9,8 @@ RSpec.describe Factorix::API::MODDownloadAPI do
 
   before do
     # Stub service_credential in Application container for lazy loading
-    allow(Factorix::Application).to receive(:[]).and_call_original
-    allow(Factorix::Application).to receive(:[]).with(:service_credential).and_return(service_credential)
+    allow(Factorix::Container).to receive(:[]).and_call_original
+    allow(Factorix::Container).to receive(:[]).with(:service_credential).and_return(service_credential)
   end
 
   describe "#download" do

--- a/spec/factorix/api/mod_management_api_spec.rb
+++ b/spec/factorix/api/mod_management_api_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe Factorix::API::MODManagementAPI do
 
   before do
     # Stub api_credential in Application container for lazy loading
-    allow(Factorix::Application).to receive(:[]).and_call_original
-    allow(Factorix::Application).to receive(:[]).with(:api_credential).and_return(api_credential)
+    allow(Factorix::Container).to receive(:[]).and_call_original
+    allow(Factorix::Container).to receive(:[]).with(:api_credential).and_return(api_credential)
   end
 
   describe "#init_publish" do

--- a/spec/factorix/application_spec.rb
+++ b/spec/factorix/application_spec.rb
@@ -1,0 +1,16 @@
+# frozen_string_literal: true
+
+RSpec.describe "Factorix::Application" do
+  describe "deprecation" do
+    it "returns Container" do
+      result = nil
+      capture_stderr { result = Factorix::Application }
+      expect(result).to eq(Factorix::Container)
+    end
+
+    it "outputs deprecation warning" do
+      warning = capture_stderr { Factorix::Application }
+      expect(warning).to match(/\[factorix\] Factorix::Application is deprecated, use Factorix::Container instead/)
+    end
+  end
+end

--- a/spec/factorix/cli/commands/cache/evict_spec.rb
+++ b/spec/factorix/cli/commands/cache/evict_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Factorix::CLI::Commands::Cache::Evict do
     %i[download api info_json].each do |name|
       dir = cache_dir / name.to_s
       dir.mkpath
-      allow(Factorix::Application.config.cache.public_send(name)).to receive(:dir).and_return(dir)
+      allow(Factorix::Container.config.cache.public_send(name)).to receive(:dir).and_return(dir)
     end
   end
 

--- a/spec/factorix/cli/commands/cache/stat_spec.rb
+++ b/spec/factorix/cli/commands/cache/stat_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Factorix::CLI::Commands::Cache::Stat do
     %i[download api info_json].each do |name|
       dir = cache_dir / name.to_s
       dir.mkpath
-      allow(Factorix::Application.config.cache.public_send(name)).to receive(:dir).and_return(dir)
+      allow(Factorix::Container.config.cache.public_send(name)).to receive(:dir).and_return(dir)
     end
   end
 

--- a/spec/factorix/cli/commands/command_wrapper_spec.rb
+++ b/spec/factorix/cli/commands/command_wrapper_spec.rb
@@ -30,10 +30,10 @@ RSpec.describe Factorix::CLI::Commands::CommandWrapper do
   let(:default_config_path) { Pathname("/tmp/factorix/config.rb") }
 
   before do
-    allow(Factorix::Application).to receive(:[]).and_call_original
-    allow(Factorix::Application).to receive(:[]).with(:runtime).and_return(runtime)
-    allow(Factorix::Application).to receive(:[]).with(:logger).and_return(logger)
-    allow(Factorix::Application).to receive(:load_config)
+    allow(Factorix::Container).to receive(:[]).and_call_original
+    allow(Factorix::Container).to receive(:[]).with(:runtime).and_return(runtime)
+    allow(Factorix::Container).to receive(:[]).with(:logger).and_return(logger)
+    allow(Factorix::Container).to receive(:load_config)
     allow(logger).to receive(:backends).and_return([file_backend])
     allow(runtime).to receive(:factorix_config_path).and_return(default_config_path)
     allow(default_config_path).to receive(:exist?).and_return(false)
@@ -57,7 +57,7 @@ RSpec.describe Factorix::CLI::Commands::CommandWrapper do
 
       it "loads configuration from specified path" do
         command.call(config_path:)
-        expect(Factorix::Application).to have_received(:load_config).with(config_path)
+        expect(Factorix::Container).to have_received(:load_config).with(config_path)
       end
     end
 
@@ -76,7 +76,7 @@ RSpec.describe Factorix::CLI::Commands::CommandWrapper do
 
           command.call
 
-          expect(Factorix::Application).to have_received(:load_config) do |path|
+          expect(Factorix::Container).to have_received(:load_config) do |path|
             expect(path).to be_a(Pathname)
             expect(path.to_s).to eq(config_file.path)
           end
@@ -91,14 +91,14 @@ RSpec.describe Factorix::CLI::Commands::CommandWrapper do
 
           it "loads configuration from default path" do
             command.call
-            expect(Factorix::Application).to have_received(:load_config).with(default_config_path)
+            expect(Factorix::Container).to have_received(:load_config).with(default_config_path)
           end
         end
 
         context "when default config file does not exist" do
           it "does not load configuration" do
             command.call
-            expect(Factorix::Application).not_to have_received(:load_config)
+            expect(Factorix::Container).not_to have_received(:load_config)
           end
         end
       end

--- a/spec/factorix/cli/commands/mod/check_spec.rb
+++ b/spec/factorix/cli/commands/mod/check_spec.rb
@@ -20,7 +20,7 @@ RSpec.describe Factorix::CLI::Commands::MOD::Check do
   let(:validation_result) { instance_double(Factorix::Dependency::ValidationResult) }
 
   before do
-    allow(Factorix::Application).to receive(:load_config)
+    allow(Factorix::Container).to receive(:load_config)
     allow(Factorix::MODList).to receive(:load).and_return(mod_list)
     allow(Factorix::InstalledMOD).to receive(:all).and_return([])
     allow(Factorix::Dependency::Graph::Builder).to receive(:build).and_return(graph)

--- a/spec/factorix/cli/commands/mod/disable_spec.rb
+++ b/spec/factorix/cli/commands/mod/disable_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Factorix::CLI::Commands::MOD::Disable do
   let(:mod_c) { Factorix::MOD[name: "mod-c"] }
 
   before do
-    allow(Factorix::Application).to receive(:load_config)
+    allow(Factorix::Container).to receive(:load_config)
     allow(Factorix::MODList).to receive(:load).and_return(mod_list)
     allow(mod_list).to receive(:save)
     allow(mod_list).to receive(:disable)

--- a/spec/factorix/cli/commands/mod/download_spec.rb
+++ b/spec/factorix/cli/commands/mod/download_spec.rb
@@ -45,9 +45,9 @@ RSpec.describe Factorix::CLI::Commands::MOD::Download do
   end
 
   before do
-    allow(Factorix::Application).to receive(:[]).and_call_original
-    allow(Factorix::Application).to receive(:[]).with(:portal).and_return(portal)
-    allow(Factorix::Application).to receive(:[]).with(:logger).and_return(logger)
+    allow(Factorix::Container).to receive(:[]).and_call_original
+    allow(Factorix::Container).to receive(:[]).with(:portal).and_return(portal)
+    allow(Factorix::Container).to receive(:[]).with(:logger).and_return(logger)
     allow(portal).to receive(:get_mod_full).with("test-mod").and_return(mod_info)
     allow(portal).to receive(:download_mod)
     allow(downloader).to receive(:subscribe)

--- a/spec/factorix/cli/commands/mod/edit_spec.rb
+++ b/spec/factorix/cli/commands/mod/edit_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe Factorix::CLI::Commands::MOD::Edit do
   let(:command) { Factorix::CLI::Commands::MOD::Edit.new(portal:) }
 
   before do
-    allow(Factorix::Application).to receive(:[]).and_call_original
-    allow(Factorix::Application).to receive(:[]).with(:portal).and_return(portal)
+    allow(Factorix::Container).to receive(:[]).and_call_original
+    allow(Factorix::Container).to receive(:[]).with(:portal).and_return(portal)
     allow(portal).to receive(:edit_mod)
   end
 

--- a/spec/factorix/cli/commands/mod/enable_spec.rb
+++ b/spec/factorix/cli/commands/mod/enable_spec.rb
@@ -27,7 +27,7 @@ RSpec.describe Factorix::CLI::Commands::MOD::Enable do
   let(:mod_c) { Factorix::MOD[name: "mod-c"] }
 
   before do
-    allow(Factorix::Application).to receive(:load_config)
+    allow(Factorix::Container).to receive(:load_config)
     allow(Factorix::MODList).to receive(:load).and_return(mod_list)
     allow(mod_list).to receive(:save)
     allow(mod_list).to receive(:enable)

--- a/spec/factorix/cli/commands/mod/image/add_spec.rb
+++ b/spec/factorix/cli/commands/mod/image/add_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe Factorix::CLI::Commands::MOD::Image::Add do
   let(:tmpdir) { Dir.mktmpdir }
 
   before do
-    allow(Factorix::Application).to receive(:[]).and_call_original
-    allow(Factorix::Application).to receive(:[]).with(:portal).and_return(portal)
+    allow(Factorix::Container).to receive(:[]).and_call_original
+    allow(Factorix::Container).to receive(:[]).with(:portal).and_return(portal)
   end
 
   after do

--- a/spec/factorix/cli/commands/mod/image/edit_spec.rb
+++ b/spec/factorix/cli/commands/mod/image/edit_spec.rb
@@ -7,8 +7,8 @@ RSpec.describe Factorix::CLI::Commands::MOD::Image::Edit do
   let(:command) { Factorix::CLI::Commands::MOD::Image::Edit.new(portal:) }
 
   before do
-    allow(Factorix::Application).to receive(:[]).and_call_original
-    allow(Factorix::Application).to receive(:[]).with(:portal).and_return(portal)
+    allow(Factorix::Container).to receive(:[]).and_call_original
+    allow(Factorix::Container).to receive(:[]).with(:portal).and_return(portal)
     allow(portal).to receive(:edit_mod_images)
   end
 

--- a/spec/factorix/cli/commands/mod/image/list_spec.rb
+++ b/spec/factorix/cli/commands/mod/image/list_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe Factorix::CLI::Commands::MOD::Image::List do
   let(:command) { Factorix::CLI::Commands::MOD::Image::List.new(portal:) }
 
   before do
-    allow(Factorix::Application).to receive(:[]).and_call_original
-    allow(Factorix::Application).to receive(:[]).with(:portal).and_return(portal)
+    allow(Factorix::Container).to receive(:[]).and_call_original
+    allow(Factorix::Container).to receive(:[]).with(:portal).and_return(portal)
   end
 
   describe "#call" do

--- a/spec/factorix/cli/commands/mod/install_spec.rb
+++ b/spec/factorix/cli/commands/mod/install_spec.rb
@@ -55,12 +55,12 @@ RSpec.describe Factorix::CLI::Commands::MOD::Install do
   end
 
   before do
-    allow(Factorix::Application).to receive(:[]).and_call_original
-    allow(Factorix::Application).to receive(:[]).with(:runtime).and_return(runtime)
-    allow(Factorix::Application).to receive(:[]).with(:logger).and_return(logger)
-    allow(Factorix::Application).to receive(:[]).with(:portal).and_return(portal)
+    allow(Factorix::Container).to receive(:[]).and_call_original
+    allow(Factorix::Container).to receive(:[]).with(:runtime).and_return(runtime)
+    allow(Factorix::Container).to receive(:[]).with(:logger).and_return(logger)
+    allow(Factorix::Container).to receive(:[]).with(:portal).and_return(portal)
 
-    allow(Factorix::Application).to receive(:load_config)
+    allow(Factorix::Container).to receive(:load_config)
 
     allow(Factorix::MODList).to receive(:load).and_return(mod_list)
     allow(mod_list).to receive(:save)
@@ -75,7 +75,7 @@ RSpec.describe Factorix::CLI::Commands::MOD::Install do
     allow(command).to receive(:load_current_state).and_return([graph, mod_list, []])
     allow(mod_dir).to receive_messages(exist?: true, "/": Pathname("/fake/path/mods/mod-a_1.0.0.zip"))
     allow(portal).to receive(:download_mod)
-    allow(Factorix::Application).to receive(:[]).with(:portal).and_return(portal)
+    allow(Factorix::Container).to receive(:[]).with(:portal).and_return(portal)
 
     downloader = instance_double(Factorix::Transfer::Downloader)
     allow(downloader).to receive(:subscribe)

--- a/spec/factorix/cli/commands/mod/list_spec.rb
+++ b/spec/factorix/cli/commands/mod/list_spec.rb
@@ -99,7 +99,7 @@ RSpec.describe Factorix::CLI::Commands::MOD::List do
   end
 
   before do
-    allow(Factorix::Application).to receive(:load_config)
+    allow(Factorix::Container).to receive(:load_config)
     allow(Factorix::MODList).to receive(:load).and_return(mod_list)
     allow(mod_list).to receive(:each_mod)
     presenter = instance_double(Factorix::Progress::Presenter, start: nil, update: nil, finish: nil)

--- a/spec/factorix/cli/commands/mod/search_spec.rb
+++ b/spec/factorix/cli/commands/mod/search_spec.rb
@@ -26,8 +26,8 @@ RSpec.describe Factorix::CLI::Commands::MOD::Search do
     base_dir.mkpath
     (base_dir / "info.json").write(JSON.generate(name: "base", version: "2.0.28", title: "Base", author: "Wube"))
 
-    allow(Factorix::Application).to receive(:[]).and_call_original
-    allow(Factorix::Application).to receive(:[]).with(:portal).and_return(portal)
+    allow(Factorix::Container).to receive(:[]).and_call_original
+    allow(Factorix::Container).to receive(:[]).with(:portal).and_return(portal)
   end
 
   after do

--- a/spec/factorix/cli/commands/mod/settings/restore_spec.rb
+++ b/spec/factorix/cli/commands/mod/settings/restore_spec.rb
@@ -40,8 +40,8 @@ RSpec.describe Factorix::CLI::Commands::MOD::Settings::Restore do
   end
 
   before do
-    allow(Factorix::Application).to receive(:[]).and_call_original
-    allow(Factorix::Application).to receive(:[]).with(:runtime).and_return(runtime)
+    allow(Factorix::Container).to receive(:[]).and_call_original
+    allow(Factorix::Container).to receive(:[]).with(:runtime).and_return(runtime)
     allow(settings).to receive(:save)
     allow(runtime).to receive(:mod_settings_path).and_return(Pathname("/default/mod-settings.dat"))
     allow(Factorix::MODSettings).to receive(:new).and_return(settings)

--- a/spec/factorix/cli/commands/mod/show_spec.rb
+++ b/spec/factorix/cli/commands/mod/show_spec.rb
@@ -47,9 +47,9 @@ RSpec.describe Factorix::CLI::Commands::MOD::Show do
   end
 
   before do
-    allow(Factorix::Application).to receive(:load_config)
-    allow(Factorix::Application).to receive(:[]).and_call_original
-    allow(Factorix::Application).to receive(:[]).with(:portal).and_return(portal)
+    allow(Factorix::Container).to receive(:load_config)
+    allow(Factorix::Container).to receive(:[]).and_call_original
+    allow(Factorix::Container).to receive(:[]).with(:portal).and_return(portal)
     allow(portal).to receive(:get_mod_full).with("test-mod").and_return(mod_info)
     allow(Factorix::InstalledMOD).to receive(:all).and_return([])
 

--- a/spec/factorix/cli/commands/mod/uninstall_spec.rb
+++ b/spec/factorix/cli/commands/mod/uninstall_spec.rb
@@ -36,13 +36,13 @@ RSpec.describe Factorix::CLI::Commands::MOD::Uninstall do
   end
 
   before do
-    allow(Factorix::Application).to receive(:[]).and_call_original
-    allow(Factorix::Application).to receive(:[]).with(:runtime).and_return(runtime)
-    allow(Factorix::Application).to receive(:[]).with(:logger).and_return(logger)
+    allow(Factorix::Container).to receive(:[]).and_call_original
+    allow(Factorix::Container).to receive(:[]).with(:runtime).and_return(runtime)
+    allow(Factorix::Container).to receive(:[]).with(:logger).and_return(logger)
 
     allow(runtime).to receive_messages(mod_list_path:, mod_dir:, data_dir:)
 
-    allow(Factorix::Application).to receive(:load_config)
+    allow(Factorix::Container).to receive(:load_config)
     allow(Factorix::MODList).to receive(:load).and_return(mod_list)
     allow(mod_list).to receive(:save)
     allow(mod_list).to receive(:remove)

--- a/spec/factorix/cli/commands/mod/update_spec.rb
+++ b/spec/factorix/cli/commands/mod/update_spec.rb
@@ -71,12 +71,12 @@ RSpec.describe Factorix::CLI::Commands::MOD::Update do
   end
 
   before do
-    allow(Factorix::Application).to receive(:[]).and_call_original
-    allow(Factorix::Application).to receive(:[]).with(:runtime).and_return(runtime)
-    allow(Factorix::Application).to receive(:[]).with(:logger).and_return(logger)
-    allow(Factorix::Application).to receive(:[]).with(:portal).and_return(portal)
+    allow(Factorix::Container).to receive(:[]).and_call_original
+    allow(Factorix::Container).to receive(:[]).with(:runtime).and_return(runtime)
+    allow(Factorix::Container).to receive(:[]).with(:logger).and_return(logger)
+    allow(Factorix::Container).to receive(:[]).with(:portal).and_return(portal)
 
-    allow(Factorix::Application).to receive(:load_config)
+    allow(Factorix::Container).to receive(:load_config)
 
     allow(Factorix::MODList).to receive(:load).and_return(mod_list)
     allow(mod_list).to receive_messages(save: nil, exist?: true, enabled?: true, remove: nil, add: nil)

--- a/spec/factorix/cli/commands/mod/upload_spec.rb
+++ b/spec/factorix/cli/commands/mod/upload_spec.rb
@@ -28,8 +28,8 @@ RSpec.describe Factorix::CLI::Commands::MOD::Upload do
       zipfile.get_output_stream("test-mod/info.json") {|f| f.write(info_json_content) }
     end
 
-    allow(Factorix::Application).to receive(:[]).and_call_original
-    allow(Factorix::Application).to receive(:[]).with(:portal).and_return(portal)
+    allow(Factorix::Container).to receive(:[]).and_call_original
+    allow(Factorix::Container).to receive(:[]).with(:portal).and_return(portal)
     allow(portal).to receive(:mod_management_api).and_return(mod_management_api)
     allow(mod_management_api).to receive(:uploader).and_return(uploader)
     allow(uploader).to receive(:subscribe)

--- a/spec/factorix/container_spec.rb
+++ b/spec/factorix/container_spec.rb
@@ -2,29 +2,29 @@
 
 require "tempfile"
 
-RSpec.describe Factorix::Application do
+RSpec.describe Factorix::Container do
   describe "container" do
     describe "[:runtime]" do
       it "resolves to a Runtime instance" do
-        runtime = Factorix::Application[:runtime]
+        runtime = Factorix::Container[:runtime]
         expect(runtime).to be_a(Factorix::Runtime::Base)
       end
     end
 
     describe "[:logger]" do
       it "resolves to a logger with standard logging interface" do
-        logger = Factorix::Application[:logger]
+        logger = Factorix::Container[:logger]
         expect(logger).to respond_to(:debug, :info, :warn, :error, :fatal)
       end
 
       it "creates log file in XDG_STATE_HOME" do
         skip "Logger is stubbed in spec_helper to prevent file creation during tests"
 
-        runtime = Factorix::Application[:runtime]
+        runtime = Factorix::Container[:runtime]
         log_path = runtime.factorix_log_path
 
         # Logger is created lazily, so resolve it
-        Factorix::Application[:logger]
+        Factorix::Container[:logger]
 
         # Log directory should be created
         expect(log_path.dirname).to exist
@@ -33,22 +33,22 @@ RSpec.describe Factorix::Application do
       it "uses log level from configuration" do
         skip "Difficult to change log level of registered logger and recreate it"
 
-        original_level = Factorix::Application.config.log_level
+        original_level = Factorix::Container.config.log_level
 
-        Factorix::Application.config.log_level = :debug
+        Factorix::Container.config.log_level = :debug
         # Force re-registration by calling resolve directly
-        logger = Factorix::Application.resolve(:logger)
+        logger = Factorix::Container.resolve(:logger)
         expect(logger.level).to eq(Logger::DEBUG)
 
-        Factorix::Application.config.log_level = :warn
-        logger = Factorix::Application.resolve(:logger)
+        Factorix::Container.config.log_level = :warn
+        logger = Factorix::Container.resolve(:logger)
         expect(logger.level).to eq(Logger::WARN)
 
-        Factorix::Application.config.log_level = original_level
+        Factorix::Container.config.log_level = original_level
       end
 
       it "formats messages with timestamp and severity" do
-        logger = Factorix::Application[:logger]
+        logger = Factorix::Container[:logger]
         logger.info("test message")
 
         expect(log_content).to match(/\[\d{4}-\d{2}-\d{2} \d{2}:\d{2}:\d{2} [+-]\d{4}\] INFO: test message/)
@@ -57,42 +57,42 @@ RSpec.describe Factorix::Application do
 
     describe "[:download_cache]" do
       it "resolves to a Cache::FileSystem instance" do
-        download_cache = Factorix::Application[:download_cache]
+        download_cache = Factorix::Container[:download_cache]
         expect(download_cache).to be_a(Factorix::Cache::FileSystem)
       end
     end
 
     describe "[:api_cache]" do
       it "resolves to a Cache::FileSystem instance" do
-        api_cache = Factorix::Application[:api_cache]
+        api_cache = Factorix::Container[:api_cache]
         expect(api_cache).to be_a(Factorix::Cache::FileSystem)
       end
     end
 
     describe "[:http_client]" do
       it "resolves to an HTTP::Client instance" do
-        http_client = Factorix::Application[:http_client]
+        http_client = Factorix::Container[:http_client]
         expect(http_client).to be_a(Factorix::HTTP::Client)
       end
     end
 
     describe "[:downloader]" do
       it "resolves to a Transfer::Downloader instance" do
-        downloader = Factorix::Application[:downloader]
+        downloader = Factorix::Container[:downloader]
         expect(downloader).to be_a(Factorix::Transfer::Downloader)
       end
     end
 
     describe "[:uploader]" do
       it "resolves to a Transfer::Uploader instance" do
-        uploader = Factorix::Application[:uploader]
+        uploader = Factorix::Container[:uploader]
         expect(uploader).to be_a(Factorix::Transfer::Uploader)
       end
     end
 
     describe "[:mod_portal_api]" do
       it "resolves to an API::MODPortalAPI instance" do
-        mod_portal_api = Factorix::Application[:mod_portal_api]
+        mod_portal_api = Factorix::Container[:mod_portal_api]
         expect(mod_portal_api).to be_a(Factorix::API::MODPortalAPI)
       end
     end
@@ -109,7 +109,7 @@ RSpec.describe Factorix::Application do
       end
 
       it "resolves to an API::MODDownloadAPI instance" do
-        mod_download_api = Factorix::Application[:mod_download_api]
+        mod_download_api = Factorix::Container[:mod_download_api]
         expect(mod_download_api).to be_a(Factorix::API::MODDownloadAPI)
       end
     end
@@ -126,35 +126,35 @@ RSpec.describe Factorix::Application do
       end
 
       it "resolves to a ServiceCredential instance" do
-        service_credential = Factorix::Application[:service_credential]
+        service_credential = Factorix::Container[:service_credential]
         expect(service_credential).to be_a(Factorix::ServiceCredential)
       end
     end
 
     describe "[:retry_strategy]" do
       it "resolves to an HTTP::RetryStrategy instance" do
-        retry_strategy = Factorix::Application[:retry_strategy]
+        retry_strategy = Factorix::Container[:retry_strategy]
         expect(retry_strategy).to be_a(Factorix::HTTP::RetryStrategy)
       end
     end
 
     describe "[:download_http_client]" do
       it "provides HTTP client interface" do
-        download_http_client = Factorix::Application[:download_http_client]
+        download_http_client = Factorix::Container[:download_http_client]
         expect(download_http_client).to respond_to(:request, :get, :post)
       end
     end
 
     describe "[:api_http_client]" do
       it "provides HTTP client interface" do
-        api_http_client = Factorix::Application[:api_http_client]
+        api_http_client = Factorix::Container[:api_http_client]
         expect(api_http_client).to respond_to(:request, :get, :post)
       end
     end
 
     describe "[:upload_http_client]" do
       it "provides HTTP client interface" do
-        upload_http_client = Factorix::Application[:upload_http_client]
+        upload_http_client = Factorix::Container[:upload_http_client]
         expect(upload_http_client).to respond_to(:request, :get, :post)
       end
     end
@@ -169,14 +169,14 @@ RSpec.describe Factorix::Application do
       end
 
       it "resolves to an APICredential instance" do
-        api_credential = Factorix::Application[:api_credential]
+        api_credential = Factorix::Container[:api_credential]
         expect(api_credential).to be_a(Factorix::APICredential)
       end
     end
 
     describe "[:mod_management_api]" do
       it "resolves to an API::MODManagementAPI instance" do
-        mod_management_api = Factorix::Application[:mod_management_api]
+        mod_management_api = Factorix::Container[:mod_management_api]
         expect(mod_management_api).to be_a(Factorix::API::MODManagementAPI)
       end
     end
@@ -193,7 +193,7 @@ RSpec.describe Factorix::Application do
       end
 
       it "resolves to a Portal instance" do
-        portal = Factorix::Application[:portal]
+        portal = Factorix::Container[:portal]
         expect(portal).to be_a(Factorix::Portal)
       end
     end
@@ -202,117 +202,117 @@ RSpec.describe Factorix::Application do
   describe "configuration" do
     after do
       # Reset configuration after each test
-      Factorix::Application.config.log_level = :info
-      Factorix::Application.config.http.connect_timeout = 5
-      Factorix::Application.config.http.read_timeout = 30
-      Factorix::Application.config.http.write_timeout = 30
+      Factorix::Container.config.log_level = :info
+      Factorix::Container.config.http.connect_timeout = 5
+      Factorix::Container.config.http.read_timeout = 30
+      Factorix::Container.config.http.write_timeout = 30
     end
 
     describe ".config" do
       it "provides access to configuration" do
-        expect(Factorix::Application.config).to respond_to(:log_level)
-        expect(Factorix::Application.config).to respond_to(:cache)
+        expect(Factorix::Container.config).to respond_to(:log_level)
+        expect(Factorix::Container.config).to respond_to(:cache)
       end
     end
 
     describe "cache.download" do
       it "defaults dir to runtime.factorix_cache_dir/download" do
-        runtime = Factorix::Application[:runtime]
-        expect(Factorix::Application.config.cache.download.dir).to eq(runtime.factorix_cache_dir / "download")
+        runtime = Factorix::Container[:runtime]
+        expect(Factorix::Container.config.cache.download.dir).to eq(runtime.factorix_cache_dir / "download")
       end
 
       it "has default ttl of nil" do
-        expect(Factorix::Application.config.cache.download.ttl).to be_nil
+        expect(Factorix::Container.config.cache.download.ttl).to be_nil
       end
 
       it "has default max_file_size of nil" do
-        expect(Factorix::Application.config.cache.download.max_file_size).to be_nil
+        expect(Factorix::Container.config.cache.download.max_file_size).to be_nil
       end
 
       it "can be overridden" do
         custom_path = Pathname("/custom/cache/download")
-        Factorix::Application.config.cache.download.dir = custom_path
-        expect(Factorix::Application.config.cache.download.dir).to eq(custom_path)
+        Factorix::Container.config.cache.download.dir = custom_path
+        expect(Factorix::Container.config.cache.download.dir).to eq(custom_path)
       end
     end
 
     describe "cache.api" do
       it "defaults dir to runtime.factorix_cache_dir/api" do
-        runtime = Factorix::Application[:runtime]
-        expect(Factorix::Application.config.cache.api.dir).to eq(runtime.factorix_cache_dir / "api")
+        runtime = Factorix::Container[:runtime]
+        expect(Factorix::Container.config.cache.api.dir).to eq(runtime.factorix_cache_dir / "api")
       end
 
       it "has default ttl of 3600 seconds" do
-        expect(Factorix::Application.config.cache.api.ttl).to eq(3600)
+        expect(Factorix::Container.config.cache.api.ttl).to eq(3600)
       end
 
       it "has default max_file_size of 10MiB" do
-        expect(Factorix::Application.config.cache.api.max_file_size).to eq(10 * 1024 * 1024)
+        expect(Factorix::Container.config.cache.api.max_file_size).to eq(10 * 1024 * 1024)
       end
     end
 
     describe "log_level" do
       it "defaults to :info" do
-        expect(Factorix::Application.config.log_level).to eq(:info)
+        expect(Factorix::Container.config.log_level).to eq(:info)
       end
 
       it "can be changed" do
-        Factorix::Application.config.log_level = :debug
-        expect(Factorix::Application.config.log_level).to eq(:debug)
+        Factorix::Container.config.log_level = :debug
+        expect(Factorix::Container.config.log_level).to eq(:debug)
       end
     end
 
     describe "http timeouts" do
       it "has default connect_timeout" do
-        expect(Factorix::Application.config.http.connect_timeout).to eq(5)
+        expect(Factorix::Container.config.http.connect_timeout).to eq(5)
       end
 
       it "has default read_timeout" do
-        expect(Factorix::Application.config.http.read_timeout).to eq(30)
+        expect(Factorix::Container.config.http.read_timeout).to eq(30)
       end
 
       it "has default write_timeout" do
-        expect(Factorix::Application.config.http.write_timeout).to eq(30)
+        expect(Factorix::Container.config.http.write_timeout).to eq(30)
       end
 
       it "can be changed" do
-        Factorix::Application.config.http.connect_timeout = 10
-        expect(Factorix::Application.config.http.connect_timeout).to eq(10)
+        Factorix::Container.config.http.connect_timeout = 10
+        expect(Factorix::Container.config.http.connect_timeout).to eq(10)
       end
     end
 
     describe ".configure block" do
       it "allows configuration via block" do
-        Factorix::Application.configure do |config|
+        Factorix::Container.configure do |config|
           config.log_level = :warn
           config.http.connect_timeout = 15
         end
 
-        expect(Factorix::Application.config.log_level).to eq(:warn)
-        expect(Factorix::Application.config.http.connect_timeout).to eq(15)
+        expect(Factorix::Container.config.log_level).to eq(:warn)
+        expect(Factorix::Container.config.http.connect_timeout).to eq(15)
       end
     end
 
     describe "runtime settings" do
       after do
-        Factorix::Application.config.runtime.executable_path = nil
-        Factorix::Application.config.runtime.user_dir = nil
-        Factorix::Application.config.runtime.data_dir = nil
+        Factorix::Container.config.runtime.executable_path = nil
+        Factorix::Container.config.runtime.user_dir = nil
+        Factorix::Container.config.runtime.data_dir = nil
       end
 
       it "converts executable_path string to Pathname" do
-        Factorix::Application.config.runtime.executable_path = "/path/to/factorio"
-        expect(Factorix::Application.config.runtime.executable_path).to eq(Pathname("/path/to/factorio"))
+        Factorix::Container.config.runtime.executable_path = "/path/to/factorio"
+        expect(Factorix::Container.config.runtime.executable_path).to eq(Pathname("/path/to/factorio"))
       end
 
       it "converts user_dir string to Pathname" do
-        Factorix::Application.config.runtime.user_dir = "/path/to/user"
-        expect(Factorix::Application.config.runtime.user_dir).to eq(Pathname("/path/to/user"))
+        Factorix::Container.config.runtime.user_dir = "/path/to/user"
+        expect(Factorix::Container.config.runtime.user_dir).to eq(Pathname("/path/to/user"))
       end
 
       it "converts data_dir string to Pathname" do
-        Factorix::Application.config.runtime.data_dir = "/path/to/data"
-        expect(Factorix::Application.config.runtime.data_dir).to eq(Pathname("/path/to/data"))
+        Factorix::Container.config.runtime.data_dir = "/path/to/data"
+        expect(Factorix::Container.config.runtime.data_dir).to eq(Pathname("/path/to/data"))
       end
     end
   end
@@ -337,22 +337,22 @@ RSpec.describe Factorix::Application do
 
       after do
         config_file.unlink
-        Factorix::Application.config.log_level = :info
-        Factorix::Application.config.http.connect_timeout = 5
+        Factorix::Container.config.log_level = :info
+        Factorix::Container.config.http.connect_timeout = 5
       end
 
       it "loads configuration from file" do
-        Factorix::Application.load_config(config_file.path)
+        Factorix::Container.load_config(config_file.path)
 
-        expect(Factorix::Application.config.log_level).to eq(:debug)
-        expect(Factorix::Application.config.http.connect_timeout).to eq(20)
+        expect(Factorix::Container.config.log_level).to eq(:debug)
+        expect(Factorix::Container.config.http.connect_timeout).to eq(20)
       end
     end
 
     context "when explicitly specified config file does not exist" do
       it "raises Errno::ENOENT" do
         expect {
-          Factorix::Application.load_config("/nonexistent/config.rb")
+          Factorix::Container.load_config("/nonexistent/config.rb")
         }.to raise_error(Factorix::ConfigurationError, /nonexistent/)
       end
     end
@@ -361,7 +361,7 @@ RSpec.describe Factorix::Application do
       it "tries to load from default path" do
         # Default path likely doesn't exist in test environment
         expect {
-          Factorix::Application.load_config(nil)
+          Factorix::Container.load_config(nil)
         }.not_to raise_error
       end
     end

--- a/spec/factorix/http/client_spec.rb
+++ b/spec/factorix/http/client_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Factorix::HTTP::Client do
 
   before do
     # Configure stub application config
-    allow(Factorix::Application.config.http).to receive_messages(
+    allow(Factorix::Container.config.http).to receive_messages(
       connect_timeout: 10,
       read_timeout: 30,
       write_timeout: 30

--- a/spec/factorix/installed_mod_spec.rb
+++ b/spec/factorix/installed_mod_spec.rb
@@ -16,8 +16,8 @@ RSpec.describe Factorix::InstalledMOD do
   let(:data_dir) { Pathname(Dir.mktmpdir) }
 
   before do
-    allow(Factorix::Application).to receive(:[]).and_call_original
-    allow(Factorix::Application).to receive(:[]).with(:runtime).and_return(runtime)
+    allow(Factorix::Container).to receive(:[]).and_call_original
+    allow(Factorix::Container).to receive(:[]).with(:runtime).and_return(runtime)
     allow(runtime).to receive_messages(mod_dir: temp_dir, data_dir:)
   end
 

--- a/spec/factorix/runtime/linux_spec.rb
+++ b/spec/factorix/runtime/linux_spec.rb
@@ -5,8 +5,8 @@ RSpec.describe Factorix::Runtime::Linux do
   let(:logger) { instance_double(Dry::Logger::Dispatcher) }
 
   before do
-    allow(Factorix::Application).to receive(:[]).with(:logger).and_return(logger)
-    allow(Factorix::Application).to receive(:[]).with(:runtime).and_return(runtime)
+    allow(Factorix::Container).to receive(:[]).with(:logger).and_return(logger)
+    allow(Factorix::Container).to receive(:[]).with(:runtime).and_return(runtime)
     allow(logger).to receive(:debug)
     allow(logger).to receive(:error)
   end

--- a/spec/factorix/runtime/user_configurable_spec.rb
+++ b/spec/factorix/runtime/user_configurable_spec.rb
@@ -23,11 +23,11 @@ RSpec.describe Factorix::Runtime::UserConfigurable do
 
   let(:runtime) { test_runtime_class.new }
   let(:logger) { instance_double(Dry::Logger::Dispatcher) }
-  let(:config) { Factorix::Application.config }
+  let(:config) { Factorix::Container.config }
 
   before do
     # Inject logger into runtime
-    allow(Factorix::Application).to receive(:[]).with(:logger).and_return(logger)
+    allow(Factorix::Container).to receive(:[]).with(:logger).and_return(logger)
     allow(logger).to receive(:debug)
     allow(logger).to receive(:error)
 
@@ -88,13 +88,13 @@ RSpec.describe Factorix::Runtime::UserConfigurable do
 
       before do
         # Mock runtime to avoid chicken-and-egg problem with factorix_config_path
-        allow(Factorix::Application).to receive(:[]).with(:runtime).and_return(
+        allow(Factorix::Container).to receive(:[]).with(:runtime).and_return(
           instance_double(
             Factorix::Runtime::Base,
             factorix_config_path: Pathname("/home/user/.config/factorix/config.rb")
           )
         )
-        allow(Factorix::Application).to receive(:[]).with(:logger).and_return(logger)
+        allow(Factorix::Container).to receive(:[]).with(:logger).and_return(logger)
       end
 
       it "raises ConfigurationError with helpful message" do
@@ -120,7 +120,7 @@ RSpec.describe Factorix::Runtime::UserConfigurable do
       it "includes configuration instructions in error message" do
         expect { runtime.executable_path }.to raise_error(
           Factorix::ConfigurationError,
-          /Factorix::Application\.configure/
+          /Factorix::Container\.configure/
         )
       end
     end
@@ -176,13 +176,13 @@ RSpec.describe Factorix::Runtime::UserConfigurable do
 
       before do
         # Mock runtime to avoid chicken-and-egg problem with factorix_config_path
-        allow(Factorix::Application).to receive(:[]).with(:runtime).and_return(
+        allow(Factorix::Container).to receive(:[]).with(:runtime).and_return(
           instance_double(
             Factorix::Runtime::Base,
             factorix_config_path: Pathname("/home/user/.config/factorix/config.rb")
           )
         )
-        allow(Factorix::Application).to receive(:[]).with(:logger).and_return(logger)
+        allow(Factorix::Container).to receive(:[]).with(:logger).and_return(logger)
       end
 
       it "raises ConfigurationError with helpful message" do
@@ -208,7 +208,7 @@ RSpec.describe Factorix::Runtime::UserConfigurable do
       it "includes configuration instructions in error message" do
         expect { runtime.user_dir }.to raise_error(
           Factorix::ConfigurationError,
-          /Factorix::Application\.configure/
+          /Factorix::Container\.configure/
         )
       end
     end
@@ -264,13 +264,13 @@ RSpec.describe Factorix::Runtime::UserConfigurable do
 
       before do
         # Mock runtime to avoid chicken-and-egg problem with factorix_config_path
-        allow(Factorix::Application).to receive(:[]).with(:runtime).and_return(
+        allow(Factorix::Container).to receive(:[]).with(:runtime).and_return(
           instance_double(
             Factorix::Runtime::Base,
             factorix_config_path: Pathname("/home/user/.config/factorix/config.rb")
           )
         )
-        allow(Factorix::Application).to receive(:[]).with(:logger).and_return(logger)
+        allow(Factorix::Container).to receive(:[]).with(:logger).and_return(logger)
       end
 
       it "raises ConfigurationError with helpful message" do
@@ -296,7 +296,7 @@ RSpec.describe Factorix::Runtime::UserConfigurable do
       it "includes configuration instructions in error message" do
         expect { runtime.data_dir }.to raise_error(
           Factorix::ConfigurationError,
-          /Factorix::Application\.configure/
+          /Factorix::Container\.configure/
         )
       end
     end

--- a/spec/factorix/service_credential_spec.rb
+++ b/spec/factorix/service_credential_spec.rb
@@ -8,8 +8,8 @@ RSpec.describe Factorix::ServiceCredential do
     let(:player_data_path) { instance_double(Pathname) }
 
     before do
-      allow(Factorix::Application).to receive(:[]).with(:runtime).and_return(runtime)
-      allow(Factorix::Application).to receive(:[]).with("logger").and_call_original
+      allow(Factorix::Container).to receive(:[]).with(:runtime).and_return(runtime)
+      allow(Factorix::Container).to receive(:[]).with("logger").and_call_original
     end
 
     context "when both environment variables are set" do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -19,8 +19,8 @@ WebMock.disable_net_connect!
 
 # Enable test interfaces for dry-core container and dry-configurable
 # before loading support files that may use stub
-Factorix::Application.enable_stubs!
-Factorix::Application.enable_test_interface
+Factorix::Container.enable_stubs!
+Factorix::Container.enable_test_interface
 
 # Load support files
 Dir[File.join(__dir__, "support", "**", "*.rb")].each {|f| require f }
@@ -50,13 +50,13 @@ RSpec.configure do |config|
 
     # Stub runtime with new XDG directories
     new_runtime = Factorix::Runtime.detect
-    Factorix::Application.stub(:runtime, new_runtime)
+    Factorix::Container.stub(:runtime, new_runtime)
 
     # Reset configuration to defaults and reconfigure with new runtime
-    Factorix::Application.reset_config
-    Factorix::Application.config.cache.download.dir = new_runtime.factorix_cache_dir / "download"
-    Factorix::Application.config.cache.api.dir = new_runtime.factorix_cache_dir / "api"
-    Factorix::Application.config.cache.info_json.dir = new_runtime.factorix_cache_dir / "info_json"
+    Factorix::Container.reset_config
+    Factorix::Container.config.cache.download.dir = new_runtime.factorix_cache_dir / "download"
+    Factorix::Container.config.cache.api.dir = new_runtime.factorix_cache_dir / "api"
+    Factorix::Container.config.cache.info_json.dir = new_runtime.factorix_cache_dir / "info_json"
   end
 
   config.after(:suite) do

--- a/spec/support/test_logger.rb
+++ b/spec/support/test_logger.rb
@@ -25,7 +25,7 @@ RSpec.configure do |config|
 
   config.before(:suite) do
     config.log_stream = StringIO.new
-    Factorix::Application.stub(:logger, Dry.Logger(:test, stream: config.log_stream, template: "[%<time>s] %<severity>s: %<message>s %<payload>s"))
+    Factorix::Container.stub(:logger, Dry.Logger(:test, stream: config.log_stream, template: "[%<time>s] %<severity>s: %<message>s %<payload>s"))
   end
 
   config.include_context "with testing log stream"


### PR DESCRIPTION
## Summary

Rename `Factorix::Application` to `Factorix::Container` to improve library usability when embedded in host applications.

## Changes

- Rename class from `Application` to `Container`
- Rename files: `application.rb` → `container.rb` (lib, spec, sig, doc)
- Update all references throughout codebase and documentation

## Rationale

- Avoid naming conflicts with host application's `Application` class
- Better reflect its role as a DI container
- Align with dry-container naming conventions

Closes #7
