### PR TITLE
:sparkles: Add Redis cache backend with distributed locking

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -45,6 +45,7 @@ Lint/EmptyClass:
 Naming/PredicateMethod:
   Exclude:
     - lib/factorix/cache/file_system.rb # fetch/store/delete return boolean but are standard cache API names
+    - lib/factorix/cache/redis.rb # write_to/store/delete return boolean but are standard cache API names
     - lib/factorix/ser_des/deserializer.rb # read_bool follows binary deserialization naming convention
     - spec/support/test_cache_backend.rb # store/delete return boolean but are standard cache API names
 
@@ -67,11 +68,13 @@ Style/HashEachMethods:
   Exclude:
     - lib/factorix/cli/commands/cache/stat.rb # cache.each is not Hash#each, it's Cache::Base#each
     - spec/factorix/cache/file_system_spec.rb # cache.each is not Hash#each, it's a custom method
+    - spec/factorix/cache/redis_spec.rb # cache.each is not Hash#each, it's Cache::Base#each
 
 Style/MapIntoArray:
   Exclude:
     - lib/factorix/cli/commands/cache/stat.rb # cache.each is Cache::Base#each, not Hash#each
     - spec/factorix/cache/file_system_spec.rb # Testing cache.each method, not optimizing for map
+    - spec/factorix/cache/redis_spec.rb # Testing cache.each method, not optimizing for map
 
 Style/IpAddresses:
   Exclude:

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,13 @@
 ## [Unreleased]
 
