### PR TITLE
:recycle: Remove encoding parameter from cache read methods

### DIFF
--- a/lib/factorix/api/mod_portal_api.rb
+++ b/lib/factorix/api/mod_portal_api.rb
@@ -108,10 +108,10 @@ module Factorix
       private def fetch_with_cache(uri)
         cache_key = uri.to_s
 
-        cached = cache.read(cache_key, encoding: "UTF-8")
+        cached = cache.read(cache_key)
         if cached
           logger.debug("API cache hit", uri: uri.to_s)
-          return JSON.parse(cached, symbolize_names: true)
+          return JSON.parse((+cached).force_encoding(Encoding::UTF_8), symbolize_names: true)
         end
 
         logger.debug("API cache miss", uri: uri.to_s)

--- a/lib/factorix/cache/base.rb
+++ b/lib/factorix/cache/base.rb
@@ -29,10 +29,9 @@ module Factorix
       # Read a cached entry as a string.
       #
       # @param key [String] logical cache key
-      # @param encoding [Encoding] encoding to use (default: ASCII-8BIT for binary)
       # @return [String, nil] cached content or nil if not found/expired
       # @abstract
-      def read(key, encoding: Encoding::ASCII_8BIT) = raise NotImplementedError, "#{self.class}#read must be implemented"
+      def read(key) = raise NotImplementedError, "#{self.class}#read must be implemented"
 
       # Write cached content to a file.
       #

--- a/lib/factorix/cache/file_system.rb
+++ b/lib/factorix/cache/file_system.rb
@@ -95,14 +95,13 @@ module Factorix
         true
       end
 
-      # Read a cached file as a string.
+      # Read a cached file as a binary string.
       # If the cache entry doesn't exist or is expired, returns nil.
       # Automatically decompresses zlib-compressed cache entries.
       #
       # @param key [String] logical cache key
-      # @param encoding [Encoding, String] encoding to use (default: ASCII-8BIT for binary)
       # @return [String, nil] cached content or nil if not found/expired
-      def read(key, encoding: Encoding::ASCII_8BIT)
+      def read(key)
         internal_key = storage_key_for(key)
         path = cache_path_for(internal_key)
         return nil unless path.exist?
@@ -110,7 +109,7 @@ module Factorix
 
         data = path.binread
         data = Zlib.inflate(data) if zlib_compressed?(data)
-        data.force_encoding(encoding)
+        data
       end
 
       # Store a file in the cache.

--- a/lib/factorix/cache/redis.rb
+++ b/lib/factorix/cache/redis.rb
@@ -66,16 +66,12 @@ module Factorix
       # @return [Boolean] true if the cache entry exists
       def exist?(key) = @redis.exists?(data_key(key))
 
-      # Read a cached entry as a string.
+      # Read a cached entry.
       #
       # @param key [String] logical cache key
-      # @param encoding [Encoding] encoding to use (default: ASCII-8BIT for binary)
       # @return [String, nil] cached content or nil if not found
-      def read(key, encoding: Encoding::ASCII_8BIT)
-        data = @redis.get(data_key(key))
-        return nil if data.nil?
-
-        data.dup.force_encoding(encoding)
+      def read(key)
+        @redis.get(data_key(key))
       end
 
       # Write cached content to a file.

--- a/lib/factorix/info_json.rb
+++ b/lib/factorix/info_json.rb
@@ -51,17 +51,17 @@ module Factorix
       logger = Container.resolve(:logger)
       cache_key = zip_path.to_s
 
-      if (cached_json = cache.read(cache_key, encoding: Encoding::UTF_8))
+      if (cached_json = cache.read(cache_key))
         logger.debug("info.json cache hit", path: zip_path.to_s)
-        return from_json(cached_json)
+        return from_json((+cached_json).force_encoding(Encoding::UTF_8))
       end
 
       logger.debug("info.json cache miss", path: zip_path.to_s)
 
       cache.with_lock(cache_key) do
-        if (cached_json = cache.read(cache_key, encoding: Encoding::UTF_8))
+        if (cached_json = cache.read(cache_key))
           logger.debug("info.json cache hit (after lock)", path: zip_path.to_s)
