### PR TITLE
:bug: Fix dry-cli type declarations that have no effect

### DIFF
--- a/lib/factorix/cli/commands/backup_support.rb
+++ b/lib/factorix/cli/commands/backup_support.rb
@@ -15,7 +15,7 @@ module Factorix
         # @param base [Class] the class prepending this module
         def self.prepended(base)
           base.class_eval do
-            option :backup_extension, type: :string, default: ".bak", desc: "Backup file extension"
+            option :backup_extension, default: ".bak", desc: "Backup file extension"
           end
         end
 

--- a/lib/factorix/cli/commands/base.rb
+++ b/lib/factorix/cli/commands/base.rb
@@ -68,8 +68,8 @@ module Factorix
         def self.backup_support! = prepend BackupSupport
 
         # Common options available to all commands
-        option :config_path, type: :string, aliases: ["-c"], desc: "Path to configuration file"
-        option :log_level, type: :string, values: %w[debug info warn error fatal], desc: "Set log level"
+        option :config_path, aliases: ["-c"], desc: "Path to configuration file"
+        option :log_level, values: %w[debug info warn error fatal], desc: "Set log level"
         option :quiet, type: :flag, default: false, aliases: ["-q"], desc: "Suppress non-essential output"
 
         private def say(message, prefix: "")

--- a/lib/factorix/cli/commands/cache/evict.rb
+++ b/lib/factorix/cli/commands/cache/evict.rb
@@ -36,7 +36,7 @@ module Factorix
 
           option :all, type: :flag, default: false, desc: "Remove all entries"
           option :expired, type: :flag, default: false, desc: "Remove expired entries only"
-          option :older_than, type: :string, default: nil, desc: "Remove entries older than AGE (e.g., 30s, 5m, 2h, 7d)"
+          option :older_than, default: nil, desc: "Remove entries older than AGE (e.g., 30s, 5m, 2h, 7d)"
 
           # Execute the cache evict command
           #

--- a/lib/factorix/cli/commands/completion.rb
+++ b/lib/factorix/cli/commands/completion.rb
@@ -28,7 +28,6 @@ module Factorix
         desc "Generate shell completion script"
 
         argument :shell,
-          type: :string,
           required: false,
           values: [nil] + SUPPORTED_SHELLS.keys,
           desc: "Shell type. Defaults to current shell from $SHELL"

--- a/lib/factorix/cli/commands/mod/download.rb
+++ b/lib/factorix/cli/commands/mod/download.rb
@@ -29,8 +29,8 @@ module Factorix
           ]
 
           argument :mod_specs, type: :array, required: true, desc: "MOD specifications (name@version or name@latest or name)"
-          option :directory, type: :string, aliases: ["-d"], default: ".", desc: "Download directory"
-          option :jobs, type: :integer, aliases: ["-j"], default: 4, desc: "Number of parallel downloads"
+          option :directory, aliases: ["-d"], default: ".", desc: "Download directory"
+          option :jobs, aliases: ["-j"], default: "4", desc: "Number of parallel downloads"
           option :recursive, type: :flag, aliases: ["-r"], default: false, desc: "Include required dependencies recursively"
 
           # Execute the download command
@@ -40,7 +40,8 @@ module Factorix
           # @param jobs [Integer] Number of parallel downloads
           # @param recursive [Boolean] Include required dependencies recursively
           # @return [void]
-          def call(mod_specs:, directory: ".", jobs: 4, recursive: false, **)
+          def call(mod_specs:, directory: ".", jobs: "4", recursive: false, **)
+            jobs = Integer(jobs)
             download_dir = Pathname(directory).expand_path
 
             raise DirectoryNotFoundError, "Download directory does not exist: #{download_dir}" unless download_dir.exist?

--- a/lib/factorix/cli/commands/mod/edit.rb
+++ b/lib/factorix/cli/commands/mod/edit.rb
@@ -19,16 +19,16 @@ module Factorix
             "some-mod --deprecated                # Mark as deprecated"
           ]
 
-          argument :mod_name, type: :string, required: true, desc: "MOD name"
-          option :description, type: :string, desc: "Markdown description"
-          option :summary, type: :string, desc: "Brief description"
-          option :title, type: :string, desc: "MOD title"
-          option :category, type: :string, desc: "MOD category"
+          argument :mod_name, required: true, desc: "MOD name"
+          option :description, desc: "Markdown description"
+          option :summary, desc: "Brief description"
+          option :title, desc: "MOD title"
+          option :category, desc: "MOD category"
           option :tags, type: :array, desc: "Array of tags"
-          option :license, type: :string, desc: "License identifier"
-          option :homepage, type: :string, desc: "Homepage URL"
-          option :source_url, type: :string, desc: "Repository URL"
-          option :faq, type: :string, desc: "FAQ text"
+          option :license, desc: "License identifier"
+          option :homepage, desc: "Homepage URL"
+          option :source_url, desc: "Repository URL"
+          option :faq, desc: "FAQ text"
           option :deprecated, type: :boolean, desc: "Deprecation flag"
 
           # Execute the edit command