+### Added
+
+- Add Redis cache backend (`Cache::Redis`) with distributed locking support (#19)
+  - Optional dependency: requires `redis` gem (~> 5) in user's Gemfile
+  - Configure with `config.cache.<type>.backend = :redis`
+  - Supports distributed locking via Lua script for atomic lock release
+  - Auto-namespaced keys: `factorix-cache:{cache_type}:{key}`
+
 ## [0.6.0] - 2026-01-18
 
 ### Changed

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,8 @@ group :development, :test do
   gem "rake", require: false
 
   gem "irb", require: false
+  # Redis client for Cache::Redis backend testing
+  gem "redis", "~> 5", require: false
   gem "repl_type_completor", require: false
 end
 

--- a/doc/components/storage.md
+++ b/doc/components/storage.md
@@ -40,6 +40,34 @@ Detection on read uses zlib magic byte (`0x78`) to handle mixed compressed/uncom
 - Acquire exclusive lock with `with_lock` method
 - Cleanup old lock files (more than 1 hour old)
 
+### Redis Backend
+
+Optional Redis-based cache (Cache::Redis) for distributed environments.
+
+**URL Resolution Order**:
+1. Explicit `url` setting in configuration
+2. `REDIS_URL` environment variable
+3. Default: `localhost:6379` (Redis gem default)
+
+**Configuration Example**:
+```ruby
+Factorix.configure do |config|
+  config.cache.api.backend = :redis
+  config.cache.api.redis.url = "redis://redis-server:6379/0"
+  config.cache.api.redis.lock_timeout = 30
+end
+```
+
+**Key Structure**:
+- Data: `factorix-cache:{cache_type}:{key}`
+- Metadata: `factorix-cache:{cache_type}:meta:{key}`
+- Lock: `factorix-cache:{cache_type}:lock:{key}`
+
+**Distributed Locking**:
+- Atomic acquire with `SET NX EX`
+- Atomic release with Lua script (ownership check)
+- Lock timeout configurable (default: 30 seconds)
+
 ## MODSettings
 
 Manages reading and writing of `mod-settings.dat` file. Uses SerDes module to handle Factorio-specific binary format.

--- a/exe/factorix
+++ b/exe/factorix
@@ -8,6 +8,23 @@ require "zip"
 # Suppress warnings about invalid dates in ZIP files
 Zip.warn_invalid_date = false
 
+# Load config early, before dry-cli instantiates commands.
+# This is necessary because command classes use Import which resolves
+# dependencies at instantiation time (before CommandWrapper#call).
+# Without this, cache backends would use default config instead of user config.
+#
+# Note: --config-path option is handled separately in CommandWrapper and
+# will override settings if specified.
+config_path_index = ARGV.index("--config-path") || ARGV.index("-c")
+if config_path_index && ARGV[config_path_index + 1]
+  Factorix.load_config(Pathname(ARGV[config_path_index + 1]))
+elsif ENV["FACTORIX_CONFIG"]
+  Factorix.load_config(Pathname(ENV.fetch("FACTORIX_CONFIG")))
+else
+  default_config = Factorix::Container[:runtime].factorix_config_path
+  Factorix.load_config(default_config) if default_config.exist?
+end
+
 begin
   Dry::CLI.new(Factorix::CLI).call
   exit 0

--- a/lib/factorix.rb
+++ b/lib/factorix.rb
@@ -49,7 +49,7 @@ module Factorix
         setting :compression_threshold, default: nil # nil for no compression (binary files)
       end
       setting :redis do
-        setting :url, default: nil # nil uses REDIS_URL env
+        setting :url, default: nil # nil falls back to REDIS_URL env, then localhost:6379
         setting :lock_timeout, default: 30
       end
     end
@@ -64,7 +64,7 @@ module Factorix
         setting :compression_threshold, default: 0 # always compress (JSON is highly compressible)
       end
       setting :redis do
-        setting :url, default: nil # nil uses REDIS_URL env
+        setting :url, default: nil # nil falls back to REDIS_URL env, then localhost:6379
         setting :lock_timeout, default: 30
       end
     end
@@ -79,7 +79,7 @@ module Factorix
         setting :compression_threshold, default: 0 # always compress (JSON is highly compressible)
       end
       setting :redis do
-        setting :url, default: nil # nil uses REDIS_URL env
+        setting :url, default: nil # nil falls back to REDIS_URL env, then localhost:6379
         setting :lock_timeout, default: 30
       end
     end

--- a/lib/factorix.rb
+++ b/lib/factorix.rb
@@ -48,6 +48,10 @@ module Factorix
         setting :max_file_size, default: nil # nil for unlimited
         setting :compression_threshold, default: nil # nil for no compression (binary files)
       end
+      setting :redis do
+        setting :url, default: nil # nil uses REDIS_URL env
+        setting :lock_timeout, default: 30
+      end
     end
 
     # API cache settings (for API responses)
@@ -59,6 +63,10 @@ module Factorix
         setting :max_file_size, default: 10 * 1024 * 1024 # 10MiB (JSON responses)
         setting :compression_threshold, default: 0 # always compress (JSON is highly compressible)
       end
+      setting :redis do
+        setting :url, default: nil # nil uses REDIS_URL env
+        setting :lock_timeout, default: 30
+      end
     end
 
     # info.json cache settings (for MOD metadata from ZIP files)
@@ -69,6 +77,10 @@ module Factorix
         setting :root, constructor: ->(value) { value ? Pathname(value) : nil }
         setting :max_file_size, default: nil # nil for unlimited (info.json is small)
         setting :compression_threshold, default: 0 # always compress (JSON is highly compressible)
+      end
+      setting :redis do
+        setting :url, default: nil # nil uses REDIS_URL env
+        setting :lock_timeout, default: 30
       end
     end
   end

--- a/lib/factorix/cache/redis.rb
+++ b/lib/factorix/cache/redis.rb
@@ -1,0 +1,267 @@
+# frozen_string_literal: true
+
+begin
+  require "redis"
+rescue LoadError
+  raise Factorix::Error, "redis gem is required for Redis cache backend. Add it to your Gemfile."
+end
+
+require "securerandom"
+
+module Factorix
+  module Cache
+    # Redis-based cache storage implementation.
+    #
+    # Stores cache entries in Redis with automatic namespace prefixing.
+    # Metadata (size, created_at) stored in separate hash keys.
+    # Supports distributed locking with Lua script for atomic release.
+    #
+    # @example Configuration
+    #   Factorix.configure do |config|
+    #     config.cache.api.backend = :redis
+    #     config.cache.api.redis.url = "redis://localhost:6379/0"
+    #     config.cache.api.redis.lock_timeout = 30
+    #   end
+    class Redis < Base
+      # @!parse
+      #   # @return [Dry::Logger::Dispatcher]
+      #   attr_reader :logger
+      include Import[:logger]
+
+      # Default timeout for distributed lock acquisition in seconds.
+      DEFAULT_LOCK_TIMEOUT = 30
+      public_constant :DEFAULT_LOCK_TIMEOUT
+
+      # TTL for distributed locks in seconds.
+      LOCK_TTL = 30
+      private_constant :LOCK_TTL
+
+      # Lua script for atomic lock release (only release if we own it).
+      RELEASE_LOCK_SCRIPT = <<~LUA
+        if redis.call("get", KEYS[1]) == ARGV[1] then
+          return redis.call("del", KEYS[1])
+        else
+          return 0
+        end
+      LUA
+      private_constant :RELEASE_LOCK_SCRIPT
+
+      # Initialize a new Redis cache storage.
+      #
+      # @param url [String, nil] Redis URL (defaults to REDIS_URL env)
+      # @param cache_type [String, Symbol] Cache type for namespace (e.g., :api, :download)
+      # @param lock_timeout [Integer] Timeout for lock acquisition in seconds
+      # @param ttl [Integer, nil] time-to-live in seconds (nil for unlimited)
+      def initialize(cache_type:, url: nil, lock_timeout: DEFAULT_LOCK_TIMEOUT, **)
+        super(**)
+        @redis = ::Redis.new(url: url || ENV.fetch("REDIS_URL", nil))
+        @namespace = "factorix-cache:#{cache_type}"
+        @lock_timeout = lock_timeout
+        logger.info("Initializing Redis cache", namespace: @namespace, ttl: @ttl, lock_timeout: @lock_timeout)
+      end
+
+      # Check if a cache entry exists.
+      #
+      # @param key [String] logical cache key
+      # @return [Boolean] true if the cache entry exists
+      def exist?(key) = @redis.exists?(data_key(key))
+
+      # Read a cached entry as a string.
+      #
+      # @param key [String] logical cache key
+      # @param encoding [Encoding] encoding to use (default: ASCII-8BIT for binary)
+      # @return [String, nil] cached content or nil if not found
+      def read(key, encoding: Encoding::ASCII_8BIT)
+        data = @redis.get(data_key(key))
+        return nil if data.nil?
+
+        data.dup.force_encoding(encoding)
+      end
+
+      # Write cached content to a file.
+      #
+      # @param key [String] logical cache key
+      # @param output [Pathname] path to write the cached content
+      # @return [Boolean] true if written successfully, false if not found
+      def write_to(key, output)
+        data = @redis.get(data_key(key))
+        return false if data.nil?
+
+        output.binwrite(data)
+        logger.debug("Cache hit", key:)
+        true
+      end
+
+      # Store data in the cache.
+      #
+      # @param key [String] logical cache key
+      # @param src [Pathname] path to the source file
+      # @return [Boolean] true if stored successfully
+      def store(key, src)
+        data = src.binread
+        data_k = data_key(key)
+        meta_k = meta_key(key)
+
+        @redis.multi do |tx|
+          tx.set(data_k, data)
+          tx.hset(meta_k, "size", data.bytesize, "created_at", Time.now.to_i)
+
+          if @ttl
+            tx.expire(data_k, @ttl)
+            tx.expire(meta_k, @ttl)
+          end
+        end
+
+        logger.debug("Stored in cache", key:, size_bytes: data.bytesize)
+        true
+      end
+
+      # Delete a cache entry.
+      #
+      # @param key [String] logical cache key
+      # @return [Boolean] true if deleted, false if not found
+      def delete(key)
+        deleted = @redis.del(data_key(key), meta_key(key))
+        logger.debug("Deleted from cache", key:) if deleted.positive?
+        deleted.positive?
+      end
+
+      # Clear all cache entries in this namespace.
+      #
+      # @return [void]
+      def clear
+        logger.info("Clearing Redis cache namespace", namespace: @namespace)
+        count = 0
+        cursor = "0"
+        pattern = "#{@namespace}:*"
+
+        loop do
+          cursor, keys = @redis.scan(cursor, match: pattern, count: 100)
+          unless keys.empty?
+            @redis.del(*keys)
+            count += keys.size
+          end
+          break if cursor == "0"
+        end
+
+        logger.info("Cache cleared", keys_removed: count)
+      end
+
+      # Get the age of a cache entry in seconds.
+      #
+      # @param key [String] logical cache key
+      # @return [Integer, nil] age in seconds, or nil if entry doesn't exist
+      def age(key)
+        value = @redis.hget(meta_key(key), "created_at")
+        return nil if value.nil?
+
+        created_at = Integer(value, 10)
+        return nil if created_at.zero?
+
+        Time.now.to_i - created_at
+      end
+
+      # Check if a cache entry has expired.
+      # With Redis native EXPIRE, non-existent keys are considered expired.
+      #
+      # @param key [String] logical cache key
+      # @return [Boolean] true if expired (or doesn't exist), false otherwise
+      def expired?(key) = !exist?(key)
+
+      # Get the size of a cached entry in bytes.
+      #
+      # @param key [String] logical cache key
+      # @return [Integer, nil] size in bytes, or nil if entry doesn't exist
+      def size(key)
+        return nil unless exist?(key)
+
+        value = @redis.hget(meta_key(key), "size")
+        value.nil? ? nil : Integer(value, 10)
+      end
+
+      # Execute a block with a distributed lock.
+      # Uses Redis SET NX EX for lock acquisition and Lua script for atomic release.
+      #
+      # @param key [String] logical cache key
+      # @yield block to execute with lock held
+      # @raise [LockTimeoutError] if lock cannot be acquired within timeout
+      def with_lock(key)
+        lkey = lock_key(key)
+        lock_value = SecureRandom.uuid
+        deadline = Time.now + @lock_timeout
+
+        until @redis.set(lkey, lock_value, nx: true, ex: LOCK_TTL)
+          raise LockTimeoutError, "Failed to acquire lock for key: #{key}" if Time.now > deadline
+
+          sleep 0.1
+        end
+
+        logger.debug("Acquired lock", key:)
+        begin
+          yield
+        ensure
+          @redis.eval(RELEASE_LOCK_SCRIPT, keys: [lkey], argv: [lock_value])
+          logger.debug("Released lock", key:)
+        end
+      end
+
+      # Enumerate cache entries.
+      #
+      # @yield [key, entry] logical key and Entry object
+      # @yieldparam key [String] logical cache key
+      # @yieldparam entry [Entry] cache entry metadata
+      # @return [Enumerator] if no block given
+      def each
+        return enum_for(__method__) unless block_given?
+
+        cursor = "0"
+        pattern = "#{@namespace}:*"
+
+        loop do
+          cursor, keys = @redis.scan(cursor, match: pattern, count: 100)
+
+          keys.each do |data_k|
+            next if data_k.include?(":meta:") || data_k.include?(":lock:")
+
+            logical_key = logical_key_from_data_key(data_k)
+            meta = @redis.hgetall(meta_key(logical_key))
+
+            entry = Entry.new(
+              size: meta["size"] ? Integer(meta["size"], 10) : 0,
+              age: meta["created_at"] ? Time.now.to_i - Integer(meta["created_at"], 10) : 0,
+              expired: false # Redis handles expiry natively
+            )
+
+            yield logical_key, entry
+          end
+
+          break if cursor == "0"
+        end
+      end
+
+      # Generate data key for the given logical key.
+      #
+      # @param logical_key [String] logical key
+      # @return [String] namespaced data key
+      private def data_key(logical_key) = "#{@namespace}:#{logical_key}"
+
+      # Generate metadata key for the given logical key.
+      #
+      # @param logical_key [String] logical key
+      # @return [String] namespaced metadata key
+      private def meta_key(logical_key) = "#{@namespace}:meta:#{logical_key}"
+
+      # Generate lock key for the given logical key.
+      #
+      # @param logical_key [String] logical key
+      # @return [String] namespaced lock key
+      private def lock_key(logical_key) = "#{@namespace}:lock:#{logical_key}"
+
+      # Extract logical key from data key.
+      #
+      # @param data_k [String] namespaced data key
+      # @return [String] logical key
+      private def logical_key_from_data_key(data_k) = data_k.delete_prefix("#{@namespace}:")
+    end
+  end
+end

--- a/lib/factorix/container.rb
+++ b/lib/factorix/container.rb
@@ -49,20 +49,40 @@ module Factorix
     # Register download cache
     register(:download_cache, memoize: true) do
       c = Factorix.config.cache.download
-      # Currently only FileSystem backend is supported
-      Cache::FileSystem.new(ttl: c.ttl, **c.file_system.to_h)
+      case c.backend
+      when :file_system
+        Cache::FileSystem.new(ttl: c.ttl, **c.file_system.to_h)
+      when :redis
+        Cache::Redis.new(ttl: c.ttl, cache_type: :download, **c.redis.to_h)
+      else
+        raise ConfigurationError, "Unknown cache backend: #{c.backend}"
+      end
     end
 
     # Register API cache (with compression for JSON responses)
     register(:api_cache, memoize: true) do
       c = Factorix.config.cache.api
-      Cache::FileSystem.new(ttl: c.ttl, **c.file_system.to_h)
+      case c.backend
+      when :file_system
+        Cache::FileSystem.new(ttl: c.ttl, **c.file_system.to_h)
+      when :redis
+        Cache::Redis.new(ttl: c.ttl, cache_type: :api, **c.redis.to_h)
+      else
+        raise ConfigurationError, "Unknown cache backend: #{c.backend}"
+      end
     end
 
     # Register info.json cache (for MOD metadata from ZIP files)
     register(:info_json_cache, memoize: true) do
       c = Factorix.config.cache.info_json
-      Cache::FileSystem.new(ttl: c.ttl, **c.file_system.to_h)
+      case c.backend
+      when :file_system
+        Cache::FileSystem.new(ttl: c.ttl, **c.file_system.to_h)
+      when :redis
+        Cache::Redis.new(ttl: c.ttl, cache_type: :info_json, **c.redis.to_h)
+      else
+        raise ConfigurationError, "Unknown cache backend: #{c.backend}"
+      end
     end
 
     # Register base HTTP client

--- a/sig/factorix/cache/redis.rbs
+++ b/sig/factorix/cache/redis.rbs
@@ -1,0 +1,36 @@
+# RBS type signature file
+# NOTE: Do not include private method definitions in RBS files.
+#       Only public interfaces should be documented here.
+
+module Factorix
+  module Cache
+    class Redis < Base
+      DEFAULT_LOCK_TIMEOUT: Integer
+
+      def initialize: (?url: String?, cache_type: String | Symbol, ?lock_timeout: Integer, ?ttl: Integer?) -> void
+
+      def exist?: (String key) -> bool
+
+      def read: (String key, ?encoding: Encoding) -> String?
+
+      def write_to: (String key, Pathname output) -> bool
+
+      def store: (String key, Pathname src) -> bool
+
+      def delete: (String key) -> bool
+
+      def clear: () -> void
+
+      def age: (String key) -> Integer?
+
+      def expired?: (String key) -> bool
+
+      def size: (String key) -> Integer?
+
+      def with_lock: [T] (String key) { () -> T } -> T
+
+      def each: () { (String, Entry) -> void } -> void
+              | () -> Enumerator[[String, Entry], void]
+    end
+  end
+end

--- a/spec/factorix/cache/redis_spec.rb
+++ b/spec/factorix/cache/redis_spec.rb
@@ -1,0 +1,290 @@
+# frozen_string_literal: true
+
+require "fileutils"
+require "pathname"
+require "securerandom"
+require "tmpdir"
+
+RSpec.describe Factorix::Cache::Redis do
+  let(:redis_client) { instance_double(Redis) }
+  let(:cache) { Factorix::Cache::Redis.new(cache_type: "api") }
+  let(:logical_key) { "test-key" }
+  let(:data_key) { "factorix-cache:api:#{logical_key}" }
+  let(:meta_key) { "factorix-cache:api:meta:#{logical_key}" }
+  let(:lock_key) { "factorix-cache:api:lock:#{logical_key}" }
+
+  before do
+    allow(Redis).to receive(:new).and_return(redis_client)
+  end
+
+  describe "#initialize" do
+    it "creates Redis client with provided URL" do
+      Factorix::Cache::Redis.new(url: "redis://custom:6379/1", cache_type: "api")
+      expect(Redis).to have_received(:new).with(url: "redis://custom:6379/1")
+    end
+
+    it "creates Redis client with REDIS_URL env when url is nil" do
+      allow(ENV).to receive(:fetch).with("REDIS_URL", nil).and_return("redis://env:6379/2")
+      Factorix::Cache::Redis.new(cache_type: "api")
+      expect(Redis).to have_received(:new).with(url: "redis://env:6379/2")
+    end
+
+    it "accepts ttl parameter" do
+      cache_with_ttl = Factorix::Cache::Redis.new(cache_type: "api", ttl: 3600)
+      expect(cache_with_ttl.ttl).to eq(3600)
+    end
+
+    it "accepts lock_timeout parameter" do
+      expect { Factorix::Cache::Redis.new(cache_type: "api", lock_timeout: 60) }.not_to raise_error
+    end
+
+    it "inherits from Base" do
+      expect(Factorix::Cache::Redis.superclass).to eq(Factorix::Cache::Base)
+    end
+  end
+
+  describe "#exist?" do
+    it "checks key existence with namespaced key" do
+      allow(redis_client).to receive(:exists?).with(data_key).and_return(true)
+      expect(cache.exist?(logical_key)).to be true
+    end
+
+    it "returns false when key does not exist" do
+      allow(redis_client).to receive(:exists?).with(data_key).and_return(false)
+      expect(cache.exist?(logical_key)).to be false
+    end
+  end
+
+  describe "#read" do
+    context "when cache entry exists" do
+      it "reads data with binary encoding by default" do
+        allow(redis_client).to receive(:get).with(data_key).and_return("cached content")
+        content = cache.read(logical_key)
+        expect(content).to eq("cached content")
+        expect(content.encoding).to eq(Encoding::ASCII_8BIT)
+      end
+
+      it "reads data with specified encoding" do
+        allow(redis_client).to receive(:get).with(data_key).and_return("UTF-8 content")
+        content = cache.read(logical_key, encoding: Encoding::UTF_8)
+        expect(content).to eq("UTF-8 content")
+        expect(content.encoding).to eq(Encoding::UTF_8)
+      end
+    end
+
+    context "when cache entry does not exist" do
+      it "returns nil" do
+        allow(redis_client).to receive(:get).with(data_key).and_return(nil)
+        expect(cache.read(logical_key)).to be_nil
+      end
+    end
+  end
+
+  describe "#write_to" do
+    let(:output_file) { Pathname(Dir.mktmpdir("output")) / "file.dat" }
+
+    after { FileUtils.remove_entry(output_file.dirname) }
+
+    context "when cache entry exists" do
+      it "writes cached content to output file" do
+        allow(redis_client).to receive(:get).with(data_key).and_return("cached content")
+        expect(cache.write_to(logical_key, output_file)).to be true
+        expect(output_file.read).to eq("cached content")
+      end
+    end
+
+    context "when cache entry does not exist" do
+      it "returns false" do
+        allow(redis_client).to receive(:get).with(data_key).and_return(nil)
+        expect(cache.write_to(logical_key, output_file)).to be false
+        expect(output_file).not_to exist
+      end
+    end
+  end
+
+  describe "#store" do
+    let(:source_file) { Pathname(Dir.mktmpdir("source")) / "data.bin" }
+
+    before { File.write(source_file, "test content") }
+    after { FileUtils.remove_entry(source_file.dirname) }
+
+    it "stores data with auto-generated namespace" do
+      allow(redis_client).to receive(:multi).and_yield(redis_client)
+      allow(redis_client).to receive(:set)
+      allow(redis_client).to receive(:hset)
+
+      expect(cache.store(logical_key, source_file)).to be true
+      expect(redis_client).to have_received(:set).with(data_key, "test content")
+      expect(redis_client).to have_received(:hset).with(meta_key, "size", 12, "created_at", kind_of(Integer))
+    end
+
+    context "with TTL" do
+      let(:cache) { Factorix::Cache::Redis.new(cache_type: "api", ttl: 3600) }
+
+      it "sets expiry on data and meta keys" do
+        allow(redis_client).to receive(:multi).and_yield(redis_client)
+        allow(redis_client).to receive(:set)
+        allow(redis_client).to receive(:hset)
+        allow(redis_client).to receive(:expire)
+
+        cache.store(logical_key, source_file)
+        expect(redis_client).to have_received(:expire).with(data_key, 3600)
+        expect(redis_client).to have_received(:expire).with(meta_key, 3600)
+      end
+    end
+  end
+
+  describe "#delete" do
+    it "deletes both data and meta keys" do
+      allow(redis_client).to receive(:del).with(data_key, meta_key).and_return(2)
+      expect(cache.delete(logical_key)).to be true
+    end
+
+    it "returns false when keys do not exist" do
+      allow(redis_client).to receive(:del).with(data_key, meta_key).and_return(0)
+      expect(cache.delete(logical_key)).to be false
+    end
+  end
+
+  describe "#clear" do
+    it "scans and deletes all keys in namespace" do
+      allow(redis_client).to receive(:scan).with("0", match: "factorix-cache:api:*", count: 100)
+        .and_return(["0", %w[factorix-cache:api:key1 factorix-cache:api:key2]])
+      allow(redis_client).to receive(:del)
+
+      cache.clear
+      expect(redis_client).to have_received(:del).with("factorix-cache:api:key1", "factorix-cache:api:key2")
+    end
+
+    it "handles pagination with cursor" do
+      allow(redis_client).to receive(:scan).with("0", match: "factorix-cache:api:*", count: 100)
+        .and_return(["123", %w[factorix-cache:api:key1]])
+      allow(redis_client).to receive(:scan).with("123", match: "factorix-cache:api:*", count: 100)
+        .and_return(["0", %w[factorix-cache:api:key2]])
+      allow(redis_client).to receive(:del)
+
+      cache.clear
+      expect(redis_client).to have_received(:del).with("factorix-cache:api:key1")
+      expect(redis_client).to have_received(:del).with("factorix-cache:api:key2")
+    end
+  end
+
+  describe "#age" do
+    it "calculates age from created_at metadata" do
+      created_at = (Time.now.to_i - 100).to_s
+      allow(redis_client).to receive(:hget).with(meta_key, "created_at").and_return(created_at)
+      expect(cache.age(logical_key)).to be_within(1).of(100)
+    end
+
+    it "returns nil when entry does not exist" do
+      allow(redis_client).to receive(:hget).with(meta_key, "created_at").and_return(nil)
+      expect(cache.age(logical_key)).to be_nil
+    end
+
+    it "returns nil when created_at is zero" do
+      allow(redis_client).to receive(:hget).with(meta_key, "created_at").and_return("0")
+      expect(cache.age(logical_key)).to be_nil
+    end
+  end
+
+  describe "#expired?" do
+    it "returns false when key exists" do
+      allow(redis_client).to receive(:exists?).with(data_key).and_return(true)
+      expect(cache.expired?(logical_key)).to be false
+    end
+
+    it "returns true when key does not exist" do
+      allow(redis_client).to receive(:exists?).with(data_key).and_return(false)
+      expect(cache.expired?(logical_key)).to be true
+    end
+  end
+
+  describe "#size" do
+    it "returns size from metadata" do
+      allow(redis_client).to receive(:exists?).with(data_key).and_return(true)
+      allow(redis_client).to receive(:hget).with(meta_key, "size").and_return("1024")
+      expect(cache.size(logical_key)).to eq(1024)
+    end
+
+    it "returns nil when entry does not exist" do
+      allow(redis_client).to receive(:exists?).with(data_key).and_return(false)
+      expect(cache.size(logical_key)).to be_nil
+    end
+  end
+
+  describe "#with_lock" do
+    it "acquires and releases lock around block" do
+      allow(SecureRandom).to receive(:uuid).and_return("test-uuid")
+      allow(redis_client).to receive(:set).with(lock_key, "test-uuid", nx: true, ex: 30).and_return(true)
+      allow(redis_client).to receive(:eval)
+
+      yielded = false
+      cache.with_lock(logical_key) { yielded = true }
+      expect(yielded).to be true
+      expect(redis_client).to have_received(:eval).with(anything, keys: [lock_key], argv: ["test-uuid"])
+    end
+
+    it "retries lock acquisition until success" do
+      allow(SecureRandom).to receive(:uuid).and_return("test-uuid")
+      call_count = 0
+      allow(redis_client).to receive(:set).with(lock_key, "test-uuid", nx: true, ex: 30) do
+        call_count += 1
+        call_count >= 3
+      end
+      allow(redis_client).to receive(:eval)
+      allow(cache).to receive(:sleep)
+
+      cache.with_lock(logical_key) { nil }
+      expect(call_count).to eq(3)
+    end
+
+    it "raises LockTimeoutError when lock cannot be acquired" do
+      cache_with_short_timeout = Factorix::Cache::Redis.new(cache_type: "api", lock_timeout: 0.2)
+      allow(SecureRandom).to receive(:uuid).and_return("test-uuid")
+      allow(redis_client).to receive(:set).with(anything, anything, nx: true, ex: 30).and_return(false)
+      allow(cache_with_short_timeout).to receive(:sleep)
+
+      expect {
+        cache_with_short_timeout.with_lock(logical_key) { nil }
+      }.to raise_error(Factorix::LockTimeoutError, /Failed to acquire lock/)
+    end
+  end
+
+  describe "#each" do
+    it "yields key-entry pairs for data keys only" do
+      allow(redis_client).to receive(:scan).with("0", match: "factorix-cache:api:*", count: 100).and_return(["0", [
+        "factorix-cache:api:key1",
+        "factorix-cache:api:meta:key1",
+        "factorix-cache:api:lock:key1",
+        "factorix-cache:api:key2"
+      ]])
+      allow(redis_client).to receive(:hgetall).with("factorix-cache:api:meta:key1")
+        .and_return({"size" => "100", "created_at" => Time.now.to_i.to_s})
+      allow(redis_client).to receive(:hgetall).with("factorix-cache:api:meta:key2")
+        .and_return({"size" => "200", "created_at" => Time.now.to_i.to_s})
+
+      keys = cache.each.map {|key, _entry| key }
+      expect(keys).to eq(%w[key1 key2])
+    end
+
+    it "returns enumerator when no block given" do
+      allow(redis_client).to receive(:scan).and_return(["0", []])
+      expect(cache.each).to be_a(Enumerator)
+    end
+
+    it "yields Entry objects with correct attributes" do
+      created_at = Time.now.to_i - 50
+      allow(redis_client).to receive(:scan).with("0", match: "factorix-cache:api:*", count: 100)
+        .and_return(["0", ["factorix-cache:api:key1"]])
+      allow(redis_client).to receive(:hgetall).with("factorix-cache:api:meta:key1")
+        .and_return({"size" => "100", "created_at" => created_at.to_s})
+
+      entries = cache.each.map {|_key, entry| entry }
+
+      expect(entries.size).to eq(1)
+      expect(entries.first.size).to eq(100)
+      expect(entries.first.age).to be_within(1).of(50)
+      expect(entries.first.expired?).to be false
+    end
+  end
+end


### PR DESCRIPTION
## Summary

Implements `Cache::Redis` backend for distributed cache storage, inheriting from `Cache::Base` with full interface compliance.

## Changes

- Add `Cache::Redis` with auto-namespaced keys (`factorix-cache:{cache_type}:{key}`)
- Implement distributed locking via Lua script for atomic lock release
- Add hierarchical configuration under `config.cache.<type>.redis`
- Add backend selection logic in DI container
- Add `redis` gem as optional dev/test dependency

## Test Plan

- Run `bundle exec rake` (all 1362 examples pass)
- Run `bundle exec rspec spec/factorix/cache/redis_spec.rb` for Redis-specific tests
- Type checking passes with `bundle exec steep check`

Fixes #19