-          return from_json(cached_json)
+          return from_json((+cached_json).force_encoding(Encoding::UTF_8))
         end
 
         json_string = Zip::File.open(zip_path) {|zip_file|

--- a/sig/factorix/cache/base.rbs
+++ b/sig/factorix/cache/base.rbs
@@ -8,7 +8,7 @@ module Factorix
       def initialize: (?ttl: Integer?) -> void
 
       def exist?: (String key) -> bool
-      def read: (String key, ?encoding: Encoding) -> String?
+      def read: (String key) -> String?
       def store: (String key, Pathname src) -> bool
       def delete: (String key) -> bool
       def clear: () -> void

--- a/sig/factorix/cache/file_system.rbs
+++ b/sig/factorix/cache/file_system.rbs
@@ -13,7 +13,7 @@ module Factorix
 
       def fetch: (String key, Pathname output) -> bool
 
-      def read: (String key, ?encoding: Encoding | String) -> String?
+      def read: (String key) -> String?
 
       def store: (String key, Pathname src) -> bool
 

--- a/sig/factorix/cache/redis.rbs
+++ b/sig/factorix/cache/redis.rbs
@@ -11,7 +11,7 @@ module Factorix
 
       def exist?: (String key) -> bool
 
-      def read: (String key, ?encoding: Encoding) -> String?
+      def read: (String key) -> String?
 
       def write_to: (String key, Pathname output) -> bool
 

--- a/spec/factorix/api/mod_portal_api_spec.rb
+++ b/spec/factorix/api/mod_portal_api_spec.rb
@@ -32,7 +32,7 @@ RSpec.describe Factorix::API::MODPortalAPI do
 
     context "when cache hit" do
       before do
-        allow(cache).to receive(:read).with("https://mods.factorio.com/api/mods", encoding: "UTF-8").and_return(response_body)
+        allow(cache).to receive(:read).with("https://mods.factorio.com/api/mods").and_return(response_body)
       end
 
       it "returns cached data without making HTTP request" do
@@ -88,7 +88,7 @@ RSpec.describe Factorix::API::MODPortalAPI do
 
     context "when cache hit" do
       before do
-        allow(cache).to receive(:read).with("https://mods.factorio.com/api/mods/example-mod", encoding: "UTF-8").and_return(response_body)
+        allow(cache).to receive(:read).with("https://mods.factorio.com/api/mods/example-mod").and_return(response_body)
       end
 
       it "returns cached data" do
@@ -143,7 +143,7 @@ RSpec.describe Factorix::API::MODPortalAPI do
 
     context "when cache hit" do
       before do
-        allow(cache).to receive(:read).with("https://mods.factorio.com/api/mods/example-mod/full", encoding: "UTF-8").and_return(response_body)
+        allow(cache).to receive(:read).with("https://mods.factorio.com/api/mods/example-mod/full").and_return(response_body)
       end
 
       it "returns cached data" do

--- a/spec/factorix/cache/file_system_spec.rb
+++ b/spec/factorix/cache/file_system_spec.rb
@@ -147,17 +147,10 @@ RSpec.describe Factorix::Cache::FileSystem do
         File.write(cache_path, "cached content")
       end
 
-      it "reads the cache file as a binary string by default" do
+      it "reads the cache file as a binary string" do
         content = cache.read(logical_key)
         expect(content).to eq("cached content")
         expect(content.encoding).to eq(Encoding::ASCII_8BIT)
-      end
-
-      it "reads the cache file with specified encoding" do
-        File.write(cache_path, "日本語コンテンツ")
-        content = cache.read(logical_key, encoding: Encoding::UTF_8)
-        expect(content).to eq("日本語コンテンツ")
-        expect(content.encoding).to eq(Encoding::UTF_8)
       end
     end
 
@@ -190,13 +183,6 @@ RSpec.describe Factorix::Cache::FileSystem do
       it "decompresses the data when reading" do
         content = cache.read(logical_key)
         expect(content).to eq("compressed content")
-      end
-
-      it "applies the specified encoding after decompression" do
-        cache_path.binwrite(Zlib.deflate("日本語コンテンツ"))
-        content = cache.read(logical_key, encoding: Encoding::UTF_8)
-        expect(content).to eq("日本語コンテンツ")
-        expect(content.encoding).to eq(Encoding::UTF_8)
       end
     end
   end

--- a/spec/factorix/cache/redis_spec.rb
+++ b/spec/factorix/cache/redis_spec.rb
@@ -57,18 +57,9 @@ RSpec.describe Factorix::Cache::Redis do
 
   describe "#read" do
     context "when cache entry exists" do
-      it "reads data with binary encoding by default" do
+      it "reads data from Redis" do
         allow(redis_client).to receive(:get).with(data_key).and_return("cached content")
-        content = cache.read(logical_key)
-        expect(content).to eq("cached content")
-        expect(content.encoding).to eq(Encoding::ASCII_8BIT)
-      end
-
-      it "reads data with specified encoding" do
-        allow(redis_client).to receive(:get).with(data_key).and_return("UTF-8 content")
-        content = cache.read(logical_key, encoding: Encoding::UTF_8)
-        expect(content).to eq("UTF-8 content")
-        expect(content.encoding).to eq(Encoding::UTF_8)
+        expect(cache.read(logical_key)).to eq("cached content")
       end
     end
 


### PR DESCRIPTION
## Summary

Remove the `encoding` parameter from cache `read` methods for cleaner separation of concerns. The cache layer now acts as pure binary storage, with encoding handled by consumers.

## Changes

- Remove `encoding` parameter from `Cache::Base#read`, `FileSystem#read`, `Redis#read`
- Update callers to use `(+cached).force_encoding(Encoding::UTF_8)` pattern
- Update RBS type signatures
- Remove encoding-specific tests (testing Ruby's behavior)

## Test Plan

- `bundle exec rake` passes (1359 examples, 0 failures)
- Type checking with Steep passes

Closes #28