--- a/lib/factorix/cli/commands/mod/image/add.rb
+++ b/lib/factorix/cli/commands/mod/image/add.rb
@@ -18,8 +18,8 @@ module Factorix
               "some-mod screenshot.png   # Add image to MOD"
             ]
 
-            argument :mod_name, type: :string, required: true, desc: "MOD name"
-            argument :image_file, type: :string, required: true, desc: "Path to image file"
+            argument :mod_name, required: true, desc: "MOD name"
+            argument :image_file, required: true, desc: "Path to image file"
 
             # Execute the add command
             #

--- a/lib/factorix/cli/commands/mod/image/edit.rb
+++ b/lib/factorix/cli/commands/mod/image/edit.rb
@@ -18,7 +18,7 @@ module Factorix
               "some-mod abc123 def456   # Set image order (IDs from 'image list')"
             ]
 
-            argument :mod_name, type: :string, required: true, desc: "MOD name"
+            argument :mod_name, required: true, desc: "MOD name"
             argument :image_ids, type: :array, required: true, desc: "Image IDs in desired order"
 
             # Execute the edit command

--- a/lib/factorix/cli/commands/mod/image/list.rb
+++ b/lib/factorix/cli/commands/mod/image/list.rb
@@ -19,7 +19,7 @@ module Factorix
               "some-mod --json   # List images in JSON format"
             ]
 
-            argument :mod_name, type: :string, required: true, desc: "MOD name"
+            argument :mod_name, required: true, desc: "MOD name"
 
             option :json, type: :flag, default: false, desc: "Output in JSON format"
 

--- a/lib/factorix/cli/commands/mod/install.rb
+++ b/lib/factorix/cli/commands/mod/install.rb
@@ -34,14 +34,15 @@ module Factorix
           ]
 
           argument :mod_specs, type: :array, required: true, desc: "MOD specifications (name@version or name@latest or name)"
-          option :jobs, type: :integer, aliases: ["-j"], default: 4, desc: "Number of parallel downloads"
+          option :jobs, aliases: ["-j"], default: "4", desc: "Number of parallel downloads"
 
           # Execute the install command
           #
           # @param mod_specs [Array<String>] MOD specifications
           # @param jobs [Integer] Number of parallel downloads
           # @return [void]
-          def call(mod_specs:, jobs: 4, **)
+          def call(mod_specs:, jobs: "4", **)
+            jobs = Integer(jobs)
             # Load current state (without validation to allow fixing issues)
             mod_list = MODList.load
             presenter = Progress::Presenter.new(title: "\u{1F50D}\u{FE0E} Scanning MOD(s)", output: $stderr)

--- a/lib/factorix/cli/commands/mod/search.rb
+++ b/lib/factorix/cli/commands/mod/search.rb
@@ -29,11 +29,11 @@ module Factorix
           argument :mod_names, type: :array, required: false, default: [], desc: "MOD names to search"
 
           option :hide_deprecated, type: :boolean, default: true, desc: "Hide deprecated MOD(s)"
-          option :page, type: :integer, default: 1, desc: "Page number"
-          option :page_size, type: :integer, default: 25, desc: "Results per page (max 500)"
-          option :sort, type: :string, values: %w[name created_at updated_at], desc: "Sort field"
-          option :sort_order, type: :string, values: %w[asc desc], desc: "Sort order"
-          option :version, type: :string, desc: "Filter by Factorio version (default: installed version)"
+          option :page, default: "1", desc: "Page number"
+          option :page_size, default: "25", desc: "Results per page (max 500)"
+          option :sort, values: %w[name created_at updated_at], desc: "Sort field"
+          option :sort_order, values: %w[asc desc], desc: "Sort order"
+          option :version, desc: "Filter by Factorio version (default: installed version)"
           option :json, type: :flag, default: false, desc: "Output in JSON format"
 
           # Execute the search command
@@ -47,7 +47,9 @@ module Factorix
           # @param version [String, nil] Factorio version filter
           # @param json [Boolean] Output in JSON format
           # @return [void]
-          def call(mod_names: [], hide_deprecated: true, page: 1, page_size: 25, sort: nil, sort_order: nil, version: nil, json: false, **)
+          def call(mod_names: [], hide_deprecated: true, page: "1", page_size: "25", sort: nil, sort_order: nil, version: nil, json: false, **)
+            page = Integer(page)
+            page_size = Integer(page_size)
             version ||= default_factorio_version
 
             mods = portal.list_mods(*mod_names, hide_deprecated: hide_deprecated || nil, page:, page_size:, sort:, sort_order:, version:)

--- a/lib/factorix/cli/commands/mod/settings/dump.rb
+++ b/lib/factorix/cli/commands/mod/settings/dump.rb
@@ -22,8 +22,8 @@ module Factorix
               "/path/to/mod-settings.dat -o out.json   # Dump specific file"
             ]
 
