### PR TITLE
:recycle: Refactor CLI commands to use lazy portal resolution

### DIFF
--- a/lib/factorix/cli/commands/download_support.rb
+++ b/lib/factorix/cli/commands/download_support.rb
@@ -97,8 +97,7 @@ module Factorix
 
           futures = targets.map {|target|
             Concurrent::Future.execute(executor: pool) do
-              thread_portal = Container[:portal]
-              thread_downloader = thread_portal.mod_download_api.downloader
+              downloader = portal.mod_download_api.downloader
 
               presenter = multi_presenter.register(
                 target[:mod].name,
@@ -106,9 +105,9 @@ module Factorix
               )
               handler = Progress::DownloadHandler.new(presenter)
 
-              thread_downloader.subscribe(handler)
-              thread_portal.download_mod(target[:release], target[:output_path])
-              thread_downloader.unsubscribe(handler)
+              downloader.subscribe(handler)
+              portal.download_mod(target[:release], target[:output_path])
+              downloader.unsubscribe(handler)
             end
           }
 

--- a/lib/factorix/cli/commands/mod/download.rb
+++ b/lib/factorix/cli/commands/mod/download.rb
@@ -10,14 +10,13 @@ module Factorix
         # Download MOD files from Factorio MOD Portal
         class Download < Base
           include DownloadSupport
+          include PortalSupport
           # @!parse
-          #   # @return [Portal]
-          #   attr_reader :portal
           #   # @return [Dry::Logger::Dispatcher]
           #   attr_reader :logger
           #   # @return [Runtime]
           #   attr_reader :runtime
-          include Import[:portal, :logger, :runtime]
+          include Import[:logger, :runtime]
 
           desc "Download MOD files from Factorio MOD Portal"
 

--- a/lib/factorix/cli/commands/mod/edit.rb
+++ b/lib/factorix/cli/commands/mod/edit.rb
@@ -6,10 +6,7 @@ module Factorix
       module MOD
         # Edit MOD metadata on Factorio MOD Portal
         class Edit < Base
-          # @!parse
-          #   # @return [Portal]
-          #   attr_reader :portal
-          include Import[:portal]
+          include PortalSupport
 
           desc "Edit MOD metadata on Factorio MOD Portal"
 

--- a/lib/factorix/cli/commands/mod/image/add.rb
+++ b/lib/factorix/cli/commands/mod/image/add.rb
@@ -7,10 +7,7 @@ module Factorix
         module Image
           # Add an image to a MOD on Factorio MOD Portal
           class Add < Base
-            # @!parse
-            #   # @return [Portal]
-            #   attr_reader :portal
-            include Import[:portal]
+            include PortalSupport
 
             desc "Add an image to a MOD"
 

--- a/lib/factorix/cli/commands/mod/image/edit.rb
+++ b/lib/factorix/cli/commands/mod/image/edit.rb
@@ -7,10 +7,7 @@ module Factorix
         module Image
           # Edit MOD's image list on Factorio MOD Portal
           class Edit < Base
-            # @!parse
-            #   # @return [Portal]
-            #   attr_reader :portal
-            include Import[:portal]
+            include PortalSupport
 
             desc "Edit MOD's image list (reorder/remove images)"
 

--- a/lib/factorix/cli/commands/mod/image/list.rb
+++ b/lib/factorix/cli/commands/mod/image/list.rb
@@ -7,10 +7,7 @@ module Factorix
         module Image
           # List images for a MOD on Factorio MOD Portal
           class List < Base
-            # @!parse
-            #   # @return [Portal]
-            #   attr_reader :portal
-            include Import[:portal]
+            include PortalSupport
 
             desc "List images for a MOD"
 

--- a/lib/factorix/cli/commands/mod/install.rb
+++ b/lib/factorix/cli/commands/mod/install.rb
@@ -14,15 +14,14 @@ module Factorix
           backup_support!
 
           include DownloadSupport
+          include PortalSupport
 
           # @!parse
