### PR TITLE
:recycle: Add Cache::Base and refactor FileSystem

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -42,11 +42,6 @@ inherit_from: .rubocop_todo.yml
 Lint/EmptyClass:
   AllowComments: true
 
-Lint/UnusedMethodArgument:
-  Exclude:
-    - lib/factorix/cache/file_system.rb # timeout parameter kept for Base interface compatibility
-    - spec/support/test_cache_backend.rb # timeout parameter kept for Base interface compatibility
-
 Naming/PredicateMethod:
   Exclude:
     - lib/factorix/cache/file_system.rb # fetch/store/delete return boolean but are standard cache API names

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -45,11 +45,13 @@ Lint/EmptyClass:
 Lint/UnusedMethodArgument:
   Exclude:
     - lib/factorix/cache/file_system.rb # timeout parameter kept for Base interface compatibility
+    - spec/support/test_cache_backend.rb # timeout parameter kept for Base interface compatibility
 
 Naming/PredicateMethod:
   Exclude:
     - lib/factorix/cache/file_system.rb # fetch/store/delete return boolean but are standard cache API names
     - lib/factorix/ser_des/deserializer.rb # read_bool follows binary deserialization naming convention
+    - spec/support/test_cache_backend.rb # store/delete return boolean but are standard cache API names
 
 Naming/VariableNumber:
   AllowedPatterns:
@@ -68,10 +70,12 @@ RSpec/IndexedLet:
 
 Style/HashEachMethods:
   Exclude:
+    - lib/factorix/cli/commands/cache/stat.rb # cache.each is not Hash#each, it's Cache::Base#each
     - spec/factorix/cache/file_system_spec.rb # cache.each is not Hash#each, it's a custom method
 
 Style/MapIntoArray:
   Exclude:
+    - lib/factorix/cli/commands/cache/stat.rb # cache.each is Cache::Base#each, not Hash#each
     - spec/factorix/cache/file_system_spec.rb # Testing cache.each method, not optimizing for map
 
 Style/IpAddresses:

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -84,6 +84,10 @@ Style/StaticClass:
     - lib/factorix/info_json.rb
     - lib/factorix.rb # Deprecated Application class for backward compatibility
 
+Metrics/BlockLength:
+  Exclude:
+    - lib/factorix.rb # Cache configuration block with hierarchical backend settings
+
 ThreadSafety/NewThread:
   Exclude:
     - spec/factorix/runtime/wsl/wsl_path_spec.rb

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -42,6 +42,10 @@ inherit_from: .rubocop_todo.yml
 Lint/EmptyClass:
   AllowComments: true
 
+Lint/UnusedMethodArgument:
+  Exclude:
+    - lib/factorix/cache/file_system.rb # timeout parameter kept for Base interface compatibility
+
 Naming/PredicateMethod:
   Exclude:
     - lib/factorix/cache/file_system.rb # fetch/store/delete return boolean but are standard cache API names
@@ -61,6 +65,14 @@ RSpec/IndexedLet:
     - '^node\d+$'     # Allow node1, node2, etc.
     - '^error\d+$'    # Allow error1, error2, etc.
     - '^suggestion\d+$' # Allow suggestion1, suggestion2, etc.
+
+Style/HashEachMethods:
+  Exclude:
+    - spec/factorix/cache/file_system_spec.rb # cache.each is not Hash#each, it's a custom method
+
+Style/MapIntoArray:
+  Exclude:
+    - spec/factorix/cache/file_system_spec.rb # Testing cache.each method, not optimizing for map
 
 Style/IpAddresses:
   Exclude:

--- a/doc/components/cache.md
+++ b/doc/components/cache.md
@@ -1,10 +1,10 @@
 # Cache System
 
-File-system based caching infrastructure for MOD files, API responses, and metadata.
+Multi-backend caching infrastructure for MOD files, API responses, and metadata.
 
 ## Overview
 
-Factorix uses three specialized cache instances optimized for different data types:
+Factorix uses a pluggable cache backend system with a common abstract interface (`Cache::Base`). Three specialized cache instances are configured with settings optimized for different data types:
 
 | Cache | Purpose | TTL | Compression |
 |-------|---------|-----|-------------|
@@ -29,12 +29,13 @@ graph TD
     end
 
     subgraph "Cache Layer"
-        CacheDecorator --> FileSystem[Cache::FileSystem]
+        CacheDecorator --> Base[Cache::Base]
+        Base --> FileSystem[Cache::FileSystem]
         FileSystem --> Storage[(File Storage)]
     end
 
     subgraph "Transfer Layer"
-        Downloader --> FileSystem
+        Downloader --> Base
     end
 
     CacheDecorator -.-> CachedResponse
@@ -44,21 +45,23 @@ graph TD
 
 | Class | Responsibility |
 |-------|----------------|
-| `Cache::FileSystem` | Core caching with file storage, compression, locking |
+| `Cache::Base` | Abstract interface defining the cache contract |
+| `Cache::Entry` | Data class representing cache entry metadata |
+| `Cache::FileSystem` | File-based backend with compression and locking |
 | `HTTP::CacheDecorator` | HTTP response caching (decorator pattern) |
 | `HTTP::CachedResponse` | Cached response wrapper |
 
-## FileSystem Class
+## Base Class
 
-Location: `lib/factorix/cache/file_system.rb`
+Location: `lib/factorix/cache/base.rb`
+
+Abstract base class that defines the cache backend interface. All cache backends must inherit from this class and implement its abstract methods.
 
 ### Public API
 
 | Method | Description |
 |--------|-------------|
-| `key_for(url_string)` | Generate SHA1 cache key from URL |
 | `exist?(key)` | Check if entry exists and is not expired |
-| `fetch(key, output)` | Copy cached file to output path |
 | `read(key, encoding)` | Read cached content as string |
 | `store(key, src)` | Store file in cache |
 | `delete(key)` | Delete specific entry |
@@ -66,7 +69,33 @@ Location: `lib/factorix/cache/file_system.rb`
 | `age(key)` | Get entry age in seconds |
 | `expired?(key)` | Check if entry exceeded TTL |
 | `size(key)` | Get cached file size |
-| `with_lock(key)` | Execute block with exclusive file lock |
+| `with_lock(key)` | Execute block with exclusive lock |
+| `each` | Enumerate cache entries |
+
+### Entry Data Class
+
+Location: `lib/factorix/cache/entry.rb`
+
+```ruby
+Entry = Data.define(:size, :age, :expired)
+```
+
+Represents metadata about a cache entry, used when enumerating entries with `#each`.
+
+## FileSystem Class
+
+Location: `lib/factorix/cache/file_system.rb`
+
+File-based cache backend that extends `Cache::Base`. Provides persistent storage with optional compression and process-safe file locking.
+
+### Additional Methods
+
+In addition to the `Base` interface, `FileSystem` provides:
+
+| Method | Description |
+|--------|-------------|
+| `key_for(url_string)` | Generate SHA1 cache key from URL |
+| `fetch(key, output)` | Copy cached file to output path |
 
 ### Storage Format
 
@@ -173,51 +202,61 @@ sequenceDiagram
 
 ## Configuration
 
-Location: `lib/factorix/application.rb`
+Location: `lib/factorix.rb`
 
 ### Cache Settings
+
+Each cache type has a `backend` selector and backend-specific nested settings:
 
 ```ruby
 setting :cache do
   setting :download do
-    setting :dir, constructor: ->(v) { Pathname(v) }
-    setting :ttl, default: nil                      # Unlimited
-    setting :max_file_size, default: nil            # Unlimited
-    setting :compression_threshold, default: nil    # No compression
+    setting :backend, default: :file_system        # Backend selector
+    setting :ttl, default: nil                     # Unlimited
+    setting :file_system do                        # FileSystem-specific settings
+      setting :dir, constructor: ->(v) { v ? Pathname(v) : nil }
+      setting :max_file_size, default: nil         # Unlimited
+      setting :compression_threshold, default: nil # No compression
+    end
   end
 
   setting :api do
-    setting :dir, constructor: ->(v) { Pathname(v) }
-    setting :ttl, default: 3600                     # 1 hour
-    setting :max_file_size, default: 10 * 1024 * 1024  # 10MiB
-    setting :compression_threshold, default: 0      # Always compress
+    setting :backend, default: :file_system
+    setting :ttl, default: 3600                    # 1 hour
+    setting :file_system do
+      setting :dir, constructor: ->(v) { v ? Pathname(v) : nil }
+      setting :max_file_size, default: 10 * 1024 * 1024  # 10MiB
+      setting :compression_threshold, default: 0   # Always compress
+    end
   end
 
   setting :info_json do
-    setting :dir, constructor: ->(v) { Pathname(v) }
-    setting :ttl, default: nil                      # Unlimited
-    setting :max_file_size, default: nil            # Unlimited
-    setting :compression_threshold, default: 0      # Always compress
+    setting :backend, default: :file_system
+    setting :ttl, default: nil                     # Unlimited
+    setting :file_system do
+      setting :dir, constructor: ->(v) { v ? Pathname(v) : nil }
+      setting :max_file_size, default: nil         # Unlimited
+      setting :compression_threshold, default: 0   # Always compress
+    end
   end
 end
 ```
 
 ### DI Container Registration
 
+The container resolves cache instances based on the configured backend:
+
 ```ruby
 register(:download_cache, memoize: true) do
-  c = config.cache.download
-  Cache::FileSystem.new(c.dir, **c.to_h.except(:dir))
+  build_cache(:download)  # Resolves to configured backend
 end
 
 register(:api_cache, memoize: true) do
-  c = config.cache.api
-  Cache::FileSystem.new(c.dir, **c.to_h.except(:dir))
+  build_cache(:api)
 end
 
 register(:info_json_cache, memoize: true) do
-  c = config.cache.info_json
-  Cache::FileSystem.new(c.dir, **c.to_h.except(:dir))
+  build_cache(:info_json)
 end
 ```
 

--- a/doc/components/cache.md
+++ b/doc/components/cache.md
@@ -94,7 +94,6 @@ In addition to the `Base` interface, `FileSystem` provides:
 
 | Method | Description |
 |--------|-------------|
-| `key_for(url_string)` | Generate SHA1 cache key from URL |
 | `fetch(key, output)` | Copy cached file to output path |
 
 ### Storage Format

--- a/doc/components/cache.md
+++ b/doc/components/cache.md
@@ -206,7 +206,7 @@ setting :cache do
     setting :backend, default: :file_system        # Backend selector
     setting :ttl, default: nil                     # Unlimited
     setting :file_system do                        # FileSystem-specific settings
-      setting :dir, constructor: ->(v) { v ? Pathname(v) : nil }
+      setting :root, constructor: ->(v) { v ? Pathname(v) : nil }
       setting :max_file_size, default: nil         # Unlimited
       setting :compression_threshold, default: nil # No compression
     end
@@ -216,7 +216,7 @@ setting :cache do
     setting :backend, default: :file_system
     setting :ttl, default: 3600                    # 1 hour
     setting :file_system do
-      setting :dir, constructor: ->(v) { v ? Pathname(v) : nil }
+      setting :root, constructor: ->(v) { v ? Pathname(v) : nil }
       setting :max_file_size, default: 10 * 1024 * 1024  # 10MiB
       setting :compression_threshold, default: 0   # Always compress
     end
@@ -226,7 +226,7 @@ setting :cache do
     setting :backend, default: :file_system
     setting :ttl, default: nil                     # Unlimited
     setting :file_system do
-      setting :dir, constructor: ->(v) { v ? Pathname(v) : nil }
+      setting :root, constructor: ->(v) { v ? Pathname(v) : nil }
       setting :max_file_size, default: nil         # Unlimited
       setting :compression_threshold, default: 0   # Always compress
     end

--- a/doc/components/cache.md
+++ b/doc/components/cache.md
@@ -63,6 +63,7 @@ Abstract base class that defines the cache backend interface. All cache backends
 |--------|-------------|
 | `exist?(key)` | Check if entry exists and is not expired |
 | `read(key, encoding)` | Read cached content as string |
+| `write_to(key, output)` | Write cached content to file |
 | `store(key, src)` | Store file in cache |
 | `delete(key)` | Delete specific entry |
 | `clear()` | Clear all entries |
@@ -87,14 +88,6 @@ Represents metadata about a cache entry, used when enumerating entries with `#ea
 Location: `lib/factorix/cache/file_system.rb`
 
 File-based cache backend that extends `Cache::Base`. Provides persistent storage with optional compression and process-safe file locking.
-
-### Additional Methods
-
-In addition to the `Base` interface, `FileSystem` provides:
-
-| Method | Description |
-|--------|-------------|
-| `fetch(key, output)` | Copy cached file to output path |
 
 ### Storage Format
 

--- a/doc/components/container.md
+++ b/doc/components/container.md
@@ -26,21 +26,33 @@ end
 
 setting :cache do
   setting :download do
-    setting :dir, constructor: ->(value) { Pathname(value) }
+    setting :backend, default: :file_system
     setting :ttl, default: nil
-    setting :max_file_size, default: nil
+    setting :file_system do
+      setting :dir, constructor: ->(v) { v ? Pathname(v) : nil }
+      setting :max_file_size, default: nil
+      setting :compression_threshold, default: nil
+    end
   end
 
   setting :api do
-    setting :dir, constructor: ->(value) { Pathname(value) }
+    setting :backend, default: :file_system
     setting :ttl, default: 3600
-    setting :max_file_size, default: 10 * 1024 * 1024
+    setting :file_system do
+      setting :dir, constructor: ->(v) { v ? Pathname(v) : nil }
+      setting :max_file_size, default: 10 * 1024 * 1024
+      setting :compression_threshold, default: 0
+    end
   end
 
   setting :info_json do
-    setting :dir, constructor: ->(value) { Pathname(value) }
-    setting :ttl, default: nil  # nil for unlimited (info.json is immutable within a MOD ZIP)
-    setting :max_file_size, default: nil
+    setting :backend, default: :file_system
+    setting :ttl, default: nil
+    setting :file_system do
+      setting :dir, constructor: ->(v) { v ? Pathname(v) : nil }
+      setting :max_file_size, default: nil
+      setting :compression_threshold, default: 0
+    end
   end
 end
 ```
@@ -51,6 +63,9 @@ end
 - `retry_strategy` - Retry strategy
 - `service_credential` - Factorio service credentials
 - `api_credential` - Portal API credentials
+- `download_cache` - Cache for MOD files
+- `api_cache` - Cache for API responses
+- `info_json_cache` - Cache for MOD metadata
 - Other common services
 
 ## Configuration File Loading
@@ -88,5 +103,6 @@ end
 ## Related Documentation
 
 - [Architecture](../architecture.md)
+- [Cache System](cache.md)
 - [Credentials Management](credentials.md)
 - [Technology Stack](../technology-stack.md)

--- a/doc/components/container.md
+++ b/doc/components/container.md
@@ -29,7 +29,7 @@ setting :cache do
     setting :backend, default: :file_system
     setting :ttl, default: nil
     setting :file_system do
-      setting :dir, constructor: ->(v) { v ? Pathname(v) : nil }
+      setting :root, constructor: ->(v) { v ? Pathname(v) : nil }
       setting :max_file_size, default: nil
       setting :compression_threshold, default: nil
     end
@@ -39,7 +39,7 @@ setting :cache do
     setting :backend, default: :file_system
     setting :ttl, default: 3600
     setting :file_system do
-      setting :dir, constructor: ->(v) { v ? Pathname(v) : nil }
+      setting :root, constructor: ->(v) { v ? Pathname(v) : nil }
       setting :max_file_size, default: 10 * 1024 * 1024
       setting :compression_threshold, default: 0
     end
@@ -49,7 +49,7 @@ setting :cache do
     setting :backend, default: :file_system
     setting :ttl, default: nil
     setting :file_system do
-      setting :dir, constructor: ->(v) { v ? Pathname(v) : nil }
+      setting :root, constructor: ->(v) { v ? Pathname(v) : nil }
       setting :max_file_size, default: nil
       setting :compression_threshold, default: 0
     end

--- a/example/config.rb
+++ b/example/config.rb
@@ -76,13 +76,32 @@ Factorix.configure do |config|
   # ============================================================================
   # Cache Configuration
   # ============================================================================
+  # Each cache type supports multiple backends with hierarchical configuration.
+  # Common settings (backend, ttl, lock_timeout) apply to all backends.
+  # Backend-specific settings are nested under the backend name.
 
   # Download cache settings (for MOD files)
+  # config.cache.download.backend = :file_system  # Currently only :file_system is supported
   # config.cache.download.ttl = nil  # nil = unlimited (MOD files are immutable)
-  # config.cache.download.max_file_size = nil  # nil = unlimited
+  # config.cache.download.lock_timeout = 30  # Lock timeout in seconds
+  # config.cache.download.file_system.dir = Pathname("~/.cache/factorix/download")
+  # config.cache.download.file_system.max_file_size = nil  # nil = unlimited
+  # config.cache.download.file_system.compression_threshold = nil  # nil = no compression
 
   # API cache settings (for API responses)
+  # config.cache.api.backend = :file_system
   # config.cache.api.ttl = 3600  # 1 hour
-  # config.cache.api.max_file_size = 10 * 1024 * 1024  # 10MiB
+  # config.cache.api.lock_timeout = 30
+  # config.cache.api.file_system.dir = Pathname("~/.cache/factorix/api")
+  # config.cache.api.file_system.max_file_size = 10 * 1024 * 1024  # 10MiB
+  # config.cache.api.file_system.compression_threshold = 0  # Always compress
+
+  # info.json cache settings (for MOD metadata from ZIP files)
+  # config.cache.info_json.backend = :file_system
+  # config.cache.info_json.ttl = nil  # nil = unlimited (info.json is immutable)
+  # config.cache.info_json.lock_timeout = 30
+  # config.cache.info_json.file_system.dir = Pathname("~/.cache/factorix/info_json")
+  # config.cache.info_json.file_system.max_file_size = nil  # nil = unlimited
+  # config.cache.info_json.file_system.compression_threshold = 0  # Always compress
 
 end

