### PR TITLE
:recycle: Refactor FileSystem cache to use cache_type parameter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,11 @@
 ## [Unreleased]
 
+### Changed
+
+- Refactor `Cache::FileSystem` to use `cache_type:` parameter instead of `root:` (#25)
+  - Aligns interface with `Cache::Redis` for consistent backend initialization
+  - Cache directory is now auto-computed from `Container[:runtime].factorix_cache_dir / cache_type`
+
 ### Added
 
 - Add Redis cache backend (`Cache::Redis`) with distributed locking support (#19)

--- a/doc/components/storage.md
+++ b/doc/components/storage.md
@@ -14,6 +14,15 @@ Filesystem-based cache (Cache::FileSystem).
 - Cache expiration management
 - Caches are created independently (API, download, info.json)
 
+### Backend Initialization
+
+Both cache backends (`FileSystem` and `Redis`) receive a `cache_type` parameter (`:download`, `:api`, or `:info_json`) and auto-compute their storage locations:
+
+- **FileSystem**: Cache directory is `{factorix_cache_dir}/{cache_type}`
+- **Redis**: Namespace prefix is `factorix-cache:{cache_type}:`
+
+This ensures consistent naming across backends and simplifies configuration.
+
 ### Compression Support
 
 Optional zlib compression for cached data:

--- a/lib/factorix.rb
+++ b/lib/factorix.rb
@@ -44,7 +44,6 @@ module Factorix
       setting :backend, default: :file_system
       setting :ttl, default: nil # nil for unlimited (MOD files are immutable)
       setting :file_system do
-        setting :root, constructor: ->(value) { value ? Pathname(value) : nil }
         setting :max_file_size, default: nil # nil for unlimited
         setting :compression_threshold, default: nil # nil for no compression (binary files)
       end
@@ -59,7 +58,6 @@ module Factorix
       setting :backend, default: :file_system
       setting :ttl, default: 3600 # 1 hour (API responses may change)
       setting :file_system do
-        setting :root, constructor: ->(value) { value ? Pathname(value) : nil }
         setting :max_file_size, default: 10 * 1024 * 1024 # 10MiB (JSON responses)
         setting :compression_threshold, default: 0 # always compress (JSON is highly compressible)
       end
@@ -74,7 +72,6 @@ module Factorix
       setting :backend, default: :file_system
       setting :ttl, default: nil # nil for unlimited (info.json is immutable within a MOD ZIP)
       setting :file_system do
-        setting :root, constructor: ->(value) { value ? Pathname(value) : nil }
         setting :max_file_size, default: nil # nil for unlimited (info.json is small)
         setting :compression_threshold, default: 0 # always compress (JSON is highly compressible)
       end
@@ -132,12 +129,6 @@ module Factorix
 
   Import = Dry::AutoInject(Container)
   public_constant :Import
-
-  # Initialize cache directory defaults after Container is loaded
-  runtime = Container.resolve(:runtime)
-  config.cache.download.file_system.root = runtime.factorix_cache_dir / "download"
-  config.cache.api.file_system.root = runtime.factorix_cache_dir / "api"
-  config.cache.info_json.file_system.root = runtime.factorix_cache_dir / "info_json"
 
   # @deprecated Use {Container} for DI and {Factorix} for configuration. Will be removed in v1.0.
   class Application

--- a/lib/factorix/cache/file_system.rb
+++ b/lib/factorix/cache/file_system.rb
@@ -35,16 +35,17 @@ module Factorix
       private_constant :ZLIB_CMF_BYTE
 
       # Initialize a new file system cache storage.
-      # Creates the cache directory if it doesn't exist
+      # Creates the cache directory if it doesn't exist.
+      # Cache directory is auto-calculated as: factorix_cache_dir / cache_type
       #
-      # @param dir [Pathname] path to the cache directory
+      # @param cache_type [Symbol] cache type for directory name (e.g., :api, :download)
       # @param max_file_size [Integer, nil] maximum file size in bytes (nil for unlimited)
       # @param compression_threshold [Integer, nil] compress data larger than this size in bytes
       #   (nil: no compression, 0: always compress, N: compress if >= N bytes)
       # @param ttl [Integer, nil] time-to-live in seconds (nil for unlimited)
-      def initialize(root:, max_file_size: nil, compression_threshold: nil, **)
+      def initialize(cache_type:, max_file_size: nil, compression_threshold: nil, **)
         super(**)
-        @cache_dir = root
+        @cache_dir = Container[:runtime].factorix_cache_dir / cache_type.to_s
         @max_file_size = max_file_size
         @compression_threshold = compression_threshold
         @cache_dir.mkpath

--- a/lib/factorix/container.rb
+++ b/lib/factorix/container.rb
@@ -51,9 +51,9 @@ module Factorix
       c = Factorix.config.cache.download
       case c.backend
       when :file_system
-        Cache::FileSystem.new(ttl: c.ttl, **c.file_system.to_h)
+        Cache::FileSystem.new(cache_type: :download, ttl: c.ttl, **c.file_system.to_h)
       when :redis
-        Cache::Redis.new(ttl: c.ttl, cache_type: :download, **c.redis.to_h)
+        Cache::Redis.new(cache_type: :download, ttl: c.ttl, **c.redis.to_h)
       else
         raise ConfigurationError, "Unknown cache backend: #{c.backend}"
       end
@@ -64,9 +64,9 @@ module Factorix
       c = Factorix.config.cache.api
       case c.backend
       when :file_system
-        Cache::FileSystem.new(ttl: c.ttl, **c.file_system.to_h)
+        Cache::FileSystem.new(cache_type: :api, ttl: c.ttl, **c.file_system.to_h)
       when :redis
-        Cache::Redis.new(ttl: c.ttl, cache_type: :api, **c.redis.to_h)
+        Cache::Redis.new(cache_type: :api, ttl: c.ttl, **c.redis.to_h)
       else
         raise ConfigurationError, "Unknown cache backend: #{c.backend}"
       end
@@ -77,9 +77,9 @@ module Factorix
       c = Factorix.config.cache.info_json
       case c.backend
       when :file_system
-        Cache::FileSystem.new(ttl: c.ttl, **c.file_system.to_h)
+        Cache::FileSystem.new(cache_type: :info_json, ttl: c.ttl, **c.file_system.to_h)
       when :redis
-        Cache::Redis.new(ttl: c.ttl, cache_type: :info_json, **c.redis.to_h)
+        Cache::Redis.new(cache_type: :info_json, ttl: c.ttl, **c.redis.to_h)
       else
         raise ConfigurationError, "Unknown cache backend: #{c.backend}"
       end

--- a/sig/factorix/cache/file_system.rbs
+++ b/sig/factorix/cache/file_system.rbs
@@ -7,11 +7,11 @@ module Factorix
     class FileSystem < Base
       LOCK_FILE_LIFETIME: Integer
 
-      def initialize: (dir: Pathname, ?ttl: Integer?, ?max_file_size: Integer?, ?compression_threshold: Integer?) -> void
+      def initialize: (cache_type: Symbol, ?ttl: Integer?, ?max_file_size: Integer?, ?compression_threshold: Integer?) -> void
 
       def exist?: (String key) -> bool
 
-      def fetch: (String key, Pathname output) -> bool
+      def write_to: (String key, Pathname output) -> bool
 
       def read: (String key) -> String?
 

--- a/spec/factorix/container_spec.rb
+++ b/spec/factorix/container_spec.rb
@@ -227,12 +227,6 @@ RSpec.describe Factorix::Container do
       it "has default max_file_size of nil" do
         expect(Factorix.config.cache.download.file_system.max_file_size).to be_nil
       end
-
-      it "can be overridden" do
-        custom_path = Pathname("/custom/cache/download")
-        Factorix.config.cache.download.file_system.root = custom_path
-        expect(Factorix.config.cache.download.file_system.root).to eq(custom_path)
-      end
     end
 
     describe "cache.api" do


### PR DESCRIPTION
## Summary

Refactor `Cache::FileSystem` to use `cache_type:` parameter instead of `root:`, aligning its interface with `Cache::Redis` for consistent backend initialization.

## Changes

- Replace `root:` parameter with `cache_type:` in `FileSystem#initialize`
- Auto-compute cache directory from `Container[:runtime].factorix_cache_dir / cache_type`
- Remove redundant `root` settings from configuration
- Update documentation and tests

## Test Plan

- Run `bundle exec rake` (all tests pass)

Fixes #25