-          #   # @return [Portal]
-          #   attr_reader :portal
           #   # @return [Dry::Logger::Dispatcher]
           #   attr_reader :logger
           #   # @return [Factorix::Runtime]
           #   attr_reader :runtime
-          include Import[:portal, :logger, :runtime]
+          include Import[:logger, :runtime]
 
           desc "Install MOD(s) from Factorio MOD Portal (downloads to MOD directory and enables)"
 

--- a/lib/factorix/cli/commands/mod/search.rb
+++ b/lib/factorix/cli/commands/mod/search.rb
@@ -8,12 +8,11 @@ module Factorix
       module MOD
         # Search MODs on Factorio MOD Portal
         class Search < Base
+          include PortalSupport
           # @!parse
-          #   # @return [Portal]
-          #   attr_reader :portal
           #   # @return [Runtime]
           #   attr_reader :runtime
-          include Import[:portal, :runtime]
+          include Import[:runtime]
 
           desc "Search MOD(s) on Factorio MOD Portal"
 

--- a/lib/factorix/cli/commands/mod/show.rb
+++ b/lib/factorix/cli/commands/mod/show.rb
@@ -20,11 +20,10 @@ module Factorix
           INCOMPATIBLE_MOD_STYLE = TIntMe[:red]
           private_constant :INCOMPATIBLE_MOD_STYLE
           # @!parse
-          #   # @return [Portal]
-          #   attr_reader :portal
           #   # @return [Runtime]
           #   attr_reader :runtime
-          include Import[:portal, :runtime]
+          include Import[:runtime]
+          include PortalSupport
 
           desc "Show MOD details from Factorio MOD Portal"
 

--- a/lib/factorix/cli/commands/mod/sync.rb
+++ b/lib/factorix/cli/commands/mod/sync.rb
@@ -14,15 +14,14 @@ module Factorix
           backup_support!
 
           include DownloadSupport
+          include PortalSupport
 
           # @!parse
-          #   # @return [Portal]
-          #   attr_reader :portal
           #   # @return [Dry::Logger::Dispatcher]
           #   attr_reader :logger
           #   # @return [Factorix::Runtime]
           #   attr_reader :runtime
-          include Import[:portal, :logger, :runtime]
+          include Import[:logger, :runtime]
 
           desc "Sync MOD states and startup settings from a save file"
 

--- a/lib/factorix/cli/commands/mod/update.rb
+++ b/lib/factorix/cli/commands/mod/update.rb
@@ -13,14 +13,13 @@ module Factorix
           require_game_stopped!
           backup_support!
 
+          include PortalSupport
           # @!parse
-          #   # @return [Portal]
-          #   attr_reader :portal
           #   # @return [Dry::Logger::Dispatcher]
           #   attr_reader :logger
           #   # @return [Factorix::Runtime]
           #   attr_reader :runtime
-          include Import[:portal, :logger, :runtime]
+          include Import[:logger, :runtime]
 
           desc "Update MOD(s) to their latest versions"
 
@@ -196,8 +195,7 @@ module Factorix
 
             futures = targets.map {|target|
               Concurrent::Future.execute(executor: pool) do
-                thread_portal = Container[:portal]
-                thread_downloader = thread_portal.mod_download_api.downloader
+                downloader = portal.mod_download_api.downloader
 
                 presenter = multi_presenter.register(
                   target[:mod].name,
@@ -205,9 +203,9 @@ module Factorix
                 )
                 handler = Progress::DownloadHandler.new(presenter)
 
-                thread_downloader.subscribe(handler)
-                thread_portal.download_mod(target[:latest_release], target[:output_path])
-                thread_downloader.unsubscribe(handler)
+                downloader.subscribe(handler)
+                portal.download_mod(target[:latest_release], target[:output_path])
+                downloader.unsubscribe(handler)
               end
             }
 

--- a/lib/factorix/cli/commands/mod/upload.rb
+++ b/lib/factorix/cli/commands/mod/upload.rb
@@ -6,10 +6,7 @@ module Factorix
       module MOD
         # Upload MOD to Factorio MOD Portal (handles both new and update)
         class Upload < Base