--- a/example/config.rb
+++ b/example/config.rb
@@ -83,21 +83,21 @@ Factorix.configure do |config|
   # Download cache settings (for MOD files)
   # config.cache.download.backend = :file_system  # Currently only :file_system is supported
   # config.cache.download.ttl = nil  # nil = unlimited (MOD files are immutable)
-  # config.cache.download.file_system.dir = Pathname("~/.cache/factorix/download")
+  # config.cache.download.file_system.root = Pathname("~/.cache/factorix/download")
   # config.cache.download.file_system.max_file_size = nil  # nil = unlimited
   # config.cache.download.file_system.compression_threshold = nil  # nil = no compression
 
   # API cache settings (for API responses)
   # config.cache.api.backend = :file_system
   # config.cache.api.ttl = 3600  # 1 hour
-  # config.cache.api.file_system.dir = Pathname("~/.cache/factorix/api")
+  # config.cache.api.file_system.root = Pathname("~/.cache/factorix/api")
   # config.cache.api.file_system.max_file_size = 10 * 1024 * 1024  # 10MiB
   # config.cache.api.file_system.compression_threshold = 0  # Always compress
 
   # info.json cache settings (for MOD metadata from ZIP files)
   # config.cache.info_json.backend = :file_system
   # config.cache.info_json.ttl = nil  # nil = unlimited (info.json is immutable)
-  # config.cache.info_json.file_system.dir = Pathname("~/.cache/factorix/info_json")
+  # config.cache.info_json.file_system.root = Pathname("~/.cache/factorix/info_json")
   # config.cache.info_json.file_system.max_file_size = nil  # nil = unlimited
   # config.cache.info_json.file_system.compression_threshold = 0  # Always compress
 

--- a/example/config.rb
+++ b/example/config.rb
@@ -77,13 +77,12 @@ Factorix.configure do |config|
   # Cache Configuration
   # ============================================================================
   # Each cache type supports multiple backends with hierarchical configuration.
-  # Common settings (backend, ttl, lock_timeout) apply to all backends.
+  # Common settings (backend, ttl) apply to all backends.
   # Backend-specific settings are nested under the backend name.
 
   # Download cache settings (for MOD files)
   # config.cache.download.backend = :file_system  # Currently only :file_system is supported
   # config.cache.download.ttl = nil  # nil = unlimited (MOD files are immutable)
-  # config.cache.download.lock_timeout = 30  # Lock timeout in seconds
   # config.cache.download.file_system.dir = Pathname("~/.cache/factorix/download")
   # config.cache.download.file_system.max_file_size = nil  # nil = unlimited
   # config.cache.download.file_system.compression_threshold = nil  # nil = no compression
@@ -91,7 +90,6 @@ Factorix.configure do |config|
   # API cache settings (for API responses)
   # config.cache.api.backend = :file_system
   # config.cache.api.ttl = 3600  # 1 hour
-  # config.cache.api.lock_timeout = 30
   # config.cache.api.file_system.dir = Pathname("~/.cache/factorix/api")
   # config.cache.api.file_system.max_file_size = 10 * 1024 * 1024  # 10MiB
   # config.cache.api.file_system.compression_threshold = 0  # Always compress
@@ -99,7 +97,6 @@ Factorix.configure do |config|
   # info.json cache settings (for MOD metadata from ZIP files)
   # config.cache.info_json.backend = :file_system
   # config.cache.info_json.ttl = nil  # nil = unlimited (info.json is immutable)
-  # config.cache.info_json.lock_timeout = 30
   # config.cache.info_json.file_system.dir = Pathname("~/.cache/factorix/info_json")
   # config.cache.info_json.file_system.max_file_size = nil  # nil = unlimited
   # config.cache.info_json.file_system.compression_threshold = 0  # Always compress

--- a/lib/factorix.rb
+++ b/lib/factorix.rb
@@ -36,14 +36,13 @@ module Factorix
 
   # Cache settings
   # Each cache type can have its own backend with hierarchical configuration.
-  # Common settings (backend, ttl, lock_timeout) apply to all backends.
+  # Common settings (backend, ttl) apply to all backends.
   # Backend-specific settings are nested under the backend name.
   setting :cache do
     # Download cache settings (for MOD files)
     setting :download do
       setting :backend, default: :file_system
       setting :ttl, default: nil # nil for unlimited (MOD files are immutable)
-      setting :lock_timeout, default: 30
       setting :file_system do
         setting :dir, constructor: ->(value) { value ? Pathname(value) : nil }
         setting :max_file_size, default: nil # nil for unlimited
@@ -55,7 +54,6 @@ module Factorix
     setting :api do
       setting :backend, default: :file_system
       setting :ttl, default: 3600 # 1 hour (API responses may change)
-      setting :lock_timeout, default: 30
       setting :file_system do
         setting :dir, constructor: ->(value) { value ? Pathname(value) : nil }
         setting :max_file_size, default: 10 * 1024 * 1024 # 10MiB (JSON responses)
@@ -67,7 +65,6 @@ module Factorix
     setting :info_json do
       setting :backend, default: :file_system
       setting :ttl, default: nil # nil for unlimited (info.json is immutable within a MOD ZIP)
-      setting :lock_timeout, default: 30
       setting :file_system do
         setting :dir, constructor: ->(value) { value ? Pathname(value) : nil }
         setting :max_file_size, default: nil # nil for unlimited (info.json is small)

--- a/lib/factorix.rb
+++ b/lib/factorix.rb
@@ -44,7 +44,7 @@ module Factorix
       setting :backend, default: :file_system
       setting :ttl, default: nil # nil for unlimited (MOD files are immutable)
       setting :file_system do
-        setting :dir, constructor: ->(value) { value ? Pathname(value) : nil }
+        setting :root, constructor: ->(value) { value ? Pathname(value) : nil }
         setting :max_file_size, default: nil # nil for unlimited
         setting :compression_threshold, default: nil # nil for no compression (binary files)
       end
@@ -55,7 +55,7 @@ module Factorix
       setting :backend, default: :file_system
       setting :ttl, default: 3600 # 1 hour (API responses may change)
       setting :file_system do
-        setting :dir, constructor: ->(value) { value ? Pathname(value) : nil }
+        setting :root, constructor: ->(value) { value ? Pathname(value) : nil }
         setting :max_file_size, default: 10 * 1024 * 1024 # 10MiB (JSON responses)
         setting :compression_threshold, default: 0 # always compress (JSON is highly compressible)
       end
@@ -66,7 +66,7 @@ module Factorix
       setting :backend, default: :file_system
       setting :ttl, default: nil # nil for unlimited (info.json is immutable within a MOD ZIP)
       setting :file_system do
-        setting :dir, constructor: ->(value) { value ? Pathname(value) : nil }
+        setting :root, constructor: ->(value) { value ? Pathname(value) : nil }
         setting :max_file_size, default: nil # nil for unlimited (info.json is small)
         setting :compression_threshold, default: 0 # always compress (JSON is highly compressible)
       end
@@ -123,9 +123,9 @@ module Factorix
 
   # Initialize cache directory defaults after Container is loaded
   runtime = Container.resolve(:runtime)
-  config.cache.download.file_system.dir = runtime.factorix_cache_dir / "download"
-  config.cache.api.file_system.dir = runtime.factorix_cache_dir / "api"
-  config.cache.info_json.file_system.dir = runtime.factorix_cache_dir / "info_json"
+  config.cache.download.file_system.root = runtime.factorix_cache_dir / "download"
+  config.cache.api.file_system.root = runtime.factorix_cache_dir / "api"
+  config.cache.info_json.file_system.root = runtime.factorix_cache_dir / "info_json"
 
   # @deprecated Use {Container} for DI and {Factorix} for configuration. Will be removed in v1.0.
   class Application

--- a/lib/factorix.rb
+++ b/lib/factorix.rb
@@ -35,29 +35,44 @@ module Factorix
   end
 
   # Cache settings
+  # Each cache type can have its own backend with hierarchical configuration.
+  # Common settings (backend, ttl, lock_timeout) apply to all backends.
+  # Backend-specific settings are nested under the backend name.
   setting :cache do
     # Download cache settings (for MOD files)
     setting :download do
-      setting :dir, constructor: ->(value) { Pathname(value) }
+      setting :backend, default: :file_system
       setting :ttl, default: nil # nil for unlimited (MOD files are immutable)
-      setting :max_file_size, default: nil # nil for unlimited
-      setting :compression_threshold, default: nil # nil for no compression (binary files)
+      setting :lock_timeout, default: 30
+      setting :file_system do
+        setting :dir, constructor: ->(value) { value ? Pathname(value) : nil }
+        setting :max_file_size, default: nil # nil for unlimited
+        setting :compression_threshold, default: nil # nil for no compression (binary files)
+      end
     end
 
     # API cache settings (for API responses)
     setting :api do
-      setting :dir, constructor: ->(value) { Pathname(value) }
+      setting :backend, default: :file_system
       setting :ttl, default: 3600 # 1 hour (API responses may change)
-      setting :max_file_size, default: 10 * 1024 * 1024 # 10MiB (JSON responses)
-      setting :compression_threshold, default: 0 # always compress (JSON is highly compressible)
+      setting :lock_timeout, default: 30
+      setting :file_system do
+        setting :dir, constructor: ->(value) { value ? Pathname(value) : nil }
+        setting :max_file_size, default: 10 * 1024 * 1024 # 10MiB (JSON responses)
+        setting :compression_threshold, default: 0 # always compress (JSON is highly compressible)
+      end
     end
 
     # info.json cache settings (for MOD metadata from ZIP files)
     setting :info_json do
-      setting :dir, constructor: ->(value) { Pathname(value) }
+      setting :backend, default: :file_system
       setting :ttl, default: nil # nil for unlimited (info.json is immutable within a MOD ZIP)
-      setting :max_file_size, default: nil # nil for unlimited (info.json is small)
-      setting :compression_threshold, default: 0 # always compress (JSON is highly compressible)
+      setting :lock_timeout, default: 30
+      setting :file_system do
+        setting :dir, constructor: ->(value) { value ? Pathname(value) : nil }
+        setting :max_file_size, default: nil # nil for unlimited (info.json is small)
+        setting :compression_threshold, default: 0 # always compress (JSON is highly compressible)
+      end
     end
   end
 
@@ -111,9 +126,9 @@ module Factorix
 
   # Initialize cache directory defaults after Container is loaded
   runtime = Container.resolve(:runtime)
-  config.cache.download.dir = runtime.factorix_cache_dir / "download"
-  config.cache.api.dir = runtime.factorix_cache_dir / "api"
-  config.cache.info_json.dir = runtime.factorix_cache_dir / "info_json"
+  config.cache.download.file_system.dir = runtime.factorix_cache_dir / "download"
+  config.cache.api.file_system.dir = runtime.factorix_cache_dir / "api"
+  config.cache.info_json.file_system.dir = runtime.factorix_cache_dir / "info_json"
 
   # @deprecated Use {Container} for DI and {Factorix} for configuration. Will be removed in v1.0.
   class Application

--- a/lib/factorix/cache/base.rb
+++ b/lib/factorix/cache/base.rb
@@ -12,16 +12,11 @@ module Factorix
       # @return [Integer, nil] time-to-live in seconds (nil for unlimited)
       attr_reader :ttl
 
-      # @return [Integer] lock timeout in seconds
-      attr_reader :lock_timeout
-
       # Initialize a new cache backend.
       #
       # @param ttl [Integer, nil] time-to-live in seconds (nil for unlimited)
-      # @param lock_timeout [Integer] lock timeout in seconds (default: 30)
-      def initialize(ttl: nil, lock_timeout: 30)
+      def initialize(ttl: nil)
         @ttl = ttl
-        @lock_timeout = lock_timeout
       end
 
       # Check if a cache entry exists and is not expired.
@@ -63,11 +58,9 @@ module Factorix
       # Execute a block with an exclusive lock on the cache entry.
       #
       # @param key [String] logical cache key
-      # @param timeout [Integer, nil] lock timeout in seconds (default: @lock_timeout)
       # @yield block to execute with lock held
-      # @raise [LockTimeoutError] if lock cannot be acquired within timeout
       # @abstract
-      def with_lock(key, timeout: @lock_timeout) = raise NotImplementedError, "#{self.class}#with_lock must be implemented"
+      def with_lock(key) = raise NotImplementedError, "#{self.class}#with_lock must be implemented"
 
       # Get the age of a cache entry in seconds.
       #

--- a/lib/factorix/cache/base.rb
+++ b/lib/factorix/cache/base.rb
@@ -1,0 +1,105 @@
+# frozen_string_literal: true
+
+module Factorix
+  module Cache
+    # Abstract base class for cache backends.
+    #
+    # All cache backends (FileSystem, S3, Redis) inherit from this class
+    # and implement the abstract methods defined here.
+    #
+    # @abstract Subclasses must implement all abstract methods.
+    class Base
+      # @return [Integer, nil] time-to-live in seconds (nil for unlimited)
+      attr_reader :ttl
+
+      # @return [Integer] lock timeout in seconds
+      attr_reader :lock_timeout
+
+      # Initialize a new cache backend.
+      #
+      # @param ttl [Integer, nil] time-to-live in seconds (nil for unlimited)
+      # @param lock_timeout [Integer] lock timeout in seconds (default: 30)
+      def initialize(ttl: nil, lock_timeout: 30)
+        @ttl = ttl
+        @lock_timeout = lock_timeout
+      end
+
+      # Check if a cache entry exists and is not expired.
+      #
+      # @param key [String] logical cache key
+      # @return [Boolean] true if the cache entry exists and is valid
+      # @abstract
+      def exist?(key) = raise NotImplementedError, "#{self.class}#exist? must be implemented"
+
+      # Read a cached entry as a string.
+      #
+      # @param key [String] logical cache key
+      # @param encoding [Encoding] encoding to use (default: ASCII-8BIT for binary)
+      # @return [String, nil] cached content or nil if not found/expired
+      # @abstract
+      def read(key, encoding: Encoding::ASCII_8BIT) = raise NotImplementedError, "#{self.class}#read must be implemented"
+
+      # Store data in the cache.
+      #
+      # @param key [String] logical cache key
+      # @param src [Pathname] path to the source file
+      # @return [Boolean] true if stored successfully
+      # @abstract
+      def store(key, src) = raise NotImplementedError, "#{self.class}#store must be implemented"
+
+      # Delete a cache entry.
+      #
+      # @param key [String] logical cache key
+      # @return [Boolean] true if deleted, false if not found
+      # @abstract
+      def delete(key) = raise NotImplementedError, "#{self.class}#delete must be implemented"
+
+      # Clear all cache entries.
+      #
+      # @return [void]
+      # @abstract
+      def clear = raise NotImplementedError, "#{self.class}#clear must be implemented"
+
+      # Execute a block with an exclusive lock on the cache entry.
+      #
+      # @param key [String] logical cache key
+      # @param timeout [Integer, nil] lock timeout in seconds (default: @lock_timeout)
+      # @yield block to execute with lock held
+      # @raise [LockTimeoutError] if lock cannot be acquired within timeout
+      # @abstract
+      def with_lock(key, timeout: @lock_timeout) = raise NotImplementedError, "#{self.class}#with_lock must be implemented"
+
+      # Get the age of a cache entry in seconds.
+      #
+      # @param key [String] logical cache key
+      # @return [Float, nil] age in seconds, or nil if entry doesn't exist
+      # @abstract
+      def age(key) = raise NotImplementedError, "#{self.class}#age must be implemented"
+
+      # Check if a cache entry has expired based on TTL.
+      #
+      # @param key [String] logical cache key
+      # @return [Boolean] true if expired, false otherwise
+      # @abstract
+      def expired?(key) = raise NotImplementedError, "#{self.class}#expired? must be implemented"
+
+      # Get the size of a cached entry in bytes.
+      #
+      # @param key [String] logical cache key
+      # @return [Integer, nil] size in bytes, or nil if entry doesn't exist/expired
+      # @abstract
+      def size(key) = raise NotImplementedError, "#{self.class}#size must be implemented"
+
+      # Enumerate cache entries.
+      #
+      # Yields [key, entry] pairs similar to Hash#each.
+      #
+      # @yield [key, entry] logical key and Entry object
+      # @yieldparam key [String] logical cache key
+      # @yieldparam entry [Entry] cache entry metadata
+      # @return [Enumerator] if no block given
+      # @abstract
+      def each = raise NotImplementedError, "#{self.class}#each must be implemented"
+    end
+  end
+end

--- a/lib/factorix/cache/base.rb
+++ b/lib/factorix/cache/base.rb
@@ -34,6 +34,17 @@ module Factorix
       # @abstract
       def read(key, encoding: Encoding::ASCII_8BIT) = raise NotImplementedError, "#{self.class}#read must be implemented"
 
+      # Write cached content to a file.
+      #
+      # Unlike {#read} which returns content as a String, this method writes
+      # directly to a file path, which is more memory-efficient for large files.
+      #
+      # @param key [String] logical cache key
+      # @param output [Pathname] path to write the cached content
+      # @return [Boolean] true if written successfully, false if not found/expired
+      # @abstract
+      def write_to(key, output) = raise NotImplementedError, "#{self.class}#write_to must be implemented"
+
       # Store data in the cache.
       #
       # @param key [String] logical cache key

--- a/lib/factorix/cache/entry.rb
+++ b/lib/factorix/cache/entry.rb
@@ -1,0 +1,22 @@
+# frozen_string_literal: true
+
+module Factorix
+  module Cache
+    Entry = Data.define(:size, :age, :expired)
+
+    # Represents a cache entry for enumeration operations.
+    #
+    # Used by {Base#each} to yield entry metadata alongside keys.
+    # Note: The key is NOT included in Entry; it is yielded separately.
+    #
+    # @!attribute [r] size
+    #   @return [Integer] entry size in bytes
+    # @!attribute [r] age
+    #   @return [Float] age in seconds since creation/modification
+    # @!attribute [r] expired
+    #   @return [Boolean] whether entry has exceeded TTL
+    class Entry
+      # All functionality provided by Data.define
+    end
+  end
+end

