### PR TITLE
:lock: Strip query parameters from download cache keys

### DIFF
--- a/lib/factorix/transfer/downloader.rb
+++ b/lib/factorix/transfer/downloader.rb
@@ -53,7 +53,7 @@ module Factorix
         end
 
         logger.info("Starting download", output: output.to_s)
-        cache_key = url.to_s
+        cache_key = strip_query(url)
 
         case try_cache_hit(cache_key, output, expected_sha1:)
         when :hit
@@ -143,6 +143,14 @@ module Factorix
         logger.error("SHA1 digest mismatch", expected: expected_sha1, actual: actual_sha1)
         raise DigestMismatchError, "SHA1 mismatch: expected #{expected_sha1}, got #{actual_sha1}"
       end
+
+      # Strip query parameters from a URI to create a safe cache key.
+      # This prevents sensitive data (e.g., authentication tokens) from being
+      # stored in cache metadata.
+      #
+      # @param uri [URI] the URI to strip
+      # @return [String] URI string without query parameters
+      private def strip_query(uri) = uri.dup.tap {|u| u.query = nil }.to_s
 
       # Create a temporary file for downloading, ensuring cleanup after use.
       #

--- a/spec/factorix/transfer/downloader_spec.rb
+++ b/spec/factorix/transfer/downloader_spec.rb
@@ -7,10 +7,10 @@ RSpec.describe Factorix::Transfer::Downloader do
   let(:cache) { instance_double(Factorix::Cache::FileSystem) }
   let(:client) { instance_double(Factorix::HTTP::Client) }
   let(:downloader) { Factorix::Transfer::Downloader.new(cache:, client:) }
-  let(:uri) { URI("https://example.com/file.zip") }
+  let(:uri) { URI("https://example.com/file.zip?username=secret&token=secret123") }
   let(:output_dir) { Pathname(Dir.mktmpdir("output")) }
   let(:output) { output_dir.join("file.zip") }
-  let(:cache_key) { uri.to_s }
+  let(:cache_key) { "https://example.com/file.zip" }
 
   around do |example|
     Dir.glob(File.join(Dir.tmpdir, "factorix*")).each do |dir|


### PR DESCRIPTION
## Summary

Remove sensitive query parameters (username, token) from download cache keys to prevent credentials from being stored in cache metadata files.

## Changes

- Add `strip_query` method to remove query parameters from URIs before using as cache keys
- Update tests to verify query parameters are stripped from cache keys

Fixes #35
