### PR TITLE
:recycle: Move configuration interface to Factorix module

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -70,6 +70,7 @@ Style/IpAddresses:
 Style/StaticClass:
   Exclude:
     - lib/factorix/info_json.rb
+    - lib/factorix.rb # Deprecated Application class for backward compatibility
 
 ThreadSafety/NewThread:
   Exclude:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -2,11 +2,16 @@
 
 ### Changed
 
-- Rename `Factorix::Application` to `Factorix::Container` to avoid naming conflicts when used as a library (#7)
+- Reorganize configuration and DI container interfaces (#7, #9)
+  - `Factorix::Application` renamed to `Factorix::Container` (DI container only)
+  - Configuration interface (`config`, `configure`, `load_config`) moved to `Factorix` module
+  - Use `Factorix.configure { |c| ... }` instead of `Factorix::Container.configure { |c| ... }`
 
 ### Deprecated
 
-- `Factorix::Application` still works but emits a deprecation warning; will be removed in v1.0
+- `Factorix::Application` still works but emits deprecation warnings; will be removed in v1.0
+  - DI methods (`[]`, `resolve`, `register`) delegate to `Factorix::Container`
+  - Configuration methods (`config`, `configure`) delegate to `Factorix`
 
 ## [0.5.1] - 2026-01-13
 

--- a/README.md
+++ b/README.md
@@ -65,7 +65,7 @@ $EDITOR ~/.config/factorix/config.rb
 
 **Example configuration:**
 ```ruby
-Factorix::Container.configure do |config|
+Factorix.configure do |config|
   config.runtime.executable_path = "/Applications/Factorio.app/Contents/MacOS/factorio"
   config.runtime.user_dir = "#{Dir.home}/Library/Application Support/factorio"
   config.runtime.data_dir = "/Applications/Factorio.app/Contents/data"

--- a/doc/components/container.md
+++ b/doc/components/container.md
@@ -68,7 +68,7 @@ Configuration file is resolved in the following order:
 ### Configuration File Format (Ruby DSL)
 
 ```ruby
-Factorix::Container.configure do |config|
+Factorix.configure do |config|
   config.cache_dir = "/custom/cache/path"
   config.log_level = :debug
   config.http.open_timeout = 120

--- a/doc/components/http.md
+++ b/doc/components/http.md
@@ -44,7 +44,7 @@ Core HTTP client using `Net::HTTP`.
 
 **Constraints**:
 - HTTPS only (raises `URLError` for non-HTTPS)
-- Timeouts configured via `Container.config.http`
+- Timeouts configured via `Factorix.config.http`
 
 ### Response
 
@@ -133,7 +133,7 @@ graph TD
 
 ## Configuration
 
-Timeouts are configured via `Container.config.http`:
+Timeouts are configured via `Factorix.config.http`:
 
 - `connect_timeout` - Connection timeout (seconds)
 - `read_timeout` - Read timeout (seconds)

--- a/doc/components/runtime.md
+++ b/doc/components/runtime.md
@@ -74,7 +74,7 @@ The `UserConfigurable` module is prepended to `Runtime::Base` and all its subcla
 Users can explicitly configure paths in `~/.config/factorix/config.rb` (or `$XDG_CONFIG_HOME/factorix/config.rb`):
 
 ```ruby
-Factorix::Container.configure do |config|
+Factorix.configure do |config|
   config.runtime.executable_path = "/path/to/factorio"
   config.runtime.user_dir = "/path/to/factorio/user/dir"
   config.runtime.data_dir = "/path/to/factorio/data"

--- a/example/config.rb
+++ b/example/config.rb
@@ -8,7 +8,7 @@
 # Copy this file to: ~/.config/factorix/config.rb
 # Or specify with: factorix --config-path /path/to/config.rb
 
-Factorix::Container.configure do |config|
+Factorix.configure do |config|
   # ============================================================================
   # Runtime Configuration
   # ============================================================================

--- a/lib/factorix.rb
+++ b/lib/factorix.rb
@@ -1,13 +1,86 @@
 # frozen_string_literal: true
 
 require "dry/auto_inject"
+require "dry/configurable"
 require "zeitwerk"
 require_relative "factorix/errors"
 require_relative "factorix/version"
 
 # Factorix provides a CLI for Factorio MOD management, settings synchronization,
 # and MOD Portal integration.
+#
+# @example Configure Factorix
+#   Factorix.configure do |config|
+#     config.log_level = :debug
+#     config.http.connect_timeout = 10
+#   end
 module Factorix
+  extend Dry::Configurable
+
+  # Log level (:debug, :info, :warn, :error, :fatal)
+  setting :log_level, default: :info
+
+  # Runtime settings (optional overrides for auto-detection)
+  setting :runtime do
+    setting :executable_path, constructor: ->(v) { v ? Pathname(v) : nil }
+    setting :user_dir, constructor: ->(v) { v ? Pathname(v) : nil }
+    setting :data_dir, constructor: ->(v) { v ? Pathname(v) : nil }
+  end
+
+  # HTTP timeout settings
+  setting :http do
+    setting :connect_timeout, default: 5
+    setting :read_timeout, default: 30
+    setting :write_timeout, default: 30
+  end
+
+  # Cache settings
+  setting :cache do
+    # Download cache settings (for MOD files)
+    setting :download do
+      setting :dir, constructor: ->(value) { Pathname(value) }
+      setting :ttl, default: nil # nil for unlimited (MOD files are immutable)
+      setting :max_file_size, default: nil # nil for unlimited
+      setting :compression_threshold, default: nil # nil for no compression (binary files)
+    end
+
+    # API cache settings (for API responses)
+    setting :api do
+      setting :dir, constructor: ->(value) { Pathname(value) }
+      setting :ttl, default: 3600 # 1 hour (API responses may change)
+      setting :max_file_size, default: 10 * 1024 * 1024 # 10MiB (JSON responses)
+      setting :compression_threshold, default: 0 # always compress (JSON is highly compressible)
+    end
+
+    # info.json cache settings (for MOD metadata from ZIP files)
+    setting :info_json do
+      setting :dir, constructor: ->(value) { Pathname(value) }
+      setting :ttl, default: nil # nil for unlimited (info.json is immutable within a MOD ZIP)
+      setting :max_file_size, default: nil # nil for unlimited (info.json is small)
+      setting :compression_threshold, default: 0 # always compress (JSON is highly compressible)
+    end
+  end
+
+  # Load configuration from file
+  #
+  # @param path [Pathname, nil] configuration file path
+  # @return [void]
+  # @raise [ConfigurationError] if explicitly specified path does not exist
+  def self.load_config(path=nil)
+    if path
+      # Explicitly specified path must exist
+      raise ConfigurationError, "Configuration file not found: #{path}" unless path.exist?
+
+      config_path = path
+    else
+      # Default path is optional
+      config_path = Container.resolve(:runtime).factorix_config_path
+      return unless config_path.exist?
+    end
+
+    instance_eval(config_path.read, config_path.to_s)
+  end
+
   loader = Zeitwerk::Loader.for_gem
   loader.ignore("#{__dir__}/factorix/version.rb")
   loader.ignore("#{__dir__}/factorix/errors.rb")
@@ -36,13 +109,47 @@ module Factorix
   Import = Dry::AutoInject(Container)
   public_constant :Import
 
-  # @deprecated Use {Container} instead of Application. Will be removed in v1.0.
-  def self.const_missing(name)
-    if name == :Application
-      warn "[factorix] Factorix::Application is deprecated, use Factorix::Container instead"
-      Container
-    else
-      super
+  # Initialize cache directory defaults after Container is loaded
+  runtime = Container.resolve(:runtime)
+  config.cache.download.dir = runtime.factorix_cache_dir / "download"
+  config.cache.api.dir = runtime.factorix_cache_dir / "api"
+  config.cache.info_json.dir = runtime.factorix_cache_dir / "info_json"
+
+  # @deprecated Use {Container} for DI and {Factorix} for configuration. Will be removed in v1.0.
+  class Application
+    # @!method [](key)
+    #   @deprecated Use {Container.[]} instead
+    def self.[](key)
+      warn "[factorix] Factorix::Application is deprecated, use Factorix::Container for DI"
+      Container[key]
+    end
+
+    # @!method resolve(key)
+    #   @deprecated Use {Container.resolve} instead
+    def self.resolve(key)
+      warn "[factorix] Factorix::Application is deprecated, use Factorix::Container for DI"
+      Container.resolve(key)
+    end
+
+    # @!method register(...)
+    #   @deprecated Use {Container.register} instead
+    def self.register(...)
+      warn "[factorix] Factorix::Application is deprecated, use Factorix::Container for DI"
+      Container.register(...)
+    end
+
+    # @!method config
+    #   @deprecated Use {Factorix.config} instead
+    def self.config
+      warn "[factorix] Factorix::Application is deprecated, use Factorix.config for configuration"
+      Factorix.config
+    end
+
+    # @!method configure(&block)
+    #   @deprecated Use {Factorix.configure} instead
+    def self.configure(&)
+      warn "[factorix] Factorix::Application is deprecated, use Factorix.configure for configuration"
+      Factorix.configure(&)
     end
   end
 end

--- a/lib/factorix/cli/commands/cache/evict.rb
+++ b/lib/factorix/cli/commands/cache/evict.rb
@@ -95,7 +95,7 @@ module Factorix
           # @return [Array<Symbol>] resolved cache names
           # @raise [InvalidArgumentError] if unknown cache name specified
           private def resolve_cache_names(caches)
-            all_caches = Container.config.cache.values.keys
+            all_caches = Factorix.config.cache.values.keys
 
             return all_caches if caches.nil? || caches.empty?
 
@@ -114,7 +114,7 @@ module Factorix
           # @param expired [Boolean] remove expired entries only
           # @return [Hash] eviction result with :count and :size
           private def evict_cache(name, all:, expired:)
-            config = Container.config.cache.public_send(name)
+            config = Factorix.config.cache.public_send(name)
             cache_dir = config.dir
             ttl = config.ttl
 

--- a/lib/factorix/cli/commands/cache/stat.rb
+++ b/lib/factorix/cli/commands/cache/stat.rb
@@ -42,7 +42,7 @@ module Factorix
             logger.debug("Collecting cache statistics")
 
             @now = Time.now
-            cache_names = Container.config.cache.values.keys
+            cache_names = Factorix.config.cache.values.keys
             stats = cache_names.to_h {|name| [name, collect_stats(name)] }
 
             if json
@@ -53,7 +53,7 @@ module Factorix
           end
 
           private def collect_stats(name)
-            config = Container.config.cache.public_send(name)
+            config = Factorix.config.cache.public_send(name)
             cache_dir = config.dir
 
             entries = scan_entries(cache_dir, config.ttl)

--- a/lib/factorix/cli/commands/command_wrapper.rb
+++ b/lib/factorix/cli/commands/command_wrapper.rb
@@ -40,7 +40,7 @@ module Factorix
           path = resolve_config_path(explicit_path)
           return unless path
 
-          Container.load_config(path)
+          Factorix.load_config(path)
         end
 
         # Resolves which config path to use

--- a/lib/factorix/container.rb
+++ b/lib/factorix/container.rb
@@ -1,26 +1,17 @@
 # frozen_string_literal: true
 
-require "dry/configurable"
 require "dry/core"
 require "dry/logger"
 
 module Factorix
-  # DI container and configuration
+  # DI container for dependency injection
   #
-  # Provides dependency injection container and configuration management
-  # using dry-core's Container and dry-configurable.
-  #
-  # @example Configure the container
-  #   Factorix::Container.configure do |config|
-  #     config.log_level = :debug
-  #     config.http.connect_timeout = 10
-  #   end
+  # Provides dependency injection container using dry-core's Container.
   #
   # @example Resolve dependencies
   #   runtime = Factorix::Container[:runtime]
   class Container
     extend Dry::Core::Container::Mixin
-    extend Dry::Configurable
 
     # Some items are registered with memoize: false to support independent event handlers
     # for each parallel download task (e.g., progress tracking).
@@ -46,7 +37,7 @@ module Factorix
       # Dispatcher level set to DEBUG to allow all messages through
       # Backend controls filtering based on --log-level option
       Dry.Logger(:factorix, level: :debug) do |dispatcher|
-        dispatcher.add_backend(level: config.log_level, stream: log_path.to_s, template: "[%<time>s] %<severity>s: %<message>s %<payload>s")
+        dispatcher.add_backend(level: Factorix.config.log_level, stream: log_path.to_s, template: "[%<time>s] %<severity>s: %<message>s %<payload>s")
       end
     end
 
@@ -57,19 +48,19 @@ module Factorix
 
     # Register download cache
     register(:download_cache, memoize: true) do
-      c = config.cache.download
+      c = Factorix.config.cache.download
       Cache::FileSystem.new(c.dir, **c.to_h.except(:dir))
     end
 
     # Register API cache (with compression for JSON responses)
     register(:api_cache, memoize: true) do
-      c = config.cache.api
+      c = Factorix.config.cache.api
       Cache::FileSystem.new(c.dir, **c.to_h.except(:dir))
     end
 
     # Register info.json cache (for MOD metadata from ZIP files)
     register(:info_json_cache, memoize: true) do
-      c = config.cache.info_json
+      c = Factorix.config.cache.info_json
       Cache::FileSystem.new(c.dir, **c.to_h.except(:dir))
     end
 
@@ -146,73 +137,5 @@ module Factorix
     register(:portal, memoize: false) do
       Portal.new
     end
-
-    # Log level (:debug, :info, :warn, :error, :fatal)
-    setting :log_level, default: :info
-
-    # Runtime settings (optional overrides for auto-detection)
-    setting :runtime do
-      setting :executable_path, constructor: ->(v) { v ? Pathname(v) : nil }
-      setting :user_dir, constructor: ->(v) { v ? Pathname(v) : nil }
-      setting :data_dir, constructor: ->(v) { v ? Pathname(v) : nil }
-    end
-
-    # HTTP timeout settings
-    setting :http do
-      setting :connect_timeout, default: 5
-      setting :read_timeout, default: 30
-      setting :write_timeout, default: 30
-    end
-
-    # Cache settings
-    setting :cache do
-      # Download cache settings (for MOD files)
-      setting :download do
-        setting :dir, constructor: ->(value) { Pathname(value) }
-        setting :ttl, default: nil # nil for unlimited (MOD files are immutable)
-        setting :max_file_size, default: nil # nil for unlimited
-        setting :compression_threshold, default: nil # nil for no compression (binary files)
-      end
-
-      # API cache settings (for API responses)
-      setting :api do
-        setting :dir, constructor: ->(value) { Pathname(value) }
-        setting :ttl, default: 3600 # 1 hour (API responses may change)
-        setting :max_file_size, default: 10 * 1024 * 1024 # 10MiB (JSON responses)
-        setting :compression_threshold, default: 0 # always compress (JSON is highly compressible)
-      end
-
-      # info.json cache settings (for MOD metadata from ZIP files)
-      setting :info_json do
-        setting :dir, constructor: ->(value) { Pathname(value) }
-        setting :ttl, default: nil # nil for unlimited (info.json is immutable within a MOD ZIP)
-        setting :max_file_size, default: nil # nil for unlimited (info.json is small)
-        setting :compression_threshold, default: 0 # always compress (JSON is highly compressible)
-      end
-    end
-
-    # Load configuration from file
-    #
-    # @param path [Pathname, String, nil] configuration file path
-    # @return [void]
-    # @raise [ConfigurationError] if explicitly specified path does not exist
-    def self.load_config(path=nil)
-      if path
-        # Explicitly specified path must exist
-        config_path = Pathname(path)
-        raise ConfigurationError, "Configuration file not found: #{config_path}" unless config_path.exist?
-      else
-        # Default path is optional
-        config_path = resolve(:runtime).factorix_config_path
-        return unless config_path.exist?
-      end
-
-      instance_eval(config_path.read, config_path.to_s)
-    end
-
-    runtime = resolve(:runtime)
-    config.cache.download.dir = runtime.factorix_cache_dir / "download"
-    config.cache.api.dir = runtime.factorix_cache_dir / "api"
-    config.cache.info_json.dir = runtime.factorix_cache_dir / "info_json"
   end
 end

--- a/lib/factorix/http/client.rb
+++ b/lib/factorix/http/client.rb
@@ -162,9 +162,9 @@ module Factorix
         Net::HTTP.new(uri.host, uri.port).tap do |http|
           http.use_ssl = uri.scheme == "https"
           http.verify_mode = OpenSSL::SSL::VERIFY_PEER
-          http.open_timeout = Container.config.http.connect_timeout
-          http.read_timeout = Container.config.http.read_timeout
-          http.write_timeout = Container.config.http.write_timeout if http.respond_to?(:write_timeout=)
+          http.open_timeout = Factorix.config.http.connect_timeout
+          http.read_timeout = Factorix.config.http.read_timeout
+          http.write_timeout = Factorix.config.http.write_timeout if http.respond_to?(:write_timeout=)
         end
       end
 

--- a/lib/factorix/runtime/user_configurable.rb
+++ b/lib/factorix/runtime/user_configurable.rb
@@ -8,10 +8,10 @@ module Factorix
     # auto-detected paths via configuration. When a configured path is available,
     # it is used instead of platform-specific auto-detection.
     #
-    # Configuration is done via Container.config:
+    # Configuration is done via Factorix.config:
     #
     # @example Configure paths in config file
-    #   Factorix::Container.configure do |config|
+    #   Factorix.configure do |config|
     #     config.runtime.executable_path = "/opt/factorio/bin/x64/factorio"
     #     config.runtime.user_dir = "/home/user/.factorio"
     #   end
@@ -46,7 +46,7 @@ module Factorix
       def data_dir = configurable_path(:data_dir, example_path: "/path/to/factorio/data") { super }
 
       private def configurable_path(name, example_path:)
-        if (configured = Container.config.runtime.public_send(name))
+        if (configured = Factorix.config.runtime.public_send(name))
           Container[:logger].debug("Using configured #{name}", path: configured.to_s)
           configured
         else
@@ -59,7 +59,7 @@ module Factorix
           #{name} not configured and auto-detection is not supported for this platform.
           Please configure it in #{Container[:runtime].factorix_config_path}:
 
-            Factorix::Container.configure do |config|
+            Factorix.configure do |config|
               config.runtime.#{name} = "#{example_path}"
             end
         MESSAGE

--- a/sig/factorix.rbs
+++ b/sig/factorix.rbs
@@ -6,4 +6,103 @@ module Factorix
   VERSION: String
 
   Import: Dry::AutoInject::_Builder
+
+  extend Dry::Configurable
+
+  def self.config: () -> Config
+
+  def self.configure: () { (Config) -> void } -> void
+
+  def self.load_config: (?Pathname? path) -> void
+
+  class Config
+    def log_level: () -> Symbol
+
+    def log_level=: (Symbol) -> void
+
+    def credential: () -> CredentialConfig
+
+    def runtime: () -> RuntimeConfig
+
+    def http: () -> HttpConfig
+
+    def cache: () -> CacheConfig
+  end
+
+  class CredentialConfig
+    def source: () -> Symbol
+
+    def source=: (Symbol) -> void
+  end
+
+  class RuntimeConfig
+    def executable_path: () -> Pathname?
+
+    def executable_path=: (Pathname | String | nil) -> void
+
+    def user_dir: () -> Pathname?
+
+    def user_dir=: (Pathname | String | nil) -> void
+
+    def data_dir: () -> Pathname?
+
+    def data_dir=: (Pathname | String | nil) -> void
+  end
+
+  class HttpConfig
+    def connect_timeout: () -> Integer
+
+    def connect_timeout=: (Integer) -> void
+
+    def read_timeout: () -> Integer
+
+    def read_timeout=: (Integer) -> void
+
+    def write_timeout: () -> Integer
+
+    def write_timeout=: (Integer) -> void
+  end
+
+  class CacheConfig
+    def download: () -> CacheInstanceConfig
+
+    def api: () -> CacheInstanceConfig
+
+    def info_json: () -> CacheInstanceConfig
+
+    def values: () -> Hash[Symbol, CacheInstanceConfig]
+  end
+
+  class CacheInstanceConfig
+    def dir: () -> Pathname
+
+    def dir=: (Pathname | String) -> void
+
+    def ttl: () -> Integer?
+
+    def ttl=: (Integer?) -> void
+
+    def max_file_size: () -> Integer?
+
+    def max_file_size=: (Integer?) -> void
+
+    def compression_threshold: () -> Integer?
+
+    def compression_threshold=: (Integer?) -> void
+
+    def to_h: () -> Hash[Symbol, untyped]
+  end
+
+  # @deprecated Use Container for DI and Factorix for configuration
+  class Application
+    def self.[]: (Symbol) -> untyped
+
+    def self.resolve: (Symbol) -> untyped
+
+    def self.register: (Symbol, ?memoize: bool) { () -> untyped } -> void
+
+    def self.config: () -> Config
+
+    def self.configure: () { (Config) -> void } -> void
+  end
 end

--- a/sig/factorix/container.rbs
+++ b/sig/factorix/container.rbs
@@ -5,82 +5,11 @@
 module Factorix
   class Container
     extend Dry::Core::Container::Mixin
-    extend Dry::Configurable
 
     def self.register: (Symbol, ?memoize: bool) { () -> untyped } -> void
 
     def self.resolve: (Symbol) -> untyped
 
     def self.[]: (Symbol) -> untyped
-
-    def self.config: () -> Config
-
-    def self.configure: () { (Config) -> void } -> void
-
-    def self.load_config: (?String? path) -> void
-
-    class Config
-      def log_level: () -> Symbol
-
-      def log_level=: (Symbol) -> void
-
-      def credential: () -> CredentialConfig
-
-      def runtime: () -> RuntimeConfig
-
-      def http: () -> HttpConfig
-
-      def cache: () -> CacheConfig
-    end
-
-    class CredentialConfig
-      def source: () -> Symbol
-
-      def source=: (Symbol) -> void
-    end
-
-    class RuntimeConfig
-      def executable_path: () -> Pathname?
-
-      def executable_path=: (Pathname | String | nil) -> void
-
-      def user_dir: () -> Pathname?
-
-      def user_dir=: (Pathname | String | nil) -> void
-    end
-
-    class HttpConfig
-      def connect_timeout: () -> Integer
-
-      def connect_timeout=: (Integer) -> void
-
-      def read_timeout: () -> Integer
-
-      def read_timeout=: (Integer) -> void
-
-      def write_timeout: () -> Integer
-
-      def write_timeout=: (Integer) -> void
-    end
-
-    class CacheConfig
-      def download: () -> CacheInstanceConfig
-
-      def api: () -> CacheInstanceConfig
-    end
-
-    class CacheInstanceConfig
-      def dir: () -> Pathname
-
-      def dir=: (Pathname | String) -> void
-
-      def ttl: () -> Integer?
-
-      def ttl=: (Integer?) -> void
-
-      def max_file_size: () -> Integer?
-
-      def max_file_size=: (Integer?) -> void
-    end
   end
 end

--- a/spec/factorix/application_spec.rb
+++ b/spec/factorix/application_spec.rb
@@ -1,16 +1,62 @@
 # frozen_string_literal: true
 
-RSpec.describe "Factorix::Application" do
-  describe "deprecation" do
-    it "returns Container" do
-      result = nil
-      capture_stderr { result = Factorix::Application }
-      expect(result).to eq(Factorix::Container)
+RSpec.describe Factorix::Application do
+  describe "deprecation warnings" do
+    describe ".[]" do
+      it "delegates to Container" do
+        result = nil
+        capture_stderr { result = Factorix::Application[:runtime] }
+        expect(result).to be_a(Factorix::Runtime::Base)
+      end
+
+      it "outputs deprecation warning" do
+        warning = capture_stderr { Factorix::Application[:runtime] }
+        expect(warning).to match(/\[factorix\] Factorix::Application is deprecated, use Factorix::Container for DI/)
+      end
     end
 
-    it "outputs deprecation warning" do
-      warning = capture_stderr { Factorix::Application }
-      expect(warning).to match(/\[factorix\] Factorix::Application is deprecated, use Factorix::Container instead/)
+    describe ".resolve" do
+      it "delegates to Container" do
+        result = nil
+        capture_stderr { result = Factorix::Application.resolve(:runtime) }
+        expect(result).to be_a(Factorix::Runtime::Base)
+      end
+
+      it "outputs deprecation warning" do
+        warning = capture_stderr { Factorix::Application.resolve(:runtime) }
+        expect(warning).to match(/\[factorix\] Factorix::Application is deprecated, use Factorix::Container for DI/)
+      end
+    end
+
+    describe ".config" do
+      it "delegates to Factorix" do
+        result = nil
+        capture_stderr { result = Factorix::Application.config }
+        expect(result).to eq(Factorix.config)
+      end
+
+      it "outputs deprecation warning" do
+        warning = capture_stderr { Factorix::Application.config }
+        expect(warning).to match(/\[factorix\] Factorix::Application is deprecated, use Factorix.config for configuration/)
+      end
+    end
+
+    describe ".configure" do
+      it "delegates to Factorix" do
+        original_level = Factorix.config.log_level
+        capture_stderr do
+          Factorix::Application.configure do |config|
+            config.log_level = :debug
+          end
+        end
+        expect(Factorix.config.log_level).to eq(:debug)
+        Factorix.config.log_level = original_level
+      end
+
+      it "outputs deprecation warning" do
+        warning = capture_stderr { Factorix::Application.configure }
+        expect(warning).to match(/\[factorix\] Factorix::Application is deprecated, use Factorix.configure for configuration/)
+      end
     end
   end
 end

--- a/spec/factorix/cli/commands/cache/evict_spec.rb
+++ b/spec/factorix/cli/commands/cache/evict_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Factorix::CLI::Commands::Cache::Evict do
     %i[download api info_json].each do |name|
       dir = cache_dir / name.to_s
       dir.mkpath
-      allow(Factorix::Container.config.cache.public_send(name)).to receive(:dir).and_return(dir)
+      allow(Factorix.config.cache.public_send(name)).to receive(:dir).and_return(dir)
     end
   end
 

--- a/spec/factorix/cli/commands/cache/stat_spec.rb
+++ b/spec/factorix/cli/commands/cache/stat_spec.rb
@@ -11,7 +11,7 @@ RSpec.describe Factorix::CLI::Commands::Cache::Stat do
     %i[download api info_json].each do |name|
       dir = cache_dir / name.to_s
       dir.mkpath
-      allow(Factorix::Container.config.cache.public_send(name)).to receive(:dir).and_return(dir)
+      allow(Factorix.config.cache.public_send(name)).to receive(:dir).and_return(dir)
     end
   end
 

--- a/spec/factorix/cli/commands/command_wrapper_spec.rb
+++ b/spec/factorix/cli/commands/command_wrapper_spec.rb
@@ -33,7 +33,7 @@ RSpec.describe Factorix::CLI::Commands::CommandWrapper do
     allow(Factorix::Container).to receive(:[]).and_call_original
     allow(Factorix::Container).to receive(:[]).with(:runtime).and_return(runtime)
     allow(Factorix::Container).to receive(:[]).with(:logger).and_return(logger)
-    allow(Factorix::Container).to receive(:load_config)
+    allow(Factorix).to receive(:load_config)
     allow(logger).to receive(:backends).and_return([file_backend])
     allow(runtime).to receive(:factorix_config_path).and_return(default_config_path)
     allow(default_config_path).to receive(:exist?).and_return(false)
@@ -57,7 +57,7 @@ RSpec.describe Factorix::CLI::Commands::CommandWrapper do
 
       it "loads configuration from specified path" do
         command.call(config_path:)
-        expect(Factorix::Container).to have_received(:load_config).with(config_path)
+        expect(Factorix).to have_received(:load_config).with(config_path)
       end
     end
 
@@ -76,7 +76,7 @@ RSpec.describe Factorix::CLI::Commands::CommandWrapper do
 
           command.call
 
-          expect(Factorix::Container).to have_received(:load_config) do |path|
+          expect(Factorix).to have_received(:load_config) do |path|
             expect(path).to be_a(Pathname)
             expect(path.to_s).to eq(config_file.path)
           end
@@ -91,14 +91,14 @@ RSpec.describe Factorix::CLI::Commands::CommandWrapper do
 
           it "loads configuration from default path" do
             command.call
-            expect(Factorix::Container).to have_received(:load_config).with(default_config_path)
+            expect(Factorix).to have_received(:load_config).with(default_config_path)
           end
         end
 
         context "when default config file does not exist" do
           it "does not load configuration" do
             command.call
-            expect(Factorix::Container).not_to have_received(:load_config)
+            expect(Factorix).not_to have_received(:load_config)
           end
         end
       end

--- a/spec/factorix/container_spec.rb
+++ b/spec/factorix/container_spec.rb
@@ -33,18 +33,18 @@ RSpec.describe Factorix::Container do
       it "uses log level from configuration" do
         skip "Difficult to change log level of registered logger and recreate it"
 
-        original_level = Factorix::Container.config.log_level
+        original_level = Factorix.config.log_level
 
-        Factorix::Container.config.log_level = :debug
+        Factorix.config.log_level = :debug
         # Force re-registration by calling resolve directly
         logger = Factorix::Container.resolve(:logger)
         expect(logger.level).to eq(Logger::DEBUG)
 
-        Factorix::Container.config.log_level = :warn
+        Factorix.config.log_level = :warn
         logger = Factorix::Container.resolve(:logger)
         expect(logger.level).to eq(Logger::WARN)
 
-        Factorix::Container.config.log_level = original_level
+        Factorix.config.log_level = original_level
       end
 
       it "formats messages with timestamp and severity" do
@@ -202,117 +202,117 @@ RSpec.describe Factorix::Container do
   describe "configuration" do
     after do
       # Reset configuration after each test
-      Factorix::Container.config.log_level = :info
-      Factorix::Container.config.http.connect_timeout = 5
-      Factorix::Container.config.http.read_timeout = 30
-      Factorix::Container.config.http.write_timeout = 30
+      Factorix.config.log_level = :info
+      Factorix.config.http.connect_timeout = 5
+      Factorix.config.http.read_timeout = 30
+      Factorix.config.http.write_timeout = 30
     end
 
     describe ".config" do
       it "provides access to configuration" do
-        expect(Factorix::Container.config).to respond_to(:log_level)
-        expect(Factorix::Container.config).to respond_to(:cache)
+        expect(Factorix.config).to respond_to(:log_level)
+        expect(Factorix.config).to respond_to(:cache)
       end
     end
 
     describe "cache.download" do
       it "defaults dir to runtime.factorix_cache_dir/download" do
         runtime = Factorix::Container[:runtime]
-        expect(Factorix::Container.config.cache.download.dir).to eq(runtime.factorix_cache_dir / "download")
+        expect(Factorix.config.cache.download.dir).to eq(runtime.factorix_cache_dir / "download")
       end
 
       it "has default ttl of nil" do
-        expect(Factorix::Container.config.cache.download.ttl).to be_nil
+        expect(Factorix.config.cache.download.ttl).to be_nil
       end
 
       it "has default max_file_size of nil" do
-        expect(Factorix::Container.config.cache.download.max_file_size).to be_nil
+        expect(Factorix.config.cache.download.max_file_size).to be_nil
       end
 
       it "can be overridden" do
         custom_path = Pathname("/custom/cache/download")
-        Factorix::Container.config.cache.download.dir = custom_path
-        expect(Factorix::Container.config.cache.download.dir).to eq(custom_path)
+        Factorix.config.cache.download.dir = custom_path
+        expect(Factorix.config.cache.download.dir).to eq(custom_path)
       end
     end
 
     describe "cache.api" do
       it "defaults dir to runtime.factorix_cache_dir/api" do
         runtime = Factorix::Container[:runtime]
-        expect(Factorix::Container.config.cache.api.dir).to eq(runtime.factorix_cache_dir / "api")
+        expect(Factorix.config.cache.api.dir).to eq(runtime.factorix_cache_dir / "api")
       end
 
       it "has default ttl of 3600 seconds" do
-        expect(Factorix::Container.config.cache.api.ttl).to eq(3600)
+        expect(Factorix.config.cache.api.ttl).to eq(3600)
       end
 
       it "has default max_file_size of 10MiB" do
-        expect(Factorix::Container.config.cache.api.max_file_size).to eq(10 * 1024 * 1024)
+        expect(Factorix.config.cache.api.max_file_size).to eq(10 * 1024 * 1024)
       end
     end
 
     describe "log_level" do
       it "defaults to :info" do
-        expect(Factorix::Container.config.log_level).to eq(:info)
+        expect(Factorix.config.log_level).to eq(:info)
       end
 
       it "can be changed" do
-        Factorix::Container.config.log_level = :debug
-        expect(Factorix::Container.config.log_level).to eq(:debug)
+        Factorix.config.log_level = :debug
+        expect(Factorix.config.log_level).to eq(:debug)
       end
     end
 
     describe "http timeouts" do
       it "has default connect_timeout" do
-        expect(Factorix::Container.config.http.connect_timeout).to eq(5)
+        expect(Factorix.config.http.connect_timeout).to eq(5)
       end
 
       it "has default read_timeout" do
-        expect(Factorix::Container.config.http.read_timeout).to eq(30)
+        expect(Factorix.config.http.read_timeout).to eq(30)
       end
 
       it "has default write_timeout" do
-        expect(Factorix::Container.config.http.write_timeout).to eq(30)
+        expect(Factorix.config.http.write_timeout).to eq(30)
       end
 
       it "can be changed" do
-        Factorix::Container.config.http.connect_timeout = 10
-        expect(Factorix::Container.config.http.connect_timeout).to eq(10)
+        Factorix.config.http.connect_timeout = 10
+        expect(Factorix.config.http.connect_timeout).to eq(10)
       end
     end
 
     describe ".configure block" do
       it "allows configuration via block" do
-        Factorix::Container.configure do |config|
+        Factorix.configure do |config|
           config.log_level = :warn
           config.http.connect_timeout = 15
         end
 
-        expect(Factorix::Container.config.log_level).to eq(:warn)
-        expect(Factorix::Container.config.http.connect_timeout).to eq(15)
+        expect(Factorix.config.log_level).to eq(:warn)
+        expect(Factorix.config.http.connect_timeout).to eq(15)
       end
     end
 
     describe "runtime settings" do
       after do
-        Factorix::Container.config.runtime.executable_path = nil
-        Factorix::Container.config.runtime.user_dir = nil
-        Factorix::Container.config.runtime.data_dir = nil
+        Factorix.config.runtime.executable_path = nil
+        Factorix.config.runtime.user_dir = nil
+        Factorix.config.runtime.data_dir = nil
       end
 
       it "converts executable_path string to Pathname" do
-        Factorix::Container.config.runtime.executable_path = "/path/to/factorio"
-        expect(Factorix::Container.config.runtime.executable_path).to eq(Pathname("/path/to/factorio"))
+        Factorix.config.runtime.executable_path = "/path/to/factorio"
+        expect(Factorix.config.runtime.executable_path).to eq(Pathname("/path/to/factorio"))
       end
 
       it "converts user_dir string to Pathname" do
-        Factorix::Container.config.runtime.user_dir = "/path/to/user"
-        expect(Factorix::Container.config.runtime.user_dir).to eq(Pathname("/path/to/user"))
+        Factorix.config.runtime.user_dir = "/path/to/user"
+        expect(Factorix.config.runtime.user_dir).to eq(Pathname("/path/to/user"))
       end
 
       it "converts data_dir string to Pathname" do
-        Factorix::Container.config.runtime.data_dir = "/path/to/data"
-        expect(Factorix::Container.config.runtime.data_dir).to eq(Pathname("/path/to/data"))
+        Factorix.config.runtime.data_dir = "/path/to/data"
+        expect(Factorix.config.runtime.data_dir).to eq(Pathname("/path/to/data"))
       end
     end
   end
@@ -337,22 +337,22 @@ RSpec.describe Factorix::Container do
 
       after do
         config_file.unlink
-        Factorix::Container.config.log_level = :info
-        Factorix::Container.config.http.connect_timeout = 5
+        Factorix.config.log_level = :info
+        Factorix.config.http.connect_timeout = 5
       end
 
       it "loads configuration from file" do
-        Factorix::Container.load_config(config_file.path)
+        Factorix.load_config(Pathname(config_file.path))
 
-        expect(Factorix::Container.config.log_level).to eq(:debug)
-        expect(Factorix::Container.config.http.connect_timeout).to eq(20)
+        expect(Factorix.config.log_level).to eq(:debug)
+        expect(Factorix.config.http.connect_timeout).to eq(20)
       end
     end
 
     context "when explicitly specified config file does not exist" do
-      it "raises Errno::ENOENT" do
+      it "raises ConfigurationError" do
         expect {
-          Factorix::Container.load_config("/nonexistent/config.rb")
+          Factorix.load_config(Pathname("/nonexistent/config.rb"))
         }.to raise_error(Factorix::ConfigurationError, /nonexistent/)
       end
     end
@@ -361,7 +361,7 @@ RSpec.describe Factorix::Container do
       it "tries to load from default path" do
         # Default path likely doesn't exist in test environment
         expect {
-          Factorix::Container.load_config(nil)
+          Factorix.load_config(nil)
         }.not_to raise_error
       end
     end

--- a/spec/factorix/http/client_spec.rb
+++ b/spec/factorix/http/client_spec.rb
@@ -8,7 +8,7 @@ RSpec.describe Factorix::HTTP::Client do
 
   before do
     # Configure stub application config
-    allow(Factorix::Container.config.http).to receive_messages(
+    allow(Factorix.config.http).to receive_messages(
       connect_timeout: 10,
       read_timeout: 30,
       write_timeout: 30

--- a/spec/factorix/runtime/user_configurable_spec.rb
+++ b/spec/factorix/runtime/user_configurable_spec.rb
@@ -23,7 +23,7 @@ RSpec.describe Factorix::Runtime::UserConfigurable do
 
   let(:runtime) { test_runtime_class.new }
   let(:logger) { instance_double(Dry::Logger::Dispatcher) }
-  let(:config) { Factorix::Container.config }
+  let(:config) { Factorix.config }
 
   before do
     # Inject logger into runtime
@@ -120,7 +120,7 @@ RSpec.describe Factorix::Runtime::UserConfigurable do
       it "includes configuration instructions in error message" do
         expect { runtime.executable_path }.to raise_error(
           Factorix::ConfigurationError,
-          /Factorix::Container\.configure/
+          /Factorix\.configure/
         )
       end
     end
@@ -208,7 +208,7 @@ RSpec.describe Factorix::Runtime::UserConfigurable do
       it "includes configuration instructions in error message" do
         expect { runtime.user_dir }.to raise_error(
           Factorix::ConfigurationError,
-          /Factorix::Container\.configure/
+          /Factorix\.configure/
         )
       end
     end
@@ -296,7 +296,7 @@ RSpec.describe Factorix::Runtime::UserConfigurable do
       it "includes configuration instructions in error message" do
         expect { runtime.data_dir }.to raise_error(
           Factorix::ConfigurationError,
-          /Factorix::Container\.configure/
+          /Factorix\.configure/
         )
       end
     end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -20,7 +20,7 @@ WebMock.disable_net_connect!
 # Enable test interfaces for dry-core container and dry-configurable
 # before loading support files that may use stub
 Factorix::Container.enable_stubs!
-Factorix::Container.enable_test_interface
+Factorix.enable_test_interface
 
 # Load support files
 Dir[File.join(__dir__, "support", "**", "*.rb")].each {|f| require f }
@@ -53,10 +53,10 @@ RSpec.configure do |config|
     Factorix::Container.stub(:runtime, new_runtime)
 
     # Reset configuration to defaults and reconfigure with new runtime
-    Factorix::Container.reset_config
-    Factorix::Container.config.cache.download.dir = new_runtime.factorix_cache_dir / "download"
-    Factorix::Container.config.cache.api.dir = new_runtime.factorix_cache_dir / "api"
-    Factorix::Container.config.cache.info_json.dir = new_runtime.factorix_cache_dir / "info_json"
+    Factorix.reset_config
+    Factorix.config.cache.download.dir = new_runtime.factorix_cache_dir / "download"
+    Factorix.config.cache.api.dir = new_runtime.factorix_cache_dir / "api"
+    Factorix.config.cache.info_json.dir = new_runtime.factorix_cache_dir / "info_json"
   end
 
   config.after(:suite) do


### PR DESCRIPTION
## Summary

Move configuration interface (`config`, `configure`, `load_config`) from `Container` to `Factorix` module for cleaner library API.

## Changes

- Move `Dry::Configurable` and settings to `Factorix` module
- `Container` now handles DI only
- Deprecated `Application` class delegates to appropriate targets

Closes #9