--- a/lib/factorix/cache/entry.rb
+++ b/lib/factorix/cache/entry.rb
@@ -13,10 +13,13 @@ module Factorix
     #   @return [Integer] entry size in bytes
     # @!attribute [r] age
     #   @return [Float] age in seconds since creation/modification
-    # @!attribute [r] expired
-    #   @return [Boolean] whether entry has exceeded TTL
     class Entry
-      # All functionality provided by Data.define
+      private :expired
+
+      # Check if the cache entry has expired.
+      #
+      # @return [Boolean] true if entry has exceeded TTL
+      def expired? = expired
     end
   end
 end

--- a/lib/factorix/cache/file_system.rb
+++ b/lib/factorix/cache/file_system.rb
@@ -64,14 +64,14 @@ module Factorix
         !expired?(key)
       end
 
-      # Fetch a cached file and copy it to the output path.
+      # Write cached content to a file.
       # If the cache entry doesn't exist or is expired, returns false without modifying the output path.
       # Automatically decompresses zlib-compressed cache entries.
       #
       # @param key [String] logical cache key
-      # @param output [Pathname] path to copy the cached file to
-      # @return [Boolean] true if the cache entry was found and copied, false otherwise
-      def fetch(key, output)
+      # @param output [Pathname] path to write the cached content to
+      # @return [Boolean] true if written successfully, false if not found/expired
+      def write_to(key, output)
         internal_key = storage_key_for(key)
         path = cache_path_for(internal_key)
         unless path.exist?

--- a/lib/factorix/cache/file_system.rb
+++ b/lib/factorix/cache/file_system.rb
@@ -42,7 +42,6 @@ module Factorix
       # @param compression_threshold [Integer, nil] compress data larger than this size in bytes
       #   (nil: no compression, 0: always compress, N: compress if >= N bytes)
       # @param ttl [Integer, nil] time-to-live in seconds (nil for unlimited)
-      # @param lock_timeout [Integer] lock timeout in seconds (default: 30)
       def initialize(dir:, max_file_size: nil, compression_threshold: nil, **)
         super(**)
         @cache_dir = dir
@@ -225,14 +224,10 @@ module Factorix
       # Executes the given block with a file lock.
       # Uses flock for process-safe file locking and automatically removes stale locks.
       #
-      # Note: The timeout parameter is accepted to match the Base interface but is
-      # currently unused. flock blocks until the lock is acquired.
-      #
       # @param key [String] logical cache key
-      # @param timeout [Integer, nil] lock timeout (unused, for interface compatibility)
       # @yield Executes the block with exclusive file lock
       # @return [void]
-      def with_lock(key, timeout: @lock_timeout)
+      def with_lock(key)
         internal_key = storage_key_for(key)
         lock_path = lock_path_for(internal_key)
         cleanup_stale_lock(lock_path)

--- a/lib/factorix/cache/file_system.rb
+++ b/lib/factorix/cache/file_system.rb
@@ -272,10 +272,11 @@ module Factorix
           next unless metadata_path.exist?
 
           logical_key = JSON.parse(metadata_path.read)["logical_key"]
+          age = Time.now - path.mtime
           entry = Entry.new(
             size: path.size,
-            age: Time.now - path.mtime,
-            expired: @ttl ? (Time.now - path.mtime > @ttl) : false
+            age:,
+            expired: @ttl ? age > @ttl : false
           )
 
           yield logical_key, entry

--- a/lib/factorix/cache/file_system.rb
+++ b/lib/factorix/cache/file_system.rb
@@ -42,13 +42,13 @@ module Factorix
       # @param compression_threshold [Integer, nil] compress data larger than this size in bytes
       #   (nil: no compression, 0: always compress, N: compress if >= N bytes)
       # @param ttl [Integer, nil] time-to-live in seconds (nil for unlimited)
-      def initialize(dir:, max_file_size: nil, compression_threshold: nil, **)
+      def initialize(root:, max_file_size: nil, compression_threshold: nil, **)
         super(**)
-        @cache_dir = dir
+        @cache_dir = root
         @max_file_size = max_file_size
         @compression_threshold = compression_threshold
         @cache_dir.mkpath
-        logger.info("Initializing cache", dir: @cache_dir.to_s, ttl: @ttl, max_size: @max_file_size, compression_threshold: @compression_threshold)
+        logger.info("Initializing cache", root: @cache_dir.to_s, ttl: @ttl, max_size: @max_file_size, compression_threshold: @compression_threshold)
       end
 
       # Check if a cache entry exists and is not expired.
@@ -168,7 +168,7 @@ module Factorix
       #
       # @return [void]
       def clear
-        logger.info("Clearing cache directory", dir: @cache_dir.to_s)
+        logger.info("Clearing cache directory", root: @cache_dir.to_s)
         count = 0
         @cache_dir.glob("**/*").each do |path|
           next unless path.file?

--- a/lib/factorix/cache/file_system.rb
+++ b/lib/factorix/cache/file_system.rb
@@ -2,6 +2,7 @@
 
 require "digest"
 require "fileutils"
+require "json"
 require "pathname"
 require "zlib"
 
@@ -12,7 +13,12 @@ module Factorix
     # Uses a two-level directory structure to store cached files,
     # with file locking to handle concurrent access and TTL support
     # for cache expiration.
-    class FileSystem
+    #
+    # Cache entries consist of:
+    # - Data file: the cached content (optionally compressed)
+    # - Metadata file (.metadata): JSON containing the logical key
+    # - Lock file (.lock): used for concurrent access control
+    class FileSystem < Base
       # @!parse
       #   # @return [Dry::Logger::Dispatcher]
       #   attr_reader :logger
@@ -31,36 +37,29 @@ module Factorix
       # Initialize a new file system cache storage.
       # Creates the cache directory if it doesn't exist
       #
-      # @param cache_dir [Pathname] path to the cache directory
-      # @param ttl [Integer, nil] time-to-live in seconds (nil for unlimited)
+      # @param dir [Pathname] path to the cache directory
       # @param max_file_size [Integer, nil] maximum file size in bytes (nil for unlimited)
       # @param compression_threshold [Integer, nil] compress data larger than this size in bytes
       #   (nil: no compression, 0: always compress, N: compress if >= N bytes)
-      def initialize(cache_dir, ttl: nil, max_file_size: nil, compression_threshold: nil, logger: nil)
-        super(logger:)
-        @cache_dir = cache_dir
-        @ttl = ttl
+      # @param ttl [Integer, nil] time-to-live in seconds (nil for unlimited)
+      # @param lock_timeout [Integer] lock timeout in seconds (default: 30)
+      def initialize(dir:, max_file_size: nil, compression_threshold: nil, **)
+        super(**)
+        @cache_dir = dir
         @max_file_size = max_file_size
         @compression_threshold = compression_threshold
         @cache_dir.mkpath
         logger.info("Initializing cache", dir: @cache_dir.to_s, ttl: @ttl, max_size: @max_file_size, compression_threshold: @compression_threshold)
       end
 
-      # Generate a cache key for the given URL string.
-      # Uses SHA1 to create a unique, deterministic key
-      #
-      # @param url_string [String] URL string to generate key for
-      # @return [String] cache key
-      # Use Digest(:SHA1) instead of Digest::SHA1 for thread-safety (Ruby 2.2+)
-      def key_for(url_string) = Digest(:SHA1).hexdigest(url_string)
-
       # Check if a cache entry exists and is not expired.
       # A cache entry is considered to exist if its file exists and is not expired
       #
-      # @param key [String] cache key to check
+      # @param key [String] logical cache key
       # @return [Boolean] true if the cache entry exists and is valid, false otherwise
       def exist?(key)
-        return false unless cache_path_for(key).exist?
+        internal_key = storage_key_for(key)
+        return false unless cache_path_for(internal_key).exist?
         return true if @ttl.nil?
 
         !expired?(key)
@@ -70,11 +69,12 @@ module Factorix
       # If the cache entry doesn't exist or is expired, returns false without modifying the output path.
       # Automatically decompresses zlib-compressed cache entries.
       #
-      # @param key [String] cache key to fetch
+      # @param key [String] logical cache key
       # @param output [Pathname] path to copy the cached file to
       # @return [Boolean] true if the cache entry was found and copied, false otherwise
       def fetch(key, output)
-        path = cache_path_for(key)
+        internal_key = storage_key_for(key)
+        path = cache_path_for(internal_key)
         unless path.exist?
           logger.debug("Cache miss", key:)
           return false
@@ -100,11 +100,12 @@ module Factorix
       # If the cache entry doesn't exist or is expired, returns nil.
       # Automatically decompresses zlib-compressed cache entries.
       #
-      # @param key [String] cache key to read
+      # @param key [String] logical cache key
       # @param encoding [Encoding, String] encoding to use (default: ASCII-8BIT for binary)
       # @return [String, nil] cached content or nil if not found/expired
       def read(key, encoding: Encoding::ASCII_8BIT)
-        path = cache_path_for(key)
+        internal_key = storage_key_for(key)
+        path = cache_path_for(internal_key)
         return nil unless path.exist?
         return nil if expired?(key)
 
@@ -118,7 +119,7 @@ module Factorix
       # Optionally compresses data based on compression_threshold setting.
       # If the (possibly compressed) size exceeds max_file_size, skips caching and returns false.
       #
-      # @param key [String] cache key to store under
+      # @param key [String] logical cache key
       # @param src [Pathname] path of the file to store
       # @return [Boolean] true if cached successfully, false if skipped due to size limit
       def store(key, src)
@@ -135,22 +136,30 @@ module Factorix
           return false
         end
 
-        path = cache_path_for(key)
+        internal_key = storage_key_for(key)
+        path = cache_path_for(internal_key)
+        metadata_path = metadata_path_for(internal_key)
+
         path.dirname.mkpath
         path.binwrite(data)
+        metadata_path.write(JSON.generate({logical_key: key}))
         logger.debug("Stored in cache", key:, size_bytes: data.bytesize)
         true
       end
 
       # Delete a specific cache entry.
       #
-      # @param key [String] cache key to delete
+      # @param key [String] logical cache key
       # @return [Boolean] true if the entry was deleted, false if it didn't exist
       def delete(key)
-        path = cache_path_for(key)
+        internal_key = storage_key_for(key)
+        path = cache_path_for(internal_key)
+        metadata_path = metadata_path_for(internal_key)
+
         return false unless path.exist?
 
         path.delete
+        metadata_path.delete if metadata_path.exist?
         logger.debug("Deleted from cache", key:)
         true
       end
@@ -163,10 +172,11 @@ module Factorix
         logger.info("Clearing cache directory", dir: @cache_dir.to_s)
         count = 0
         @cache_dir.glob("**/*").each do |path|
-          if path.file?
-            path.delete
-            count += 1
-          end
+          next unless path.file?
+          next if path.extname == ".lock"
+
+          path.delete
+          count += 1
         end
         logger.info("Cache cleared", files_removed: count)
       end
@@ -174,10 +184,11 @@ module Factorix
       # Get the age of a cache entry in seconds.
       # Returns nil if the entry doesn't exist.
       #
-      # @param key [String] cache key
+      # @param key [String] logical cache key
       # @return [Float, nil] age in seconds, or nil if entry doesn't exist
       def age(key)
-        path = cache_path_for(key)
+        internal_key = storage_key_for(key)
+        path = cache_path_for(internal_key)
         return nil unless path.exist?
 
         Time.now - path.mtime
@@ -186,7 +197,7 @@ module Factorix
       # Check if a cache entry has expired based on TTL.
       # Returns false if TTL is not set (unlimited) or if entry doesn't exist.
       #
-      # @param key [String] cache key
+      # @param key [String] logical cache key
       # @return [Boolean] true if expired, false otherwise
       def expired?(key)
         return false if @ttl.nil?
@@ -200,10 +211,11 @@ module Factorix
       # Get the size of a cached file in bytes.
       # Returns nil if the entry doesn't exist or is expired.
       #
-      # @param key [String] cache key
+      # @param key [String] logical cache key
       # @return [Integer, nil] file size in bytes, or nil if entry doesn't exist/expired
       def size(key)
-        path = cache_path_for(key)
+        internal_key = storage_key_for(key)
+        path = cache_path_for(internal_key)
         return nil unless path.exist?
         return nil if expired?(key)
 
@@ -211,13 +223,18 @@ module Factorix
       end
 
       # Executes the given block with a file lock.
-      # Uses flock for process-safe file locking and automatically removes stale locks
+      # Uses flock for process-safe file locking and automatically removes stale locks.
       #
-      # @param key [String] cache key to lock
+      # Note: The timeout parameter is accepted to match the Base interface but is
+      # currently unused. flock blocks until the lock is acquired.
+      #
+      # @param key [String] logical cache key
+      # @param timeout [Integer, nil] lock timeout (unused, for interface compatibility)
       # @yield Executes the block with exclusive file lock
       # @return [void]
-      def with_lock(key)
-        lock_path = lock_path_for(key)
+      def with_lock(key, timeout: @lock_timeout)
+        internal_key = storage_key_for(key)
+        lock_path = lock_path_for(internal_key)
         cleanup_stale_lock(lock_path)
 
         lock_path.dirname.mkpath
@@ -240,23 +257,69 @@ module Factorix
         end
       end
 
-      # Get the cache file path for the given key.
-      # Uses a two-level directory structure to avoid too many files in one directory
+      # Enumerate cache entries.
       #
-      # @param key [String] cache key
-      # @return [Pathname] path to the cache file
-      private def cache_path_for(key)
-        prefix = key[0, 2]
-        @cache_dir.join(prefix, key[2..])
+      # Yields [key, entry] pairs similar to Hash#each.
+      # Skips entries without metadata files (legacy entries).
+      #
+      # @yield [key, entry] logical key and Entry object
+      # @yieldparam key [String] logical cache key
+      # @yieldparam entry [Entry] cache entry metadata
+      # @return [Enumerator] if no block given
+      def each
+        return enum_for(__method__) unless block_given?
+
+        @cache_dir.glob("**/*").each do |path|
+          next unless path.file?
+          next if path.extname == ".metadata" || path.extname == ".lock"
+
+          metadata_path = Pathname("#{path}.metadata")
+          next unless metadata_path.exist?
+
+          logical_key = JSON.parse(metadata_path.read)["logical_key"]
+          entry = Entry.new(
+            size: path.size,
+            age: Time.now - path.mtime,
+            expired: @ttl ? (Time.now - path.mtime > @ttl) : false
+          )
+
+          yield logical_key, entry
+        end
       end
 
-      # Get the lock file path for the given key.
+      # Generate a storage key for the given logical key.
+      # Uses SHA1 to create a unique, deterministic key.
+      # Use Digest(:SHA1) instead of Digest::SHA1 for thread-safety (Ruby 2.2+)
+      #
+      # @param logical_key [String] logical key to generate storage key for
+      # @return [String] storage key (SHA1 hash)
+      private def storage_key_for(logical_key) = Digest(:SHA1).hexdigest(logical_key)
+
+      # Get the cache file path for the given internal key.
+      # Uses a two-level directory structure to avoid too many files in one directory
+      #
+      # @param internal_key [String] internal storage key
+      # @return [Pathname] path to the cache file
+      private def cache_path_for(internal_key)
+        prefix = internal_key[0, 2]
+        @cache_dir.join(prefix, internal_key[2..])
+      end
+
+      # Get the metadata file path for the given internal key.
+      #
+      # @param internal_key [String] internal storage key
+      # @return [Pathname] path to the metadata file
+      private def metadata_path_for(internal_key)
+        Pathname("#{cache_path_for(internal_key)}.metadata")
+      end
+
+      # Get the lock file path for the given internal key.
       # Lock files are stored alongside cache files with a .lock extension
       #
-      # @param key [String] cache key
+      # @param internal_key [String] internal storage key
       # @return [Pathname] path to the lock file
-      private def lock_path_for(key)
-        cache_path_for(key).sub_ext(".lock")
+      private def lock_path_for(internal_key)
+        cache_path_for(internal_key).sub_ext(".lock")
       end
 
       # Check if data should be compressed based on compression_threshold setting.

--- a/lib/factorix/cli/commands/cache/evict.rb
+++ b/lib/factorix/cli/commands/cache/evict.rb
@@ -115,7 +115,7 @@ module Factorix
           # @return [Hash] eviction result with :count and :size
           private def evict_cache(name, all:, expired:)
             config = Factorix.config.cache.public_send(name)
-            cache_dir = config.dir
+            cache_dir = config.file_system.dir
             ttl = config.ttl
 
             return {count: 0, size: 0} unless cache_dir.exist?

--- a/lib/factorix/cli/commands/cache/evict.rb
+++ b/lib/factorix/cli/commands/cache/evict.rb
@@ -48,7 +48,6 @@ module Factorix
           def call(caches: nil, all: false, expired: false, older_than: nil, **)
             validate_options!(all, expired, older_than)
 
-            @now = Time.now
             @older_than_seconds = parse_age(older_than) if older_than
 
             cache_names = resolve_cache_names(caches)
@@ -114,28 +113,26 @@ module Factorix
           # @param expired [Boolean] remove expired entries only
           # @return [Hash] eviction result with :count and :size
           private def evict_cache(name, all:, expired:)
-            config = Factorix.config.cache.public_send(name)
-            cache_dir = config.file_system.dir
-            ttl = config.ttl
-
-            return {count: 0, size: 0} unless cache_dir.exist?
+            cache = Container.resolve(:"#{name}_cache")
 
             count = 0
             size = 0
 
-            cache_dir.glob("**/*").each do |path|
-              next unless path.file?
-              next if path.extname == ".lock" || path.extname == ".metadata"
+            # Collect keys to evict (we can't modify during iteration)
+            to_evict = []
+            cache.each do |key, entry|
+              next unless should_evict?(entry, all:, expired:)
 