-          # @!parse
-          #   # @return [Portal]
-          #   attr_reader :portal
-          include Import[:portal]
+          include PortalSupport
 
           desc "Upload MOD to Factorio MOD Portal (handles both new and update)"
 

--- a/lib/factorix/cli/commands/portal_support.rb
+++ b/lib/factorix/cli/commands/portal_support.rb
@@ -1,0 +1,27 @@
+# frozen_string_literal: true
+
+module Factorix
+  class CLI
+    module Commands
+      # Provides lazy Portal resolution for CLI commands
+      #
+      # This module defers Portal dependency resolution until first use,
+      # allowing configuration to be loaded before cache backends are resolved.
+      #
+      # @example
+      #   class Show < Base
+      #     include PortalSupport
+      #
+      #     def call(mod_name:, **)
+      #       mod_info = portal.get_mod(mod_name)
+      #     end
+      #   end
+      module PortalSupport
+        # Lazily resolve Portal from Container
+        #
+        # @return [Portal] the portal instance
+        private def portal = @portal ||= Container[:portal]
+      end
+    end
+  end
+end

--- a/spec/factorix/cli/commands/mod/download_spec.rb
+++ b/spec/factorix/cli/commands/mod/download_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Factorix::CLI::Commands::MOD::Download do
   let(:logger) { instance_double(Dry::Logger::Dispatcher, debug: nil, info: nil, warn: nil, error: nil) }
   let(:runtime) { instance_double(Factorix::Runtime::Base, mod_dir: Pathname("/fake/mods")) }
   let(:downloader) { instance_double(Factorix::Transfer::Downloader) }