-            argument :settings_file, type: :string, required: false, desc: "Path to mod-settings.dat file"
-            option :output, type: :string, aliases: ["-o"], desc: "Output file path"
+            argument :settings_file, required: false, desc: "Path to mod-settings.dat file"
+            option :output, aliases: ["-o"], desc: "Output file path"
 
             # Execute the dump command
             #

--- a/lib/factorix/cli/commands/mod/settings/restore.rb
+++ b/lib/factorix/cli/commands/mod/settings/restore.rb
@@ -24,8 +24,8 @@ module Factorix
               "                        # Restore from stdin"
             ]
 
-            argument :settings_file, type: :string, required: false, desc: "Path to mod-settings.dat file to write"
-            option :input, type: :string, aliases: ["-i"], desc: "Input file path"
+            argument :settings_file, required: false, desc: "Path to mod-settings.dat file to write"
+            option :input, aliases: ["-i"], desc: "Input file path"
 
             # Execute the restore command
             #

--- a/lib/factorix/cli/commands/mod/show.rb
+++ b/lib/factorix/cli/commands/mod/show.rb
@@ -32,7 +32,7 @@ module Factorix
             "some-mod          # Show details for some-mod"
           ]
 
-          argument :mod_name, type: :string, required: true, desc: "MOD name to show"
+          argument :mod_name, required: true, desc: "MOD name to show"
 
           # Execute the show command
           #

--- a/lib/factorix/cli/commands/mod/sync.rb
+++ b/lib/factorix/cli/commands/mod/sync.rb
@@ -31,15 +31,16 @@ module Factorix
             "-j 8 save.zip      # Use 8 parallel downloads"
           ]
 
-          argument :save_file, type: :string, required: true, desc: "Path to Factorio save file (.zip)"
-          option :jobs, type: :integer, aliases: ["-j"], default: 4, desc: "Number of parallel downloads"
+          argument :save_file, required: true, desc: "Path to Factorio save file (.zip)"
+          option :jobs, aliases: ["-j"], default: "4", desc: "Number of parallel downloads"
 
           # Execute the sync command
           #
           # @param save_file [String] Path to save file
           # @param jobs [Integer] Number of parallel downloads
           # @return [void]
-          def call(save_file:, jobs: 4, **)
+          def call(save_file:, jobs: "4", **)
+            jobs = Integer(jobs)
             # Load save file
             say "Loading save file: #{save_file}", prefix: :info
             save_data = SaveFile.load(Pathname(save_file))

--- a/lib/factorix/cli/commands/mod/update.rb
+++ b/lib/factorix/cli/commands/mod/update.rb
@@ -32,14 +32,15 @@ module Factorix
           ]
 
           argument :mod_names, type: :array, required: false, desc: "MOD names to update (all if not specified)"
-          option :jobs, type: :integer, aliases: ["-j"], default: 4, desc: "Number of parallel downloads"
+          option :jobs, aliases: ["-j"], default: "4", desc: "Number of parallel downloads"
 
           # Execute the update command
           #
           # @param mod_names [Array<String>] MOD names to update
           # @param jobs [Integer] Number of parallel downloads
           # @return [void]
-          def call(mod_names: [], jobs: 4, **)
+          def call(mod_names: [], jobs: "4", **)
+            jobs = Integer(jobs)
             presenter = Progress::Presenter.new(title: "\u{1F50D}\u{FE0E} Scanning MOD(s)", output: $stderr)
             handler = Progress::ScanHandler.new(presenter)
             installed_mods = InstalledMOD.all(handler:)

--- a/lib/factorix/cli/commands/mod/upload.rb
+++ b/lib/factorix/cli/commands/mod/upload.rb
@@ -18,11 +18,11 @@ module Factorix
             "my-mod_1.0.0.zip --category automation     # Upload with category"
           ]
 
-          argument :file, type: :string, required: true, desc: "Path to MOD zip file"
-          option :description, type: :string, desc: "Markdown description"
-          option :category, type: :string, desc: "MOD category"
-          option :license, type: :string, desc: "License identifier"
-          option :source_url, type: :string, desc: "Repository URL"
+          argument :file, required: true, desc: "Path to MOD zip file"
+          option :description, desc: "Markdown description"
+          option :category, desc: "MOD category"
+          option :license, desc: "License identifier"
+          option :source_url, desc: "Repository URL"
 
           # Execute the upload command
           #


### PR DESCRIPTION
## Summary

Fix `type: :integer` and `type: :string` option declarations that are ignored by dry-cli.

## Changes

- Remove ineffective `type: :string` and `type: :integer` declarations from all commands
- Convert integer option values using `Integer()` in command handlers
- Change integer default values to strings for consistency with CLI input

## Root Cause

dry-cli 1.4.0 only interprets the following types:
- `:boolean` - creates `--[no-]option` pattern
- `:flag` - creates `--option` without value
- `:array` - collects values into array

`:integer` and `:string` have no special handling - values remain as strings.

Fixes #12