-              next unless should_evict?(path, ttl, all:, expired:)
+              to_evict << [key, entry.size]
+            end
 
-              size += path.size
-              path.delete
-              # Also delete associated metadata file if it exists
-              metadata_path = Pathname("#{path}.metadata")
-              metadata_path.delete if metadata_path.exist?
+            # Perform eviction
+            to_evict.each do |key, entry_size|
+              next unless cache.delete(key)
+
               count += 1
-              logger.debug("Evicted cache entry", path: path.to_s)
+              size += entry_size
+              logger.debug("Evicted cache entry", key:)
             end
 
             logger.info("Evicted cache entries", cache: name, count:, size:)
@@ -144,23 +141,18 @@ module Factorix
 
           # Determine if a cache entry should be evicted
           #
-          # @param path [Pathname] path to cache entry
-          # @param ttl [Integer, nil] cache TTL
+          # @param entry [Cache::Entry] cache entry
           # @param all [Boolean] remove all entries
           # @param expired [Boolean] remove expired entries only
           # @return [Boolean] true if entry should be evicted
-          private def should_evict?(path, ttl, all:, expired:)
+          private def should_evict?(entry, all:, expired:)
             return true if all
 
-            age_seconds = @now - path.mtime
-
             if expired
-              return false if ttl.nil? # No TTL means never expires
-
-              age_seconds > ttl
+              entry.expired?
             else
               # --older-than
-              age_seconds > @older_than_seconds
+              entry.age > @older_than_seconds
             end
           end
 

--- a/lib/factorix/cli/commands/cache/evict.rb
+++ b/lib/factorix/cli/commands/cache/evict.rb
@@ -125,12 +125,15 @@ module Factorix
 
             cache_dir.glob("**/*").each do |path|
               next unless path.file?
-              next if path.extname == ".lock"
+              next if path.extname == ".lock" || path.extname == ".metadata"
 
               next unless should_evict?(path, ttl, all:, expired:)
 
               size += path.size
               path.delete
+              # Also delete associated metadata file if it exists
+              metadata_path = Pathname("#{path}.metadata")
+              metadata_path.delete if metadata_path.exist?
               count += 1
               logger.debug("Evicted cache entry", path: path.to_s)
             end

--- a/lib/factorix/cli/commands/cache/stat.rb
+++ b/lib/factorix/cli/commands/cache/stat.rb
@@ -81,7 +81,7 @@ module Factorix
             entries = []
             cache_dir.glob("**/*").each do |path|
               next unless path.file?
-              next if path.extname == ".lock"
+              next if path.extname == ".lock" || path.extname == ".metadata"
 
               age_seconds = @now - path.mtime
               expired = ttl ? age_seconds > ttl : false

--- a/lib/factorix/cli/commands/cache/stat.rb
+++ b/lib/factorix/cli/commands/cache/stat.rb
@@ -54,15 +54,16 @@ module Factorix
 
           private def collect_stats(name)
             config = Factorix.config.cache.public_send(name)