-  let(:command) { Factorix::CLI::Commands::MOD::Download.new(portal:, logger:, runtime:) }
+  let(:command) { Factorix::CLI::Commands::MOD::Download.new(logger:, runtime:) }
   let(:mod_info) do
     Factorix::API::MODInfo.new(
       name: "test-mod",

--- a/spec/factorix/cli/commands/mod/edit_spec.rb
+++ b/spec/factorix/cli/commands/mod/edit_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe Factorix::CLI::Commands::MOD::Edit do
   let(:portal) { instance_double(Factorix::Portal) }
-  let(:command) { Factorix::CLI::Commands::MOD::Edit.new(portal:) }
+  let(:command) { Factorix::CLI::Commands::MOD::Edit.new }
 
   before do
     allow(Factorix::Container).to receive(:[]).and_call_original

--- a/spec/factorix/cli/commands/mod/image/add_spec.rb
+++ b/spec/factorix/cli/commands/mod/image/add_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe Factorix::CLI::Commands::MOD::Image::Add do
   let(:portal) { instance_double(Factorix::Portal) }
-  let(:command) { Factorix::CLI::Commands::MOD::Image::Add.new(portal:) }
+  let(:command) { Factorix::CLI::Commands::MOD::Image::Add.new }
   let(:tmpdir) { Dir.mktmpdir }
 
   before do

--- a/spec/factorix/cli/commands/mod/image/edit_spec.rb
+++ b/spec/factorix/cli/commands/mod/image/edit_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe Factorix::CLI::Commands::MOD::Image::Edit do
   let(:portal) { instance_double(Factorix::Portal) }
-  let(:command) { Factorix::CLI::Commands::MOD::Image::Edit.new(portal:) }
+  let(:command) { Factorix::CLI::Commands::MOD::Image::Edit.new }
 
   before do
     allow(Factorix::Container).to receive(:[]).and_call_original

--- a/spec/factorix/cli/commands/mod/image/list_spec.rb
+++ b/spec/factorix/cli/commands/mod/image/list_spec.rb
@@ -2,7 +2,7 @@
 
 RSpec.describe Factorix::CLI::Commands::MOD::Image::List do
   let(:portal) { instance_double(Factorix::Portal) }
-  let(:command) { Factorix::CLI::Commands::MOD::Image::List.new(portal:) }
+  let(:command) { Factorix::CLI::Commands::MOD::Image::List.new }
 
   before do
     allow(Factorix::Container).to receive(:[]).and_call_original

--- a/spec/factorix/cli/commands/mod/install_spec.rb
+++ b/spec/factorix/cli/commands/mod/install_spec.rb
@@ -16,8 +16,7 @@ RSpec.describe Factorix::CLI::Commands::MOD::Install do
   let(:command) do
     Factorix::CLI::Commands::MOD::Install.new(
       runtime:,
-      logger:,
-      portal:
+      logger:
     )
   end
   let(:mod_list_path) { Pathname("/fake/path/mod-list.json") }

--- a/spec/factorix/cli/commands/mod/search_spec.rb
+++ b/spec/factorix/cli/commands/mod/search_spec.rb
@@ -4,7 +4,7 @@ RSpec.describe Factorix::CLI::Commands::MOD::Search do
   let(:data_dir) { Pathname(Dir.mktmpdir) }
   let(:runtime) { instance_double(Factorix::Runtime::Base, data_dir:) }
   let(:portal) { instance_double(Factorix::Portal) }
-  let(:command) { Factorix::CLI::Commands::MOD::Search.new(runtime:, portal:) }
+  let(:command) { Factorix::CLI::Commands::MOD::Search.new(runtime:) }
 
   let(:mod_info) do
     Factorix::API::MODInfo.new(

--- a/spec/factorix/cli/commands/mod/show_spec.rb
+++ b/spec/factorix/cli/commands/mod/show_spec.rb
@@ -5,7 +5,7 @@ RSpec.describe Factorix::CLI::Commands::MOD::Show do
   let(:mod_list_path) { Pathname(Dir.mktmpdir) / "mod-list.json" }
   let(:runtime) { instance_double(Factorix::Runtime::Base, mod_dir:, mod_list_path:) }
   let(:portal) { instance_double(Factorix::Portal) }
-  let(:command) { Factorix::CLI::Commands::MOD::Show.new(runtime:, portal:) }
+  let(:command) { Factorix::CLI::Commands::MOD::Show.new(runtime:) }
 
   let(:release_data) do
     {

--- a/spec/factorix/cli/commands/mod/sync_spec.rb
+++ b/spec/factorix/cli/commands/mod/sync_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe Factorix::CLI::Commands::MOD::Sync do
   let(:command) do
     Factorix::CLI::Commands::MOD::Sync.new(
       runtime:,
-      portal:,
       logger:
     )
   end

--- a/spec/factorix/cli/commands/mod/update_spec.rb
+++ b/spec/factorix/cli/commands/mod/update_spec.rb
@@ -16,8 +16,7 @@ RSpec.describe Factorix::CLI::Commands::MOD::Update do
   let(:command) do
     Factorix::CLI::Commands::MOD::Update.new(
       runtime:,
-      logger:,
-      portal:
+      logger:
     )
   end
   let(:mod_list_path) { Pathname("/fake/path/mod-list.json") }

--- a/spec/factorix/cli/commands/mod/upload_spec.rb
+++ b/spec/factorix/cli/commands/mod/upload_spec.rb
@@ -7,7 +7,7 @@ RSpec.describe Factorix::CLI::Commands::MOD::Upload do
   let(:portal) { instance_double(Factorix::Portal) }
   let(:mod_management_api) { instance_double(Factorix::API::MODManagementAPI) }
   let(:uploader) { instance_double(Factorix::Transfer::Uploader) }
-  let(:command) { Factorix::CLI::Commands::MOD::Upload.new(portal:) }
+  let(:command) { Factorix::CLI::Commands::MOD::Upload.new }
 
   let(:temp_dir) { Dir.mktmpdir }
   let(:zip_path) { Pathname(temp_dir) / "test-mod_1.0.0.zip" }


### PR DESCRIPTION
## Summary

Refactor CLI commands to use lazy Portal dependency resolution, fixing Issue #27.

## Changes

- Create `PortalSupport` module with lazy `portal` method
- Replace `Import[:portal]` with `include PortalSupport` in 11 CLI commands
- Remove direct `Container[:portal]` calls from `download_support.rb`
- Update spec files to not pass `portal:` to command constructors

Fixes #27