-            cache_dir = config.dir
+            fs_config = config.file_system
+            cache_dir = fs_config.dir
 
             entries = scan_entries(cache_dir, config.ttl)
 
             {
               directory: cache_dir.to_s,
               ttl: config.ttl,
-              max_file_size: config.max_file_size,
-              compression_threshold: config.compression_threshold,
+              max_file_size: fs_config.max_file_size,
+              compression_threshold: fs_config.compression_threshold,
               entries: build_entry_stats(entries),
               size: build_size_stats(entries),
               age: build_age_stats(entries),

--- a/lib/factorix/container.rb
+++ b/lib/factorix/container.rb
@@ -49,19 +49,19 @@ module Factorix
     # Register download cache
     register(:download_cache, memoize: true) do
       c = Factorix.config.cache.download
-      Cache::FileSystem.new(c.dir, **c.to_h.except(:dir))
+      Cache::FileSystem.new(**c.to_h)
     end
 
     # Register API cache (with compression for JSON responses)
     register(:api_cache, memoize: true) do
       c = Factorix.config.cache.api
-      Cache::FileSystem.new(c.dir, **c.to_h.except(:dir))
+      Cache::FileSystem.new(**c.to_h)
     end
 
     # Register info.json cache (for MOD metadata from ZIP files)
     register(:info_json_cache, memoize: true) do
       c = Factorix.config.cache.info_json
-      Cache::FileSystem.new(c.dir, **c.to_h.except(:dir))
+      Cache::FileSystem.new(**c.to_h)
     end
 
     # Register base HTTP client

--- a/lib/factorix/container.rb
+++ b/lib/factorix/container.rb
@@ -49,19 +49,20 @@ module Factorix
     # Register download cache
     register(:download_cache, memoize: true) do
       c = Factorix.config.cache.download
-      Cache::FileSystem.new(**c.to_h)
+      # Currently only FileSystem backend is supported
+      Cache::FileSystem.new(ttl: c.ttl, lock_timeout: c.lock_timeout, **c.file_system.to_h)
     end
 
     # Register API cache (with compression for JSON responses)
     register(:api_cache, memoize: true) do
       c = Factorix.config.cache.api
-      Cache::FileSystem.new(**c.to_h)
+      Cache::FileSystem.new(ttl: c.ttl, lock_timeout: c.lock_timeout, **c.file_system.to_h)
     end
 
     # Register info.json cache (for MOD metadata from ZIP files)
     register(:info_json_cache, memoize: true) do
       c = Factorix.config.cache.info_json
-      Cache::FileSystem.new(**c.to_h)
+      Cache::FileSystem.new(ttl: c.ttl, lock_timeout: c.lock_timeout, **c.file_system.to_h)
     end
 
     # Register base HTTP client

--- a/lib/factorix/container.rb
+++ b/lib/factorix/container.rb
@@ -50,19 +50,19 @@ module Factorix
     register(:download_cache, memoize: true) do
       c = Factorix.config.cache.download
       # Currently only FileSystem backend is supported
-      Cache::FileSystem.new(ttl: c.ttl, lock_timeout: c.lock_timeout, **c.file_system.to_h)
+      Cache::FileSystem.new(ttl: c.ttl, **c.file_system.to_h)
     end
 
     # Register API cache (with compression for JSON responses)
     register(:api_cache, memoize: true) do
       c = Factorix.config.cache.api
-      Cache::FileSystem.new(ttl: c.ttl, lock_timeout: c.lock_timeout, **c.file_system.to_h)
+      Cache::FileSystem.new(ttl: c.ttl, **c.file_system.to_h)
     end
 
     # Register info.json cache (for MOD metadata from ZIP files)
     register(:info_json_cache, memoize: true) do
       c = Factorix.config.cache.info_json
-      Cache::FileSystem.new(ttl: c.ttl, lock_timeout: c.lock_timeout, **c.file_system.to_h)
+      Cache::FileSystem.new(ttl: c.ttl, **c.file_system.to_h)
     end
 
     # Register base HTTP client

--- a/lib/factorix/errors.rb
+++ b/lib/factorix/errors.rb
@@ -48,6 +48,9 @@ module Factorix
   class HTTPNotFoundError < HTTPClientError; end
   class HTTPServerError < HTTPError; end
 
+  # Cache lock timeout errors
+  class LockTimeoutError < InfrastructureError; end
+
   # Digest verification errors
   class DigestMismatchError < InfrastructureError; end
 

--- a/lib/factorix/info_json.rb
+++ b/lib/factorix/info_json.rb
@@ -49,7 +49,7 @@ module Factorix
     def self.from_zip(zip_path)
       cache = Container.resolve(:info_json_cache)
       logger = Container.resolve(:logger)
-      cache_key = cache.key_for(zip_path.to_s)
+      cache_key = zip_path.to_s
 
       if (cached_json = cache.read(cache_key, encoding: Encoding::UTF_8))
         logger.debug("info.json cache hit", path: zip_path.to_s)

--- a/lib/factorix/transfer/downloader.rb
+++ b/lib/factorix/transfer/downloader.rb
@@ -53,9 +53,9 @@ module Factorix
         end
 
         logger.info("Starting download", output: output.to_s)
-        key = cache.key_for(url.to_s)
+        cache_key = url.to_s
 
-        case try_cache_hit(key, output, expected_sha1:)
+        case try_cache_hit(cache_key, output, expected_sha1:)
         when :hit
           return
         when :miss
@@ -68,14 +68,14 @@ module Factorix
           raise RuntimeError, "Unexpected cache state"
         end
 
-        cache.with_lock(key) do
-          return if try_cache_hit(key, output, expected_sha1:) == :hit
+        cache.with_lock(cache_key) do
+          return if try_cache_hit(cache_key, output, expected_sha1:) == :hit
 
           with_temporary_file do |temp_file|
             download_file_with_progress(url, temp_file)
             verify_sha1(temp_file, expected_sha1) if expected_sha1
-            cache.store(key, temp_file)
-            cache.fetch(key, output)
+            cache.store(cache_key, temp_file)
+            cache.fetch(cache_key, output)
           end
         end
       end
@@ -112,21 +112,21 @@ module Factorix
       # If the cached file exists but fails SHA1 verification, the cache entry
       # is invalidated and :corrupted is returned to trigger re-download.
       #
-      # @param key [String] cache key
+      # @param cache_key [String] logical cache key (URL string)
       # @param output [Pathname] path to save the cached file
       # @param expected_sha1 [String, nil] expected SHA1 digest for verification (optional)
       # @return [Symbol] :hit if cache hit with valid SHA1, :miss if not cached, :corrupted if SHA1 mismatch
-      private def try_cache_hit(key, output, expected_sha1:)
-        return :miss unless cache.fetch(key, output)
+      private def try_cache_hit(cache_key, output, expected_sha1:)
+        return :miss unless cache.fetch(cache_key, output)
 
         logger.info("Cache hit", output: output.to_s)
         verify_sha1(output, expected_sha1) if expected_sha1
-        total_size = cache.size(key)
+        total_size = cache.size(cache_key)
         publish("cache.hit", output: output.to_s, total_size:)
         :hit
       rescue DigestMismatchError => e
         logger.warn("Cache corrupted, invalidating", output: output.to_s, error: e.message)
-        cache.delete(key)
+        cache.delete(cache_key)
         :corrupted
       end
 

--- a/lib/factorix/transfer/downloader.rb
+++ b/lib/factorix/transfer/downloader.rb
@@ -75,7 +75,7 @@ module Factorix
             download_file_with_progress(url, temp_file)
             verify_sha1(temp_file, expected_sha1) if expected_sha1
             cache.store(cache_key, temp_file)
-            cache.fetch(cache_key, output)
+            cache.write_to(cache_key, output)
           end
         end
       end
@@ -117,7 +117,7 @@ module Factorix
       # @param expected_sha1 [String, nil] expected SHA1 digest for verification (optional)
       # @return [Symbol] :hit if cache hit with valid SHA1, :miss if not cached, :corrupted if SHA1 mismatch
       private def try_cache_hit(cache_key, output, expected_sha1:)
-        return :miss unless cache.fetch(cache_key, output)
+        return :miss unless cache.write_to(cache_key, output)
 
         logger.info("Cache hit", output: output.to_s)
         verify_sha1(output, expected_sha1) if expected_sha1

--- a/sig/factorix/cache/base.rbs
+++ b/sig/factorix/cache/base.rbs
@@ -4,9 +4,8 @@ module Factorix
   module Cache
     class Base
       attr_reader ttl: Integer?
-      attr_reader lock_timeout: Integer
 
-      def initialize: (?ttl: Integer?, ?lock_timeout: Integer) -> void
+      def initialize: (?ttl: Integer?) -> void
 
       def exist?: (String key) -> bool
       def read: (String key, ?encoding: Encoding) -> String?
@@ -14,7 +13,7 @@ module Factorix
       def delete: (String key) -> bool
       def clear: () -> void
 
-      def with_lock: (String key, ?timeout: Integer?) { () -> void } -> void
+      def with_lock: (String key) { () -> void } -> void
 
       def age: (String key) -> Float?
       def expired?: (String key) -> bool

--- a/sig/factorix/cache/base.rbs
+++ b/sig/factorix/cache/base.rbs
@@ -1,0 +1,27 @@
+# RBS type signature file
+
+module Factorix
+  module Cache
+    class Base
+      attr_reader ttl: Integer?
+      attr_reader lock_timeout: Integer
+
+      def initialize: (?ttl: Integer?, ?lock_timeout: Integer) -> void
+
+      def exist?: (String key) -> bool
+      def read: (String key, ?encoding: Encoding) -> String?
+      def store: (String key, Pathname src) -> bool
+      def delete: (String key) -> bool
+      def clear: () -> void
+
+      def with_lock: (String key, ?timeout: Integer?) { () -> void } -> void
+
+      def age: (String key) -> Float?
+      def expired?: (String key) -> bool
+      def size: (String key) -> Integer?
+
+      def each: () -> Enumerator[[String, Entry], void]
+              | () { ([String, Entry]) -> void } -> void
+    end
+  end
+end

--- a/sig/factorix/cache/entry.rbs
+++ b/sig/factorix/cache/entry.rbs
@@ -5,7 +5,8 @@ module Factorix
     class Entry
       attr_reader size: Integer
       attr_reader age: Float
-      attr_reader expired: bool
+
+      def expired?: () -> bool
 
       def initialize: (size: Integer, age: Float, expired: bool) -> void
     end

--- a/sig/factorix/cache/entry.rbs
+++ b/sig/factorix/cache/entry.rbs
@@ -1,0 +1,13 @@
+# RBS type signature file
+
+module Factorix
+  module Cache
+    class Entry
+      attr_reader size: Integer
+      attr_reader age: Float
+      attr_reader expired: bool
+
+      def initialize: (size: Integer, age: Float, expired: bool) -> void
+    end
+  end
+end

--- a/sig/factorix/cache/file_system.rbs
+++ b/sig/factorix/cache/file_system.rbs
@@ -7,7 +7,7 @@ module Factorix
     class FileSystem < Base
       LOCK_FILE_LIFETIME: Integer
 
-      def initialize: (dir: Pathname, ?ttl: Integer?, ?lock_timeout: Integer, ?max_file_size: Integer?, ?compression_threshold: Integer?) -> void
+      def initialize: (dir: Pathname, ?ttl: Integer?, ?max_file_size: Integer?, ?compression_threshold: Integer?) -> void
 
       def exist?: (String key) -> bool
 
@@ -27,7 +27,7 @@ module Factorix
 
       def size: (String key) -> Integer?
 
-      def with_lock: [T] (String key, ?timeout: Integer?) { () -> T } -> T
+      def with_lock: [T] (String key) { () -> T } -> T
 
       def each: () { (String, Entry) -> void } -> void
               | () -> Enumerator[[String, Entry], void]

--- a/sig/factorix/cache/file_system.rbs
+++ b/sig/factorix/cache/file_system.rbs
@@ -4,12 +4,10 @@
 
 module Factorix
   module Cache
-    class FileSystem
+    class FileSystem < Base
       LOCK_FILE_LIFETIME: Integer
 
-      def initialize: (Pathname cache_dir, ?ttl: Integer?, ?max_file_size: Integer?, ?compression_threshold: Integer?) -> void
-
-      def key_for: (String url_string) -> String
+      def initialize: (dir: Pathname, ?ttl: Integer?, ?lock_timeout: Integer, ?max_file_size: Integer?, ?compression_threshold: Integer?) -> void
 
       def exist?: (String key) -> bool
 
@@ -29,7 +27,10 @@ module Factorix
 
       def size: (String key) -> Integer?
 
-      def with_lock: [T] (String key) { () -> T } -> T
+      def with_lock: [T] (String key, ?timeout: Integer?) { () -> T } -> T
+
+      def each: () { (String, Entry) -> void } -> void
+              | () -> Enumerator[[String, Entry], void]
     end
   end
 end

--- a/sig/factorix/errors.rbs
+++ b/sig/factorix/errors.rbs
@@ -49,6 +49,9 @@ module Factorix
   class HTTPServerError < HTTPError
   end
 
+  class LockTimeoutError < InfrastructureError
+  end
+
   class DigestMismatchError < InfrastructureError
   end
 

--- a/spec/factorix/api/mod_portal_api_spec.rb
+++ b/spec/factorix/api/mod_portal_api_spec.rb
@@ -7,10 +7,6 @@ RSpec.describe Factorix::API::MODPortalAPI do
   let(:cache) { instance_double(Factorix::Cache::FileSystem) }
   let(:api) { Factorix::API::MODPortalAPI.new(cache:, client:) }
 
-  before do
-    allow(cache).to receive(:key_for).and_return("cache_key")
-  end
-
   describe "#get_mods" do
     let(:response_body) { '{"results": [], "pagination": {}}' }
     let(:parsed_response) { {results: [], pagination: {}} }
@@ -30,13 +26,13 @@ RSpec.describe Factorix::API::MODPortalAPI do
 
       it "stores response in cache" do
         api.get_mods
-        expect(cache).to have_received(:store).with("cache_key", kind_of(Pathname))
+        expect(cache).to have_received(:store).with("https://mods.factorio.com/api/mods", kind_of(Pathname))
       end
     end
 
     context "when cache hit" do
       before do
-        allow(cache).to receive(:read).with("cache_key", encoding: "UTF-8").and_return(response_body)
+        allow(cache).to receive(:read).with("https://mods.factorio.com/api/mods", encoding: "UTF-8").and_return(response_body)
       end
 
       it "returns cached data without making HTTP request" do
@@ -92,7 +88,7 @@ RSpec.describe Factorix::API::MODPortalAPI do
 
     context "when cache hit" do
       before do
-        allow(cache).to receive(:read).with("cache_key", encoding: "UTF-8").and_return(response_body)
+        allow(cache).to receive(:read).with("https://mods.factorio.com/api/mods/example-mod", encoding: "UTF-8").and_return(response_body)
       end
 
       it "returns cached data" do
@@ -147,7 +143,7 @@ RSpec.describe Factorix::API::MODPortalAPI do
 
     context "when cache hit" do
       before do
-        allow(cache).to receive(:read).with("cache_key", encoding: "UTF-8").and_return(response_body)
+        allow(cache).to receive(:read).with("https://mods.factorio.com/api/mods/example-mod/full", encoding: "UTF-8").and_return(response_body)
       end
 
       it "returns cached data" do
@@ -279,7 +275,6 @@ RSpec.describe Factorix::API::MODPortalAPI do
 
   describe "#on_mod_changed" do
     before do
-      allow(cache).to receive(:key_for) {|uri| "key_for_#{uri}" }
       allow(cache).to receive(:with_lock).and_yield
       allow(cache).to receive(:delete)
     end
@@ -289,10 +284,10 @@ RSpec.describe Factorix::API::MODPortalAPI do
 
       api.on_mod_changed(event)
 
-      expect(cache).to have_received(:with_lock).with("key_for_https://mods.factorio.com/api/mods/example-mod")
-      expect(cache).to have_received(:with_lock).with("key_for_https://mods.factorio.com/api/mods/example-mod/full")
-      expect(cache).to have_received(:delete).with("key_for_https://mods.factorio.com/api/mods/example-mod")
-      expect(cache).to have_received(:delete).with("key_for_https://mods.factorio.com/api/mods/example-mod/full")
+      expect(cache).to have_received(:with_lock).with("https://mods.factorio.com/api/mods/example-mod")
+      expect(cache).to have_received(:with_lock).with("https://mods.factorio.com/api/mods/example-mod/full")
+      expect(cache).to have_received(:delete).with("https://mods.factorio.com/api/mods/example-mod")
+      expect(cache).to have_received(:delete).with("https://mods.factorio.com/api/mods/example-mod/full")
     end
 
     it "URL-encodes MOD names with special characters" do
@@ -300,10 +295,10 @@ RSpec.describe Factorix::API::MODPortalAPI do
 
       api.on_mod_changed(event)
 
-      expect(cache).to have_received(:with_lock).with("key_for_https://mods.factorio.com/api/mods/Explosive%20Excavation")
-      expect(cache).to have_received(:with_lock).with("key_for_https://mods.factorio.com/api/mods/Explosive%20Excavation/full")
-      expect(cache).to have_received(:delete).with("key_for_https://mods.factorio.com/api/mods/Explosive%20Excavation")
-      expect(cache).to have_received(:delete).with("key_for_https://mods.factorio.com/api/mods/Explosive%20Excavation/full")
+      expect(cache).to have_received(:with_lock).with("https://mods.factorio.com/api/mods/Explosive%20Excavation")
+      expect(cache).to have_received(:with_lock).with("https://mods.factorio.com/api/mods/Explosive%20Excavation/full")
+      expect(cache).to have_received(:delete).with("https://mods.factorio.com/api/mods/Explosive%20Excavation")
+      expect(cache).to have_received(:delete).with("https://mods.factorio.com/api/mods/Explosive%20Excavation/full")
     end
   end
 end

--- a/spec/factorix/cache/base_spec.rb
+++ b/spec/factorix/cache/base_spec.rb
@@ -4,19 +4,13 @@ RSpec.describe Factorix::Cache::Base do
   let(:base) { Factorix::Cache::Base.new }
 
   describe "#initialize" do
-    it "sets default values for ttl and lock_timeout" do
+    it "sets default value for ttl" do
       expect(base.ttl).to be_nil
-      expect(base.lock_timeout).to eq(30)
     end
 
     it "accepts custom ttl" do
       cache = Factorix::Cache::Base.new(ttl: 3600)
       expect(cache.ttl).to eq(3600)
-    end
-
-    it "accepts custom lock_timeout" do
-      cache = Factorix::Cache::Base.new(lock_timeout: 60)
-      expect(cache.lock_timeout).to eq(60)
     end
   end
 

--- a/spec/factorix/cache/base_spec.rb
+++ b/spec/factorix/cache/base_spec.rb
@@ -1,0 +1,64 @@
+# frozen_string_literal: true
+
+RSpec.describe Factorix::Cache::Base do
+  let(:base) { Factorix::Cache::Base.new }
+
+  describe "#initialize" do
+    it "sets default values for ttl and lock_timeout" do
+      expect(base.ttl).to be_nil
+      expect(base.lock_timeout).to eq(30)
+    end
+
+    it "accepts custom ttl" do
+      cache = Factorix::Cache::Base.new(ttl: 3600)
+      expect(cache.ttl).to eq(3600)
+    end
+
+    it "accepts custom lock_timeout" do
+      cache = Factorix::Cache::Base.new(lock_timeout: 60)
+      expect(cache.lock_timeout).to eq(60)
+    end
+  end
+
+  describe "abstract methods" do
+    it "raises NotImplementedError for #exist?" do
+      expect { base.exist?("key") }.to raise_error(NotImplementedError, /exist\?/)
+    end
+
+    it "raises NotImplementedError for #read" do
+      expect { base.read("key") }.to raise_error(NotImplementedError, /read/)
+    end
+
+    it "raises NotImplementedError for #store" do
+      expect { base.store("key", Pathname("/tmp/file")) }.to raise_error(NotImplementedError, /store/)
+    end
+
+    it "raises NotImplementedError for #delete" do
+      expect { base.delete("key") }.to raise_error(NotImplementedError, /delete/)
+    end
+
+    it "raises NotImplementedError for #clear" do
+      expect { base.clear }.to raise_error(NotImplementedError, /clear/)
+    end
+
+    it "raises NotImplementedError for #with_lock" do
+      expect { base.with_lock("key") { nil } }.to raise_error(NotImplementedError, /with_lock/)
+    end
+
+    it "raises NotImplementedError for #age" do
+      expect { base.age("key") }.to raise_error(NotImplementedError, /age/)
+    end
+
+    it "raises NotImplementedError for #expired?" do
+      expect { base.expired?("key") }.to raise_error(NotImplementedError, /expired\?/)
+    end
+
+    it "raises NotImplementedError for #size" do
+      expect { base.size("key") }.to raise_error(NotImplementedError, /size/)
+    end
+
+    it "raises NotImplementedError for #each" do
+      expect { base.each }.to raise_error(NotImplementedError, /each/)
+    end
+  end
+end

--- a/spec/factorix/cache/entry_spec.rb
+++ b/spec/factorix/cache/entry_spec.rb
@@ -2,18 +2,18 @@
 
 RSpec.describe Factorix::Cache::Entry do
   describe ".new" do
-    it "creates an entry with size, age, and expired attributes" do
+    it "creates an entry with size, age, and expired? attributes" do
       entry = Factorix::Cache::Entry.new(size: 1024, age: 3600.5, expired: false)
 
       expect(entry.size).to eq(1024)
       expect(entry.age).to eq(3600.5)
-      expect(entry.expired).to be false
+      expect(entry).not_to be_expired
     end
 
     it "creates an expired entry" do
       entry = Factorix::Cache::Entry.new(size: 512, age: 7200.0, expired: true)
 
-      expect(entry.expired).to be true
+      expect(entry).to be_expired
     end
   end
 
@@ -40,8 +40,8 @@ RSpec.describe Factorix::Cache::Entry do
 
       expect(new_entry.size).to eq(100)
       expect(new_entry.age).to eq(50.0)
-      expect(new_entry.expired).to be true
-      expect(entry.expired).to be false
+      expect(new_entry).to be_expired
+      expect(entry).not_to be_expired
     end
   end
 

--- a/spec/factorix/cache/entry_spec.rb
+++ b/spec/factorix/cache/entry_spec.rb
@@ -1,0 +1,60 @@
+# frozen_string_literal: true
+
+RSpec.describe Factorix::Cache::Entry do
+  describe ".new" do
+    it "creates an entry with size, age, and expired attributes" do
+      entry = Factorix::Cache::Entry.new(size: 1024, age: 3600.5, expired: false)
+
+      expect(entry.size).to eq(1024)
+      expect(entry.age).to eq(3600.5)
+      expect(entry.expired).to be false
+    end
+
+    it "creates an expired entry" do
+      entry = Factorix::Cache::Entry.new(size: 512, age: 7200.0, expired: true)
+
+      expect(entry.expired).to be true
+    end
+  end
+
+  describe "#==" do
+    it "considers entries with same attributes equal" do
+      entry1 = Factorix::Cache::Entry.new(size: 100, age: 50.0, expired: false)
+      entry2 = Factorix::Cache::Entry.new(size: 100, age: 50.0, expired: false)
+
+      expect(entry1).to eq(entry2)
+    end
+
+    it "considers entries with different attributes not equal" do
+      entry1 = Factorix::Cache::Entry.new(size: 100, age: 50.0, expired: false)
+      entry2 = Factorix::Cache::Entry.new(size: 200, age: 50.0, expired: false)
+
+      expect(entry1).not_to eq(entry2)
+    end
+  end
+
+  describe "#with" do
+    it "creates a new entry with updated attributes" do
+      entry = Factorix::Cache::Entry.new(size: 100, age: 50.0, expired: false)
+      new_entry = entry.with(expired: true)
+
+      expect(new_entry.size).to eq(100)
+      expect(new_entry.age).to eq(50.0)
+      expect(new_entry.expired).to be true
+      expect(entry.expired).to be false
+    end
+  end
+
+  describe "#deconstruct_keys" do
+    it "supports pattern matching" do
+      entry = Factorix::Cache::Entry.new(size: 1024, age: 100.0, expired: true)
+
+      case entry
+      in {size: s, expired: true}
+        expect(s).to eq(1024)
+      else
+        raise RuntimeError, "Pattern should have matched"
+      end
+    end
+  end
+end

--- a/spec/factorix/cache/file_system_spec.rb
+++ b/spec/factorix/cache/file_system_spec.rb
@@ -86,7 +86,7 @@ RSpec.describe Factorix::Cache::FileSystem do
     end
   end
 
-  describe "#fetch" do
+  describe "#write_to" do
     let(:output_file) { Pathname(Dir.mktmpdir("output")) + "file.zip" }
 
     after do
@@ -100,14 +100,14 @@ RSpec.describe Factorix::Cache::FileSystem do
       end
 
       it "copies the cache file to the output path" do
-        expect(cache.fetch(logical_key, output_file)).to be true
+        expect(cache.write_to(logical_key, output_file)).to be true
         expect(output_file.read).to eq("cached content")
       end
     end
 
     context "when the cache file does not exist" do
       it "returns false" do
-        expect(cache.fetch(logical_key, output_file)).to be false
+        expect(cache.write_to(logical_key, output_file)).to be false
         expect(output_file).not_to exist
       end
     end
@@ -122,7 +122,7 @@ RSpec.describe Factorix::Cache::FileSystem do
 
       it "returns false for expired cache" do
         FileUtils.touch(cache_path, mtime: Time.now - 20)
-        expect(cache.fetch(logical_key, output_file)).to be false
+        expect(cache.write_to(logical_key, output_file)).to be false
         expect(output_file).not_to exist
       end
     end
@@ -133,8 +133,8 @@ RSpec.describe Factorix::Cache::FileSystem do
         cache_path.binwrite(Zlib.deflate("compressed content"))
       end
 
-      it "decompresses the data when fetching" do
-        expect(cache.fetch(logical_key, output_file)).to be true
+      it "decompresses the data when writing" do
+        expect(cache.write_to(logical_key, output_file)).to be true
         expect(output_file.read).to eq("compressed content")
       end
     end

--- a/spec/factorix/cache/file_system_spec.rb
+++ b/spec/factorix/cache/file_system_spec.rb
@@ -8,7 +8,7 @@ require "tmpdir"
 
 RSpec.describe Factorix::Cache::FileSystem do
   let(:cache_dir) { Pathname(Dir.mktmpdir("cache")) }
-  let(:cache) { Factorix::Cache::FileSystem.new(dir: cache_dir) }
+  let(:cache) { Factorix::Cache::FileSystem.new(root: cache_dir) }
   let(:url) { "https://example.com/file.zip" }
   let(:logical_key) { url }
   let(:internal_key) { Digest(:SHA1).hexdigest(logical_key) }
@@ -24,23 +24,23 @@ RSpec.describe Factorix::Cache::FileSystem do
     it "creates the cache directory if it does not exist" do
       FileUtils.remove_entry(cache_dir)
       expect {
-        Factorix::Cache::FileSystem.new(dir: cache_dir)
+        Factorix::Cache::FileSystem.new(root: cache_dir)
       }.to change(cache_dir, :exist?).from(false).to(true)
     end
 
     it "accepts ttl parameter" do
-      cache_with_ttl = Factorix::Cache::FileSystem.new(dir: cache_dir, ttl: 3600)
+      cache_with_ttl = Factorix::Cache::FileSystem.new(root: cache_dir, ttl: 3600)
       expect(cache_with_ttl).to be_a(Factorix::Cache::FileSystem)
       expect(cache_with_ttl.ttl).to eq(3600)
     end
 
     it "accepts max_file_size parameter" do
-      cache_with_limit = Factorix::Cache::FileSystem.new(dir: cache_dir, max_file_size: 1024 * 1024)
+      cache_with_limit = Factorix::Cache::FileSystem.new(root: cache_dir, max_file_size: 1024 * 1024)
       expect(cache_with_limit).to be_a(Factorix::Cache::FileSystem)
     end
 
     it "accepts compression_threshold parameter" do
-      cache_with_compression = Factorix::Cache::FileSystem.new(dir: cache_dir, compression_threshold: 0)
+      cache_with_compression = Factorix::Cache::FileSystem.new(root: cache_dir, compression_threshold: 0)
       expect(cache_with_compression).to be_a(Factorix::Cache::FileSystem)
     end
 
@@ -68,7 +68,7 @@ RSpec.describe Factorix::Cache::FileSystem do
     end
 
     context "with TTL" do
-      let(:cache) { Factorix::Cache::FileSystem.new(dir: cache_dir, ttl: 10) }
+      let(:cache) { Factorix::Cache::FileSystem.new(root: cache_dir, ttl: 10) }
 
       before do
         cache_path.dirname.mkpath
@@ -113,7 +113,7 @@ RSpec.describe Factorix::Cache::FileSystem do
     end
 
     context "with TTL" do
-      let(:cache) { Factorix::Cache::FileSystem.new(dir: cache_dir, ttl: 10) }
+      let(:cache) { Factorix::Cache::FileSystem.new(root: cache_dir, ttl: 10) }
 
       before do
         cache_path.dirname.mkpath
@@ -168,7 +168,7 @@ RSpec.describe Factorix::Cache::FileSystem do
     end
 
     context "with TTL" do
-      let(:cache) { Factorix::Cache::FileSystem.new(dir: cache_dir, ttl: 10) }
+      let(:cache) { Factorix::Cache::FileSystem.new(root: cache_dir, ttl: 10) }
 
       before do
         cache_path.dirname.mkpath
@@ -232,7 +232,7 @@ RSpec.describe Factorix::Cache::FileSystem do
     end
 
     context "with max_file_size limit" do
-      let(:cache) { Factorix::Cache::FileSystem.new(dir: cache_dir, max_file_size: 10) }
+      let(:cache) { Factorix::Cache::FileSystem.new(root: cache_dir, max_file_size: 10) }
 
       it "stores files within the limit" do
         small_file = Pathname(Dir.mktmpdir("small")) + "small.txt"
@@ -256,7 +256,7 @@ RSpec.describe Factorix::Cache::FileSystem do
     end
 
     context "with compression_threshold: 0 (always compress)" do
-      let(:cache) { Factorix::Cache::FileSystem.new(dir: cache_dir, compression_threshold: 0) }
+      let(:cache) { Factorix::Cache::FileSystem.new(root: cache_dir, compression_threshold: 0) }
 
       it "stores compressed data" do
         expect(cache.store(logical_key, source_file)).to be true
@@ -281,7 +281,7 @@ RSpec.describe Factorix::Cache::FileSystem do
     end
 
     context "with compression_threshold: N (compress if >= N bytes)" do
-      let(:cache) { Factorix::Cache::FileSystem.new(dir: cache_dir, compression_threshold: 100) }
+      let(:cache) { Factorix::Cache::FileSystem.new(root: cache_dir, compression_threshold: 100) }
 
       it "compresses files meeting the threshold" do
         large_file = Pathname(Dir.mktmpdir("large")) + "large.txt"
@@ -309,7 +309,7 @@ RSpec.describe Factorix::Cache::FileSystem do
     end
 
     context "with max_file_size and compression" do
-      let(:cache) { Factorix::Cache::FileSystem.new(dir: cache_dir, max_file_size: 50, compression_threshold: 0) }
+      let(:cache) { Factorix::Cache::FileSystem.new(root: cache_dir, max_file_size: 50, compression_threshold: 0) }
 
       it "uses compressed size for max_file_size check" do
         # Create a file that exceeds 50 bytes uncompressed but compresses to under 50
@@ -399,7 +399,7 @@ RSpec.describe Factorix::Cache::FileSystem do
     end
 
     context "with TTL" do
-      let(:cache) { Factorix::Cache::FileSystem.new(dir: cache_dir, ttl: 50) }
+      let(:cache) { Factorix::Cache::FileSystem.new(root: cache_dir, ttl: 50) }
 
       before do
         cache_path.dirname.mkpath
@@ -417,7 +417,7 @@ RSpec.describe Factorix::Cache::FileSystem do
     end
 
     context "when cache file does not exist" do
-      let(:cache) { Factorix::Cache::FileSystem.new(dir: cache_dir, ttl: 50) }
+      let(:cache) { Factorix::Cache::FileSystem.new(root: cache_dir, ttl: 50) }
 
       it "returns false" do
         expect(cache.expired?(logical_key)).to be false
@@ -444,7 +444,7 @@ RSpec.describe Factorix::Cache::FileSystem do
     end
 
     context "with TTL" do
-      let(:cache) { Factorix::Cache::FileSystem.new(dir: cache_dir, ttl: 10) }
+      let(:cache) { Factorix::Cache::FileSystem.new(root: cache_dir, ttl: 10) }
 
       before do
         cache_path.dirname.mkpath
@@ -555,7 +555,7 @@ RSpec.describe Factorix::Cache::FileSystem do
 
     context "with expired entries" do
       let(:source_file) { Pathname(Dir.mktmpdir("source")) + "data.txt" }
-      let(:cache) { Factorix::Cache::FileSystem.new(dir: cache_dir, ttl: 10) }
+      let(:cache) { Factorix::Cache::FileSystem.new(root: cache_dir, ttl: 10) }
 
       before do
         File.write(source_file, "test")

--- a/spec/factorix/cache/file_system_spec.rb
+++ b/spec/factorix/cache/file_system_spec.rb
@@ -1,15 +1,19 @@
 # frozen_string_literal: true
 
+require "digest"
 require "fileutils"
+require "json"
 require "pathname"
 require "tmpdir"
 
 RSpec.describe Factorix::Cache::FileSystem do
   let(:cache_dir) { Pathname(Dir.mktmpdir("cache")) }
-  let(:cache) { Factorix::Cache::FileSystem.new(cache_dir) }
+  let(:cache) { Factorix::Cache::FileSystem.new(dir: cache_dir) }
   let(:url) { "https://example.com/file.zip" }
-  let(:key) { cache.key_for(url) }
-  let(:cache_path) { cache_dir + key[0, 2] + key[2..] }
+  let(:logical_key) { url }
+  let(:internal_key) { Digest(:SHA1).hexdigest(logical_key) }
+  let(:cache_path) { cache_dir + internal_key[0, 2] + internal_key[2..] }
+  let(:metadata_path) { Pathname("#{cache_path}.metadata") }
   let(:lock_path) { cache_path.sub_ext(".lock") }
 
   after do
@@ -20,30 +24,28 @@ RSpec.describe Factorix::Cache::FileSystem do
     it "creates the cache directory if it does not exist" do
       FileUtils.remove_entry(cache_dir)
       expect {
-        Factorix::Cache::FileSystem.new(cache_dir)
+        Factorix::Cache::FileSystem.new(dir: cache_dir)
       }.to change(cache_dir, :exist?).from(false).to(true)
     end
 
     it "accepts ttl parameter" do
-      cache_with_ttl = Factorix::Cache::FileSystem.new(cache_dir, ttl: 3600)
+      cache_with_ttl = Factorix::Cache::FileSystem.new(dir: cache_dir, ttl: 3600)
       expect(cache_with_ttl).to be_a(Factorix::Cache::FileSystem)
+      expect(cache_with_ttl.ttl).to eq(3600)
     end
 
     it "accepts max_file_size parameter" do
-      cache_with_limit = Factorix::Cache::FileSystem.new(cache_dir, max_file_size: 1024 * 1024)
+      cache_with_limit = Factorix::Cache::FileSystem.new(dir: cache_dir, max_file_size: 1024 * 1024)
       expect(cache_with_limit).to be_a(Factorix::Cache::FileSystem)
     end
 
     it "accepts compression_threshold parameter" do
-      cache_with_compression = Factorix::Cache::FileSystem.new(cache_dir, compression_threshold: 0)
+      cache_with_compression = Factorix::Cache::FileSystem.new(dir: cache_dir, compression_threshold: 0)
       expect(cache_with_compression).to be_a(Factorix::Cache::FileSystem)
     end
-  end
 
-  describe "#key_for" do
-    it "generates a SHA1 hash of the URL" do
-      expect(key).to match(/\A[0-9a-f]{40}\z/)
-      expect(key).to eq(Digest::SHA1.hexdigest(url))
+    it "inherits from Base" do
+      expect(Factorix::Cache::FileSystem.superclass).to eq(Factorix::Cache::Base)
     end
   end
 
@@ -55,18 +57,18 @@ RSpec.describe Factorix::Cache::FileSystem do
       end
 
       it "returns true" do
-        expect(cache.exist?(key)).to be true
+        expect(cache.exist?(logical_key)).to be true
       end
     end
 
     context "when the cache file does not exist" do
       it "returns false" do
-        expect(cache.exist?(key)).to be false
+        expect(cache.exist?(logical_key)).to be false
       end
     end
 
     context "with TTL" do
-      let(:cache) { Factorix::Cache::FileSystem.new(cache_dir, ttl: 10) }
+      let(:cache) { Factorix::Cache::FileSystem.new(dir: cache_dir, ttl: 10) }
 
       before do
         cache_path.dirname.mkpath
@@ -74,12 +76,12 @@ RSpec.describe Factorix::Cache::FileSystem do
       end
 
       it "returns true for non-expired cache" do
-        expect(cache.exist?(key)).to be true
+        expect(cache.exist?(logical_key)).to be true
       end
 
       it "returns false for expired cache" do
         FileUtils.touch(cache_path, mtime: Time.now - 20)
-        expect(cache.exist?(key)).to be false
+        expect(cache.exist?(logical_key)).to be false
       end
     end
   end
@@ -98,20 +100,20 @@ RSpec.describe Factorix::Cache::FileSystem do
       end
 
       it "copies the cache file to the output path" do
-        expect(cache.fetch(key, output_file)).to be true
+        expect(cache.fetch(logical_key, output_file)).to be true
         expect(output_file.read).to eq("cached content")
       end
     end
 
     context "when the cache file does not exist" do
       it "returns false" do
-        expect(cache.fetch(key, output_file)).to be false
+        expect(cache.fetch(logical_key, output_file)).to be false
         expect(output_file).not_to exist
       end
     end
 
     context "with TTL" do
-      let(:cache) { Factorix::Cache::FileSystem.new(cache_dir, ttl: 10) }
+      let(:cache) { Factorix::Cache::FileSystem.new(dir: cache_dir, ttl: 10) }
 
       before do
         cache_path.dirname.mkpath
@@ -120,7 +122,7 @@ RSpec.describe Factorix::Cache::FileSystem do
 
       it "returns false for expired cache" do
         FileUtils.touch(cache_path, mtime: Time.now - 20)
-        expect(cache.fetch(key, output_file)).to be false
+        expect(cache.fetch(logical_key, output_file)).to be false
         expect(output_file).not_to exist
       end
     end
@@ -132,7 +134,7 @@ RSpec.describe Factorix::Cache::FileSystem do
       end
 
       it "decompresses the data when fetching" do
-        expect(cache.fetch(key, output_file)).to be true
+        expect(cache.fetch(logical_key, output_file)).to be true
         expect(output_file.read).to eq("compressed content")
       end
     end
@@ -146,14 +148,14 @@ RSpec.describe Factorix::Cache::FileSystem do
       end
 
       it "reads the cache file as a binary string by default" do
-        content = cache.read(key)
+        content = cache.read(logical_key)
         expect(content).to eq("cached content")
         expect(content.encoding).to eq(Encoding::ASCII_8BIT)
       end
 
       it "reads the cache file with specified encoding" do
         File.write(cache_path, "日本語コンテンツ")
-        content = cache.read(key, encoding: Encoding::UTF_8)
+        content = cache.read(logical_key, encoding: Encoding::UTF_8)
         expect(content).to eq("日本語コンテンツ")
         expect(content.encoding).to eq(Encoding::UTF_8)
       end
@@ -161,12 +163,12 @@ RSpec.describe Factorix::Cache::FileSystem do
 
     context "when the cache file does not exist" do
       it "returns nil" do
-        expect(cache.read(key)).to be_nil
+        expect(cache.read(logical_key)).to be_nil
       end
     end
 
     context "with TTL" do
-      let(:cache) { Factorix::Cache::FileSystem.new(cache_dir, ttl: 10) }
+      let(:cache) { Factorix::Cache::FileSystem.new(dir: cache_dir, ttl: 10) }
 
       before do
         cache_path.dirname.mkpath
@@ -175,7 +177,7 @@ RSpec.describe Factorix::Cache::FileSystem do
 
       it "returns nil for expired cache" do
         FileUtils.touch(cache_path, mtime: Time.now - 20)
-        expect(cache.read(key)).to be_nil
+        expect(cache.read(logical_key)).to be_nil
       end
     end
 
@@ -186,13 +188,13 @@ RSpec.describe Factorix::Cache::FileSystem do
       end
 
       it "decompresses the data when reading" do
-        content = cache.read(key)
+        content = cache.read(logical_key)
         expect(content).to eq("compressed content")
       end
 
       it "applies the specified encoding after decompression" do
         cache_path.binwrite(Zlib.deflate("日本語コンテンツ"))
-        content = cache.read(key, encoding: Encoding::UTF_8)
+        content = cache.read(logical_key, encoding: Encoding::UTF_8)
         expect(content).to eq("日本語コンテンツ")
         expect(content.encoding).to eq(Encoding::UTF_8)
       end
@@ -211,25 +213,32 @@ RSpec.describe Factorix::Cache::FileSystem do
     end
 
     it "copies the source file to the cache" do
-      expect(cache.store(key, source_file)).to be true
+      expect(cache.store(logical_key, source_file)).to be true
       expect(cache_path).to exist
       expect(cache_path.read).to eq("source content")
     end
 
     it "creates the cache subdirectory" do
       expect {
-        cache.store(key, source_file)
+        cache.store(logical_key, source_file)
       }.to change(cache_path.dirname, :exist?).from(false).to(true)
     end
 
+    it "creates a metadata file with the logical key" do
+      cache.store(logical_key, source_file)
+      expect(metadata_path).to exist
+      metadata = JSON.parse(metadata_path.read)
+      expect(metadata["logical_key"]).to eq(logical_key)
+    end
+
     context "with max_file_size limit" do
-      let(:cache) { Factorix::Cache::FileSystem.new(cache_dir, max_file_size: 10) }
+      let(:cache) { Factorix::Cache::FileSystem.new(dir: cache_dir, max_file_size: 10) }
 
       it "stores files within the limit" do
         small_file = Pathname(Dir.mktmpdir("small")) + "small.txt"
         File.write(small_file, "small")
 
-        expect(cache.store(key, small_file)).to be true
+        expect(cache.store(logical_key, small_file)).to be true
         expect(cache_path).to exist
 
         FileUtils.remove_entry(small_file.dirname)
@@ -239,7 +248,7 @@ RSpec.describe Factorix::Cache::FileSystem do
         large_file = Pathname(Dir.mktmpdir("large")) + "large.txt"
         File.write(large_file, "a" * 100)
 
-        expect(cache.store(key, large_file)).to be false
+        expect(cache.store(logical_key, large_file)).to be false
         expect(cache_path).not_to exist
 
         FileUtils.remove_entry(large_file.dirname)
@@ -247,10 +256,10 @@ RSpec.describe Factorix::Cache::FileSystem do
     end
 
     context "with compression_threshold: 0 (always compress)" do
-      let(:cache) { Factorix::Cache::FileSystem.new(cache_dir, compression_threshold: 0) }
+      let(:cache) { Factorix::Cache::FileSystem.new(dir: cache_dir, compression_threshold: 0) }
 
       it "stores compressed data" do
-        expect(cache.store(key, source_file)).to be true
+        expect(cache.store(logical_key, source_file)).to be true
         expect(cache_path).to exist
 
         # Verify the stored data is zlib-compressed (starts with 0x78)
@@ -263,7 +272,7 @@ RSpec.describe Factorix::Cache::FileSystem do
         compressible_file = Pathname(Dir.mktmpdir("compress")) + "data.txt"
         File.write(compressible_file, "a" * 1000)
 
-        cache.store(key, compressible_file)
+        cache.store(logical_key, compressible_file)
 
         expect(cache_path.size).to be < 1000
 
@@ -272,13 +281,13 @@ RSpec.describe Factorix::Cache::FileSystem do
     end
 
     context "with compression_threshold: N (compress if >= N bytes)" do
-      let(:cache) { Factorix::Cache::FileSystem.new(cache_dir, compression_threshold: 100) }
+      let(:cache) { Factorix::Cache::FileSystem.new(dir: cache_dir, compression_threshold: 100) }
 
       it "compresses files meeting the threshold" do
         large_file = Pathname(Dir.mktmpdir("large")) + "large.txt"
         File.write(large_file, "a" * 200)
 
-        cache.store(key, large_file)
+        cache.store(logical_key, large_file)
 
         stored_data = cache_path.binread
         expect(stored_data.getbyte(0)).to eq(0x78)
@@ -290,7 +299,7 @@ RSpec.describe Factorix::Cache::FileSystem do
         small_file = Pathname(Dir.mktmpdir("small")) + "small.txt"
         File.write(small_file, "small data")
 
-        cache.store(key, small_file)
+        cache.store(logical_key, small_file)
 
         stored_data = cache_path.binread
         expect(stored_data).to eq("small data")
@@ -300,14 +309,14 @@ RSpec.describe Factorix::Cache::FileSystem do
     end
 
     context "with max_file_size and compression" do
-      let(:cache) { Factorix::Cache::FileSystem.new(cache_dir, max_file_size: 50, compression_threshold: 0) }
+      let(:cache) { Factorix::Cache::FileSystem.new(dir: cache_dir, max_file_size: 50, compression_threshold: 0) }
 
       it "uses compressed size for max_file_size check" do
         # Create a file that exceeds 50 bytes uncompressed but compresses to under 50
         compressible_file = Pathname(Dir.mktmpdir("compress")) + "data.txt"
         File.write(compressible_file, "a" * 200)
 
-        expect(cache.store(key, compressible_file)).to be true
+        expect(cache.store(logical_key, compressible_file)).to be true
         expect(cache_path).to exist
 
         FileUtils.remove_entry(compressible_file.dirname)
@@ -320,36 +329,44 @@ RSpec.describe Factorix::Cache::FileSystem do
       before do
         cache_path.dirname.mkpath
         FileUtils.touch(cache_path)
+        metadata_path.write(JSON.generate({logical_key:}))
       end
 
       it "deletes the cache file and returns true" do
-        expect(cache.delete(key)).to be true
+        expect(cache.delete(logical_key)).to be true
         expect(cache_path).not_to exist
+      end
+
+      it "deletes the metadata file" do
+        cache.delete(logical_key)
+        expect(metadata_path).not_to exist
       end
     end
 
     context "when the cache file does not exist" do
       it "returns false" do
-        expect(cache.delete(key)).to be false
+        expect(cache.delete(logical_key)).to be false
       end
     end
   end
 
   describe "#clear" do
     before do
-      # Create multiple cache entries
+      # Create multiple cache entries with metadata
       3.times do |i|
-        test_key = cache.key_for("https://example.com/file#{i}.zip")
-        test_path = cache_dir + test_key[0, 2] + test_key[2..]
+        test_url = "https://example.com/file#{i}.zip"
+        test_internal_key = Digest(:SHA1).hexdigest(test_url)
+        test_path = cache_dir + test_internal_key[0, 2] + test_internal_key[2..]
         test_path.dirname.mkpath
         FileUtils.touch(test_path)
+        Pathname("#{test_path}.metadata").write(JSON.generate({logical_key: test_url}))
       end
     end
 
-    it "removes all cache files" do
+    it "removes all cache files and metadata" do
       cache.clear
 
-      cache_files = cache_dir.glob("**/*").select(&:file?)
+      cache_files = cache_dir.glob("**/*").select {|f| f.file? && f.extname != ".lock" }
       expect(cache_files).to be_empty
     end
   end
@@ -362,14 +379,14 @@ RSpec.describe Factorix::Cache::FileSystem do
       end
 
       it "returns the age in seconds" do
-        age = cache.age(key)
+        age = cache.age(logical_key)
         expect(age).to be_within(1).of(100)
       end
     end
 
     context "when the cache file does not exist" do
       it "returns nil" do
-        expect(cache.age(key)).to be_nil
+        expect(cache.age(logical_key)).to be_nil
       end
     end
   end
@@ -377,12 +394,12 @@ RSpec.describe Factorix::Cache::FileSystem do
   describe "#expired?" do
     context "without TTL" do
       it "always returns false" do
-        expect(cache.expired?(key)).to be false
+        expect(cache.expired?(logical_key)).to be false
       end
     end
 
     context "with TTL" do
-      let(:cache) { Factorix::Cache::FileSystem.new(cache_dir, ttl: 50) }
+      let(:cache) { Factorix::Cache::FileSystem.new(dir: cache_dir, ttl: 50) }
 
       before do
         cache_path.dirname.mkpath
@@ -390,20 +407,20 @@ RSpec.describe Factorix::Cache::FileSystem do
       end
 
       it "returns true for expired cache" do
-        expect(cache.expired?(key)).to be true
+        expect(cache.expired?(logical_key)).to be true
       end
 
       it "returns false for non-expired cache" do
         FileUtils.touch(cache_path, mtime: Time.now - 30)
-        expect(cache.expired?(key)).to be false
+        expect(cache.expired?(logical_key)).to be false
       end
     end
 
     context "when cache file does not exist" do
-      let(:cache) { Factorix::Cache::FileSystem.new(cache_dir, ttl: 50) }
+      let(:cache) { Factorix::Cache::FileSystem.new(dir: cache_dir, ttl: 50) }
 
       it "returns false" do
-        expect(cache.expired?(key)).to be false
+        expect(cache.expired?(logical_key)).to be false
       end
     end
   end
@@ -416,18 +433,18 @@ RSpec.describe Factorix::Cache::FileSystem do
       end
 
       it "returns the file size in bytes" do
-        expect(cache.size(key)).to eq(14) # "cached content" is 14 bytes
+        expect(cache.size(logical_key)).to eq(14) # "cached content" is 14 bytes
       end
     end
 
     context "when the cache file does not exist" do
       it "returns nil" do
-        expect(cache.size(key)).to be_nil
+        expect(cache.size(logical_key)).to be_nil
       end
     end
 
     context "with TTL" do
-      let(:cache) { Factorix::Cache::FileSystem.new(cache_dir, ttl: 10) }
+      let(:cache) { Factorix::Cache::FileSystem.new(dir: cache_dir, ttl: 10) }
 
       before do
         cache_path.dirname.mkpath
@@ -435,12 +452,12 @@ RSpec.describe Factorix::Cache::FileSystem do
       end
 
       it "returns the size for non-expired cache" do
-        expect(cache.size(key)).to eq(14)
+        expect(cache.size(logical_key)).to eq(14)
       end
 
       it "returns nil for expired cache" do
         FileUtils.touch(cache_path, mtime: Time.now - 20)
-        expect(cache.size(key)).to be_nil
+        expect(cache.size(logical_key)).to be_nil
       end
     end
   end
@@ -451,17 +468,17 @@ RSpec.describe Factorix::Cache::FileSystem do
     end
 
     it "creates and removes the lock file" do
-      cache.with_lock(key) { nil } # Empty block intentional - testing lock lifecycle
+      cache.with_lock(logical_key) { nil } # Empty block intentional - testing lock lifecycle
       expect(lock_path).not_to exist
     end
 
     it "yields to the block" do
-      expect {|b| cache.with_lock(key, &b) }.to yield_control
+      expect {|b| cache.with_lock(logical_key, &b) }.to yield_control
     end
 
     it "ensures the lock file is removed even if the block raises an error" do
       expect {
-        cache.with_lock(key) { raise RuntimeError, "error" }
+        cache.with_lock(logical_key) { raise RuntimeError, "error" }
       }.to raise_error(RuntimeError, "error")
       expect(lock_path).not_to exist
     end
@@ -474,7 +491,7 @@ RSpec.describe Factorix::Cache::FileSystem do
       end
 
       it "removes the stale lock file" do
-        cache.with_lock(key) { nil } # Empty block intentional - testing stale lock cleanup
+        cache.with_lock(logical_key) { nil } # Empty block intentional - testing stale lock cleanup
         expect(lock_path).not_to exist
       end
     end
@@ -489,8 +506,83 @@ RSpec.describe Factorix::Cache::FileSystem do
         # This test is a bit tricky because we can't easily test file locking
         # Instead, we just verify that the code doesn't raise any errors
         expect {
-          cache.with_lock(key) { nil } # Empty block intentional - testing lock behavior
+          cache.with_lock(logical_key) { nil } # Empty block intentional - testing lock behavior
         }.not_to raise_error
+      end
+    end
+  end
+
+  describe "#each" do
+    context "with no cache entries" do
+      it "returns an empty enumerator" do
+        expect(cache.each.to_a).to be_empty
+      end
+    end
+
+    context "with cache entries" do
+      let(:urls) { ["https://example.com/a.zip", "https://example.com/b.zip", "https://example.com/c.zip"] }
+      let(:source_file) { Pathname(Dir.mktmpdir("source")) + "data.txt" }
+
+      before do
+        File.write(source_file, "test content")
+        urls.each {|u| cache.store(u, source_file) }
+      end
+
+      after do
+        FileUtils.remove_entry(source_file.dirname)
+      end
+
+      it "yields each key and entry pair" do
+        yielded_keys = []
+        cache.each {|key, _entry| yielded_keys << key }
+        expect(yielded_keys.sort).to eq(urls.sort)
+      end
+
+      it "yields Entry objects with correct attributes" do
+        cache.each do |_key, entry|
+          expect(entry).to be_a(Factorix::Cache::Entry)
+          expect(entry.size).to eq(12) # "test content" is 12 bytes
+          expect(entry.age).to be_within(1).of(0)
+          expect(entry.expired).to be false
+        end
+      end
+
+      it "returns an enumerator when no block given" do
+        expect(cache.each).to be_a(Enumerator)
+        expect(cache.each.count).to eq(3)
+      end
+    end
+
+    context "with expired entries" do
+      let(:source_file) { Pathname(Dir.mktmpdir("source")) + "data.txt" }
+      let(:cache) { Factorix::Cache::FileSystem.new(dir: cache_dir, ttl: 10) }
+
+      before do
+        File.write(source_file, "test")
+        cache.store(logical_key, source_file)
+        FileUtils.touch(cache_path, mtime: Time.now - 20)
+      end
+
+      after do
+        FileUtils.remove_entry(source_file.dirname)
+      end
+
+      it "marks entry as expired" do
+        cache.each do |_key, entry|
+          expect(entry.expired).to be true
+        end
+      end
+    end
+
+    context "with entries without metadata (legacy entries)" do
+      before do
+        # Create a cache file without metadata
+        cache_path.dirname.mkpath
+        File.write(cache_path, "legacy content")
+      end
+
+      it "skips entries without metadata" do
+        expect(cache.each.to_a).to be_empty
       end
     end
   end

--- a/spec/factorix/cache/file_system_spec.rb
+++ b/spec/factorix/cache/file_system_spec.rb
@@ -543,7 +543,7 @@ RSpec.describe Factorix::Cache::FileSystem do
           expect(entry).to be_a(Factorix::Cache::Entry)
           expect(entry.size).to eq(12) # "test content" is 12 bytes
           expect(entry.age).to be_within(1).of(0)
-          expect(entry.expired).to be false
+          expect(entry).not_to be_expired
         end
       end
 
@@ -569,7 +569,7 @@ RSpec.describe Factorix::Cache::FileSystem do
 
       it "marks entry as expired" do
         cache.each do |_key, entry|
-          expect(entry.expired).to be true
+          expect(entry).to be_expired
         end
       end
     end

--- a/spec/factorix/cli/commands/cache/evict_spec.rb
+++ b/spec/factorix/cli/commands/cache/evict_spec.rb
@@ -1,6 +1,6 @@
 # frozen_string_literal: true
 
-RSpec.describe Factorix::CLI::Commands::Cache::Evict, :with_test_caches do
+RSpec.describe Factorix::CLI::Commands::Cache::Evict do
   let(:command) { Factorix::CLI::Commands::Cache::Evict.new }
 
   describe "#call" do

--- a/spec/factorix/cli/commands/cache/evict_spec.rb
+++ b/spec/factorix/cli/commands/cache/evict_spec.rb
@@ -9,7 +9,7 @@ RSpec.describe Factorix::CLI::Commands::Cache::Evict do
     %i[download api info_json].each do |name|
       dir = cache_dir / name.to_s
       dir.mkpath
-      allow(Factorix.config.cache.public_send(name)).to receive(:dir).and_return(dir)
+      allow(Factorix.config.cache.public_send(name).file_system).to receive(:dir).and_return(dir)
     end
   end
 

--- a/spec/factorix/cli/commands/cache/evict_spec.rb
+++ b/spec/factorix/cli/commands/cache/evict_spec.rb
@@ -1,21 +1,7 @@
 # frozen_string_literal: true
 
-RSpec.describe Factorix::CLI::Commands::Cache::Evict do
+RSpec.describe Factorix::CLI::Commands::Cache::Evict, :with_test_caches do
   let(:command) { Factorix::CLI::Commands::Cache::Evict.new }
-  let(:cache_dir) { Pathname(Dir.mktmpdir) }
-
-  before do
-    # Set up test cache directories
-    %i[download api info_json].each do |name|
-      dir = cache_dir / name.to_s
-      dir.mkpath
-      allow(Factorix.config.cache.public_send(name).file_system).to receive(:dir).and_return(dir)
-    end
-  end
-
-  after do
-    FileUtils.rm_rf(cache_dir)
-  end
 
   describe "#call" do
     context "without any option" do
@@ -32,92 +18,70 @@ RSpec.describe Factorix::CLI::Commands::Cache::Evict do
 
     context "with --all option" do
       before do
-        download_dir = cache_dir / "download"
-        (download_dir / "ab").mkpath
-        (download_dir / "ab" / "cdef1234").write("test content 1")
-        (download_dir / "ab" / "cdef5678").write("test content 2")
+        download_cache.add_entry("http://example.com/file1", "test content 1")
+        download_cache.add_entry("http://example.com/file2", "test content 2")
       end
 
       it "removes all entries" do
         result = run_command(command, %w[--all])
 
         expect(result.stdout).to match(/download.*2 entries removed/)
-        expect((cache_dir / "download").glob("**/*").select(&:file?)).to be_empty
+        expect(download_cache.each.to_a).to be_empty
       end
 
       it "respects cache name argument" do
-        api_dir = cache_dir / "api"
-        (api_dir / "ab").mkpath
-        (api_dir / "ab" / "api_entry").write("api content")
+        api_cache.add_entry("http://example.com/api_entry", "api content")
 
         result = run_command(command, %w[download --all])
 
         expect(result.stdout).to match(/download/)
         expect(result.stdout).not_to match(/\bapi\s*:/)
         # api cache should still have its entry
-        expect(cache_dir / "api" / "ab" / "api_entry").to exist
+        expect(api_cache.exist?("http://example.com/api_entry")).to be true
       end
     end
 
     context "with --expired option" do
       before do
-        api_dir = cache_dir / "api"
-        (api_dir / "ab").mkpath
-
-        # Create an expired file (older than TTL of 3600s)
-        old_file = api_dir / "ab" / "old_entry"
-        old_file.write("old content")
-        FileUtils.touch(old_file, mtime: Time.now - 7200)
-
-        # Create a valid file
-        new_file = api_dir / "ab" / "new_entry"
-        new_file.write("new content")
+        # Create an expired entry (older than TTL of 3600s)
+        api_cache.add_entry("http://example.com/old", "old content", age: 7200)
+        # Create a valid entry
+        api_cache.add_entry("http://example.com/new", "new content", age: 0)
       end
 
       it "removes only expired entries" do
         result = run_command(command, %w[--expired])
 
         expect(result.stdout).to match(/api.*1 entries removed/)
-        expect(cache_dir / "api" / "ab" / "old_entry").not_to exist
-        expect(cache_dir / "api" / "ab" / "new_entry").to exist
+        expect(api_cache.exist?("http://example.com/old")).to be false
+        expect(api_cache.exist?("http://example.com/new")).to be true
       end
 
       it "does not remove entries from caches without TTL" do
-        download_dir = cache_dir / "download"
-        (download_dir / "ab").mkpath
-        old_file = download_dir / "ab" / "old_download"
-        old_file.write("old download content")
-        FileUtils.touch(old_file, mtime: Time.now - 86400) # 1 day old
+        download_cache.add_entry("http://example.com/old", "old download content", age: 86400) # 1 day old
 
         result = run_command(command, %w[--expired])
 
         # download cache has no TTL, so no entries should be removed
         expect(result.stdout).to match(/download.*0 entries removed/)
-        expect(cache_dir / "download" / "ab" / "old_download").to exist
+        expect(download_cache.exist?("http://example.com/old")).to be true
       end
     end
 
     context "with --older-than option" do
       before do
-        download_dir = cache_dir / "download"
-        (download_dir / "ab").mkpath
-
-        # Create an old file
-        old_file = download_dir / "ab" / "old_entry"
-        old_file.write("old content")
-        FileUtils.touch(old_file, mtime: Time.now - 86400) # 1 day old
-
-        # Create a new file
-        new_file = download_dir / "ab" / "new_entry"
-        new_file.write("new content")
+        # Create an old entry
+        download_cache.add_entry("http://example.com/old", "old content", age: 86400) # 1 day old
+        # Create a new entry
+        download_cache.add_entry("http://example.com/new", "new content", age: 0)
       end
 
       it "removes entries older than specified age" do
         result = run_command(command, %w[--older-than=12h])
 
         expect(result.stdout).to match(/download.*1 entries removed/)
-        expect(cache_dir / "download" / "ab" / "old_entry").not_to exist
-        expect(cache_dir / "download" / "ab" / "new_entry").to exist
+        expect(download_cache.exist?("http://example.com/old")).to be false
+        expect(download_cache.exist?("http://example.com/new")).to be true
       end
 
       it "parses various age formats" do
@@ -140,29 +104,11 @@ RSpec.describe Factorix::CLI::Commands::Cache::Evict do
         expect { run_command(command, %w[unknown --all]) }.to raise_error(SystemExit)
       end
     end
-
-    context "with lock files" do
-      before do
-        download_dir = cache_dir / "download"
-        (download_dir / "ab").mkpath
-        (download_dir / "ab" / "entry").write("content")
-        (download_dir / "ab" / "entry.lock").write("")
-      end
-
-      it "does not remove lock files" do
-        run_command(command, %w[--all])
-
-        expect(cache_dir / "download" / "ab" / "entry").not_to exist
-        expect(cache_dir / "download" / "ab" / "entry.lock").to exist
-      end
-    end
   end
 
   describe "output format" do
     before do
-      download_dir = cache_dir / "download"
-      (download_dir / "ab").mkpath
-      (download_dir / "ab" / "entry").write("x" * 2048) # 2 KiB
+      download_cache.add_entry("http://example.com/large", "x" * 2048) # 2 KiB
     end
 
     it "formats sizes using binary prefixes" do

--- a/spec/factorix/cli/commands/cache/stat_spec.rb
+++ b/spec/factorix/cli/commands/cache/stat_spec.rb
@@ -2,7 +2,7 @@
 
 require "json"
 
-RSpec.describe Factorix::CLI::Commands::Cache::Stat, :with_test_caches do
+RSpec.describe Factorix::CLI::Commands::Cache::Stat do
   describe "#call" do
     context "with empty caches" do
       it "outputs statistics in text format" do

--- a/spec/factorix/cli/commands/cache/stat_spec.rb
+++ b/spec/factorix/cli/commands/cache/stat_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Factorix::CLI::Commands::Cache::Stat do
     %i[download api info_json].each do |name|
       dir = cache_dir / name.to_s
       dir.mkpath
-      allow(Factorix.config.cache.public_send(name)).to receive(:dir).and_return(dir)
+      allow(Factorix.config.cache.public_send(name).file_system).to receive(:dir).and_return(dir)
     end
   end
 

--- a/spec/factorix/container_spec.rb
+++ b/spec/factorix/container_spec.rb
@@ -218,36 +218,52 @@ RSpec.describe Factorix::Container do
     describe "cache.download" do
       it "defaults dir to runtime.factorix_cache_dir/download" do
         runtime = Factorix::Container[:runtime]
-        expect(Factorix.config.cache.download.dir).to eq(runtime.factorix_cache_dir / "download")
+        expect(Factorix.config.cache.download.file_system.dir).to eq(runtime.factorix_cache_dir / "download")
+      end
+
+      it "has default backend of :file_system" do
+        expect(Factorix.config.cache.download.backend).to eq(:file_system)
       end
 
       it "has default ttl of nil" do
         expect(Factorix.config.cache.download.ttl).to be_nil
       end
 
+      it "has default lock_timeout of 30" do
+        expect(Factorix.config.cache.download.lock_timeout).to eq(30)
+      end
+
       it "has default max_file_size of nil" do
-        expect(Factorix.config.cache.download.max_file_size).to be_nil
+        expect(Factorix.config.cache.download.file_system.max_file_size).to be_nil
       end
 
       it "can be overridden" do
         custom_path = Pathname("/custom/cache/download")
-        Factorix.config.cache.download.dir = custom_path
-        expect(Factorix.config.cache.download.dir).to eq(custom_path)
+        Factorix.config.cache.download.file_system.dir = custom_path
+        expect(Factorix.config.cache.download.file_system.dir).to eq(custom_path)
       end
     end
 
     describe "cache.api" do
       it "defaults dir to runtime.factorix_cache_dir/api" do
         runtime = Factorix::Container[:runtime]
-        expect(Factorix.config.cache.api.dir).to eq(runtime.factorix_cache_dir / "api")
+        expect(Factorix.config.cache.api.file_system.dir).to eq(runtime.factorix_cache_dir / "api")
+      end
+
+      it "has default backend of :file_system" do
+        expect(Factorix.config.cache.api.backend).to eq(:file_system)
       end
 
       it "has default ttl of 3600 seconds" do
         expect(Factorix.config.cache.api.ttl).to eq(3600)
       end
 
+      it "has default lock_timeout of 30" do
+        expect(Factorix.config.cache.api.lock_timeout).to eq(30)
+      end
+
       it "has default max_file_size of 10MiB" do
-        expect(Factorix.config.cache.api.max_file_size).to eq(10 * 1024 * 1024)
+        expect(Factorix.config.cache.api.file_system.max_file_size).to eq(10 * 1024 * 1024)
       end
     end
 

--- a/spec/factorix/container_spec.rb
+++ b/spec/factorix/container_spec.rb
@@ -230,8 +230,8 @@ RSpec.describe Factorix::Container do
 
       it "can be overridden" do
         custom_path = Pathname("/custom/cache/download")
-        Factorix.config.cache.download.file_system.dir = custom_path
-        expect(Factorix.config.cache.download.file_system.dir).to eq(custom_path)
+        Factorix.config.cache.download.file_system.root = custom_path
+        expect(Factorix.config.cache.download.file_system.root).to eq(custom_path)
       end
     end
 

--- a/spec/factorix/container_spec.rb
+++ b/spec/factorix/container_spec.rb
@@ -229,10 +229,6 @@ RSpec.describe Factorix::Container do
         expect(Factorix.config.cache.download.ttl).to be_nil
       end
 
-      it "has default lock_timeout of 30" do
-        expect(Factorix.config.cache.download.lock_timeout).to eq(30)
-      end
-
       it "has default max_file_size of nil" do
         expect(Factorix.config.cache.download.file_system.max_file_size).to be_nil
       end
@@ -256,10 +252,6 @@ RSpec.describe Factorix::Container do
 
       it "has default ttl of 3600 seconds" do
         expect(Factorix.config.cache.api.ttl).to eq(3600)
-      end
-
-      it "has default lock_timeout of 30" do
-        expect(Factorix.config.cache.api.lock_timeout).to eq(30)
       end
 
       it "has default max_file_size of 10MiB" do

--- a/spec/factorix/container_spec.rb
+++ b/spec/factorix/container_spec.rb
@@ -56,16 +56,16 @@ RSpec.describe Factorix::Container do
     end
 
     describe "[:download_cache]" do
-      it "resolves to a Cache::FileSystem instance" do
+      it "resolves to a Cache::Base instance" do
         download_cache = Factorix::Container[:download_cache]
-        expect(download_cache).to be_a(Factorix::Cache::FileSystem)
+        expect(download_cache).to be_a(Factorix::Cache::Base)
       end
     end
 
     describe "[:api_cache]" do
-      it "resolves to a Cache::FileSystem instance" do
+      it "resolves to a Cache::Base instance" do
         api_cache = Factorix::Container[:api_cache]
-        expect(api_cache).to be_a(Factorix::Cache::FileSystem)
+        expect(api_cache).to be_a(Factorix::Cache::Base)
       end
     end
 
@@ -216,11 +216,6 @@ RSpec.describe Factorix::Container do
     end
 
     describe "cache.download" do
-      it "defaults dir to runtime.factorix_cache_dir/download" do
-        runtime = Factorix::Container[:runtime]
-        expect(Factorix.config.cache.download.file_system.dir).to eq(runtime.factorix_cache_dir / "download")
-      end
-
       it "has default backend of :file_system" do
         expect(Factorix.config.cache.download.backend).to eq(:file_system)
       end
@@ -241,11 +236,6 @@ RSpec.describe Factorix::Container do
     end
 
     describe "cache.api" do
-      it "defaults dir to runtime.factorix_cache_dir/api" do
-        runtime = Factorix::Container[:runtime]
-        expect(Factorix.config.cache.api.file_system.dir).to eq(runtime.factorix_cache_dir / "api")
-      end
-
       it "has default backend of :file_system" do
         expect(Factorix.config.cache.api.backend).to eq(:file_system)
       end

--- a/spec/factorix/http/cache_decorator_spec.rb
+++ b/spec/factorix/http/cache_decorator_spec.rb
@@ -7,12 +7,11 @@ RSpec.describe Factorix::HTTP::CacheDecorator do
   let(:decorator) { Factorix::HTTP::CacheDecorator.new(client:, cache:, logger:) }
 
   let(:uri) { URI("https://example.com/api/data.json") }
-  let(:cache_key) { "cache_key_123" }
+  let(:cache_key) { uri.to_s }
   let(:response) { instance_double(Factorix::HTTP::Response, success?: true, body: "response data") }
 
   before do
     allow(logger).to receive(:debug)
-    allow(cache).to receive(:key_for).with(uri.to_s).and_return(cache_key)
   end
 
   describe "#request" do

--- a/spec/factorix/transfer/downloader_spec.rb
+++ b/spec/factorix/transfer/downloader_spec.rb
@@ -42,7 +42,7 @@ RSpec.describe Factorix::Transfer::Downloader do
       let(:cached_content) { "cached file content" }
 
       before do
-        allow(cache).to receive(:fetch).with(cache_key, output) do
+        allow(cache).to receive(:write_to).with(cache_key, output) do
           output.write(cached_content)
           true
         end
@@ -50,7 +50,7 @@ RSpec.describe Factorix::Transfer::Downloader do
 
       it "fetches the file from cache" do
         downloader.download(uri, output)
-        expect(cache).to have_received(:fetch).with(cache_key, output).once
+        expect(cache).to have_received(:write_to).with(cache_key, output).once
       end
 
       it "does not download the file" do
@@ -77,7 +77,7 @@ RSpec.describe Factorix::Transfer::Downloader do
 
             # After cache invalidation, fetch returns false
             fetch_count = 0
-            allow(cache).to receive(:fetch).with(cache_key, output) do
+            allow(cache).to receive(:write_to).with(cache_key, output) do
               fetch_count += 1
               if fetch_count == 1
                 # First call: cached content (corrupted)
@@ -117,7 +117,7 @@ RSpec.describe Factorix::Transfer::Downloader do
       let(:response_body) { "file content" }
 
       before do
-        allow(cache).to receive(:fetch).with(cache_key, output).and_return(false)
+        allow(cache).to receive(:write_to).with(cache_key, output).and_return(false)
         allow(cache).to receive(:with_lock).with(cache_key).and_yield
         allow(cache).to receive(:store)
 
@@ -141,15 +141,15 @@ RSpec.describe Factorix::Transfer::Downloader do
       end
 
       it "fetches the file from cache after download" do
-        allow(cache).to receive(:fetch).with(cache_key, output).and_return(false)
+        allow(cache).to receive(:write_to).with(cache_key, output).and_return(false)
         downloader.download(uri, output)
-        expect(cache).to have_received(:fetch).with(cache_key, output).exactly(3).times
+        expect(cache).to have_received(:write_to).with(cache_key, output).exactly(3).times
       end
 
       context "when another process is downloading" do
         before do
           fetch_results = [false, true]
-          allow(cache).to receive(:fetch) do
+          allow(cache).to receive(:write_to) do
             fetch_results.shift
           end
         end
@@ -211,7 +211,7 @@ RSpec.describe Factorix::Transfer::Downloader do
 
     context "when download fails with 404" do
       before do
-        allow(cache).to receive(:fetch).with(cache_key, output).and_return(false)
+        allow(cache).to receive(:write_to).with(cache_key, output).and_return(false)
         allow(cache).to receive(:with_lock).with(cache_key).and_yield
         allow(client).to receive(:get).and_raise(Factorix::HTTPNotFoundError.new("404 Not Found"))
       end

--- a/spec/factorix/transfer/downloader_spec.rb
+++ b/spec/factorix/transfer/downloader_spec.rb
@@ -10,7 +10,7 @@ RSpec.describe Factorix::Transfer::Downloader do
   let(:uri) { URI("https://example.com/file.zip") }
   let(:output_dir) { Pathname(Dir.mktmpdir("output")) }
   let(:output) { output_dir.join("file.zip") }
-  let(:cache_key) { "cache_key" }
+  let(:cache_key) { uri.to_s }
 
   around do |example|
     Dir.glob(File.join(Dir.tmpdir, "factorix*")).each do |dir|
@@ -29,7 +29,6 @@ RSpec.describe Factorix::Transfer::Downloader do
   end
 
   before do
-    allow(cache).to receive(:key_for).with("https://example.com/file.zip").and_return(cache_key)
     allow(cache).to receive(:size).and_return(1024)
     allow(client).to receive(:get)
   end

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -52,11 +52,8 @@ RSpec.configure do |config|
     new_runtime = Factorix::Runtime.detect
     Factorix::Container.stub(:runtime, new_runtime)
 
-    # Reset configuration to defaults and reconfigure with new runtime
+    # Reset configuration to defaults
     Factorix.reset_config
-    Factorix.config.cache.download.file_system.dir = new_runtime.factorix_cache_dir / "download"
-    Factorix.config.cache.api.file_system.dir = new_runtime.factorix_cache_dir / "api"
-    Factorix.config.cache.info_json.file_system.dir = new_runtime.factorix_cache_dir / "info_json"
   end
 
   config.after(:suite) do

--- a/spec/spec_helper.rb
+++ b/spec/spec_helper.rb
@@ -54,9 +54,9 @@ RSpec.configure do |config|
 
     # Reset configuration to defaults and reconfigure with new runtime
     Factorix.reset_config
-    Factorix.config.cache.download.dir = new_runtime.factorix_cache_dir / "download"
-    Factorix.config.cache.api.dir = new_runtime.factorix_cache_dir / "api"
-    Factorix.config.cache.info_json.dir = new_runtime.factorix_cache_dir / "info_json"
+    Factorix.config.cache.download.file_system.dir = new_runtime.factorix_cache_dir / "download"
+    Factorix.config.cache.api.file_system.dir = new_runtime.factorix_cache_dir / "api"
+    Factorix.config.cache.info_json.file_system.dir = new_runtime.factorix_cache_dir / "info_json"
   end
 
   config.after(:suite) do

--- a/spec/support/test_cache_backend.rb
+++ b/spec/support/test_cache_backend.rb
@@ -16,8 +16,7 @@ module Factorix
       # Initialize a new test backend.
       #
       # @param ttl [Integer, nil] time-to-live in seconds (nil for unlimited)
-      # @param lock_timeout [Integer] lock timeout in seconds (default: 30)
-      def initialize(ttl: nil, lock_timeout: 30)
+      def initialize(ttl: nil)
         super
         @entries = {}
       end
@@ -72,9 +71,8 @@ module Factorix
       # Execute a block with an exclusive lock on the cache entry.
       #
       # @param key [String] logical cache key
-      # @param timeout [Integer, nil] lock timeout in seconds (ignored in test backend)
       # @yield block to execute with lock held
-      def with_lock(_key, timeout: @lock_timeout)
+      def with_lock(_key)
         yield
       end
 

--- a/spec/support/test_cache_backend.rb
+++ b/spec/support/test_cache_backend.rb
@@ -117,10 +117,11 @@ module Factorix
         return enum_for(__method__) unless block_given?
 
         @entries.each do |key, data|
+          age = Time.now - data[:stored_at]
           entry = Entry.new(
             size: data[:size],
-            age: Time.now - data[:stored_at],
-            expired: @ttl ? (Time.now - data[:stored_at] > @ttl) : false
+            age:,
+            expired: @ttl ? age > @ttl : false
           )
           yield key, entry
         end

--- a/spec/support/test_cache_backend.rb
+++ b/spec/support/test_cache_backend.rb
@@ -42,6 +42,18 @@ module Factorix
         @entries[key][:data].dup.force_encoding(encoding)
       end
 
+      # Write cached content to a file.
+      #
+      # @param key [String] logical cache key
+      # @param output [Pathname] path to write the cached content
+      # @return [Boolean] true if written successfully, false if not found/expired
+      def write_to(key, output)
+        return false unless exist?(key)
+
+        output.binwrite(@entries[key][:data])
+        true
+      end
+
       # Store data in the cache.
       #
       # @param key [String] logical cache key

--- a/spec/support/test_cache_backend.rb
+++ b/spec/support/test_cache_backend.rb
@@ -1,0 +1,157 @@
+# frozen_string_literal: true
+
+module Factorix
+  module Cache
+    # Test backend for cache CLI command testing.
+    #
+    # This backend stores entries in memory and provides test helper methods
+    # for manipulating entry age and stale locks count.
+    #
+    # @example Basic usage
+    #   cache = Factorix::Cache::TestBackend.new(ttl: 3600)
+    #   cache.store("key", Pathname("/path/to/file"))
+    #   cache.set_entry_age("key", 7200) # Make entry 2 hours old (expired)
+    #
+    class TestBackend < Base
+      # Initialize a new test backend.
+      #
+      # @param ttl [Integer, nil] time-to-live in seconds (nil for unlimited)
+      # @param lock_timeout [Integer] lock timeout in seconds (default: 30)
+      def initialize(ttl: nil, lock_timeout: 30)
+        super
+        @entries = {}
+      end
+
+      # Check if a cache entry exists and is not expired.
+      #
+      # @param key [String] logical cache key
+      # @return [Boolean] true if the cache entry exists and is valid
+      def exist?(key)
+        return false unless @entries.key?(key)
+
+        !expired?(key)
+      end
+
+      # Read a cached entry as a string.
+      #
+      # @param key [String] logical cache key
+      # @param encoding [Encoding] encoding to use (default: ASCII-8BIT for binary)
+      # @return [String, nil] cached content or nil if not found/expired
+      def read(key, encoding: Encoding::ASCII_8BIT)
+        return nil unless exist?(key)
+
+        @entries[key][:data].dup.force_encoding(encoding)
+      end
+
+      # Store data in the cache.
+      #
+      # @param key [String] logical cache key
+      # @param src [Pathname] path to the source file
+      # @return [Boolean] true if stored successfully
+      def store(key, src)
+        data = src.binread
+        @entries[key] = {data:, stored_at: Time.now, size: data.bytesize}
+        true
+      end
+
+      # Delete a cache entry.
+      #
+      # @param key [String] logical cache key
+      # @return [Boolean] true if deleted, false if not found
+      def delete(key)
+        !!@entries.delete(key)
+      end
+
+      # Clear all cache entries.
+      #
+      # @return [void]
+      def clear
+        @entries.clear
+      end
+
+      # Execute a block with an exclusive lock on the cache entry.
+      #
+      # @param key [String] logical cache key
+      # @param timeout [Integer, nil] lock timeout in seconds (ignored in test backend)
+      # @yield block to execute with lock held
+      def with_lock(_key, timeout: @lock_timeout)
+        yield
+      end
+
+      # Get the age of a cache entry in seconds.
+      #
+      # @param key [String] logical cache key
+      # @return [Float, nil] age in seconds, or nil if entry doesn't exist
+      def age(key)
+        return nil unless @entries.key?(key)
+
+        Time.now - @entries[key][:stored_at]
+      end
+
+      # Check if a cache entry has expired based on TTL.
+      #
+      # @param key [String] logical cache key
+      # @return [Boolean] true if expired, false otherwise
+      def expired?(key)
+        return false unless @entries.key?(key)
+        return false if @ttl.nil?
+
+        age(key) > @ttl
+      end
+
+      # Get the size of a cached entry in bytes.
+      #
+      # @param key [String] logical cache key
+      # @return [Integer, nil] size in bytes, or nil if entry doesn't exist/expired
+      def size(key)
+        return nil unless exist?(key)
+
+        @entries[key][:size]
+      end
+
+      # Enumerate cache entries.
+      #
+      # @yield [key, entry] logical key and Entry object
+      # @yieldparam key [String] logical cache key
+      # @yieldparam entry [Entry] cache entry metadata
+      # @return [Enumerator] if no block given
+      def each
+        return enum_for(__method__) unless block_given?
+
+        @entries.each do |key, data|
+          entry = Entry.new(
+            size: data[:size],
+            age: Time.now - data[:stored_at],
+            expired: @ttl ? (Time.now - data[:stored_at] > @ttl) : false
+          )
+          yield key, entry
+        end
+      end
+
+      # Test helper: Set the age of a cache entry.
+      #
+      # @param key [String] logical cache key
+      # @param age_seconds [Numeric] age in seconds
+      # @return [void]
+      def set_entry_age(key, age_seconds)
+        return unless @entries.key?(key)
+
+        @entries[key][:stored_at] = Time.now - age_seconds
+      end
+
+      # Test helper: Add an entry directly with specified properties.
+      #
+      # @param key [String] logical cache key
+      # @param content [String] entry content
+      # @param age [Numeric] entry age in seconds (default: 0)
+      # @return [void]
+      def add_entry(key, content, age: 0)
+        @entries[key] = {
+          data: content.b,
+          stored_at: Time.now - age,
+          size: content.bytesize
+        }
+      end
+    end
+  end
+end

--- a/spec/support/with_test_caches.rb
+++ b/spec/support/with_test_caches.rb
@@ -1,14 +1,9 @@
 # frozen_string_literal: true
 
-# Shared context for tests that need test cache backends.
-# Uses Container stubbing to provide TestBackend instances.
+# Shared context that provides TestBackend instances for all tests.
+# Every test gets fresh cache instances via let variables.
 #
-# @example Use with test caches
-#   describe "cache operations", :with_test_caches do
-#     # download_cache, api_cache, info_json_cache are available as let variables
-#   end
-#
-# @example Access the test cache
+# @example Access the test cache directly
 #   it "stores entries" do
 #     download_cache.add_entry("key", "content")
 #     expect(download_cache.exist?("key")).to be true
@@ -23,14 +18,8 @@ RSpec.shared_context "with test caches" do
     Factorix::Container.stub(:api_cache, api_cache)
     Factorix::Container.stub(:info_json_cache, info_json_cache)
   end
-
-  after do
-    Factorix::Container.unstub(:download_cache)
-    Factorix::Container.unstub(:api_cache)
-    Factorix::Container.unstub(:info_json_cache)
-  end
 end
 
 RSpec.configure do |config|
-  config.include_context "with test caches", :with_test_caches
+  config.include_context "with test caches"
 end

--- a/spec/support/with_test_caches.rb
+++ b/spec/support/with_test_caches.rb
@@ -1,0 +1,36 @@
+# frozen_string_literal: true
+
+# Shared context for tests that need test cache backends.
+# Uses Container stubbing to provide TestBackend instances.
+#
+# @example Use with test caches
+#   describe "cache operations", :with_test_caches do
+#     # download_cache, api_cache, info_json_cache are available as let variables
+#   end
+#
+# @example Access the test cache
+#   it "stores entries" do
+#     download_cache.add_entry("key", "content")
+#     expect(download_cache.exist?("key")).to be true
+#   end
+RSpec.shared_context "with test caches" do
+  let(:download_cache) { Factorix::Cache::TestBackend.new(ttl: nil) }
+  let(:api_cache) { Factorix::Cache::TestBackend.new(ttl: 3600) }
+  let(:info_json_cache) { Factorix::Cache::TestBackend.new(ttl: nil) }
+
+  before do
+    Factorix::Container.stub(:download_cache, download_cache)
+    Factorix::Container.stub(:api_cache, api_cache)
+    Factorix::Container.stub(:info_json_cache, info_json_cache)
+  end
+
+  after do
+    Factorix::Container.unstub(:download_cache)
+    Factorix::Container.unstub(:api_cache)
+    Factorix::Container.unstub(:info_json_cache)
+  end
+end
+
+RSpec.configure do |config|
+  config.include_context "with test caches", :with_test_caches
+end


### PR DESCRIPTION
## Summary
Introduce abstract cache base class and refactor FileSystem cache to use logical keys, preparing for multi-backend cache system.

## Changes
- Add `Cache::Entry` data class for cache entry metadata
- Add `Cache::Base` abstract class defining cache interface
- FileSystem now inherits from Base with logical key interface
- Store logical keys in `.metadata` files for enumeration support
- Add `LockTimeoutError` for future backend implementations
- Update all callers to use logical keys directly (no more `key_for`)

## Test Plan
- `bundle exec rake` passes (spec + rubocop + steep)
- 1336 examples, 0 failures

Closes #20
Closes #17
