### PR TITLE
:recycle: Remove redundant caching in MODPortalAPI

### DIFF
--- a/spec/factorix/api/mod_portal_api_spec.rb
+++ b/spec/factorix/api/mod_portal_api_spec.rb
@@ -11,45 +11,22 @@ RSpec.describe Factorix::API::MODPortalAPI do
     let(:response_body) { '{"results": [], "pagination": {}}' }
     let(:parsed_response) { {results: [], pagination: {}} }
 
-    context "when cache miss" do
-      before do
-        allow(cache).to receive(:read).and_return(nil)
-        allow(cache).to receive(:store)
-        response = instance_double(Factorix::HTTP::Response, code: 200, body: response_body)
-        allow(client).to receive(:get).and_return(response)
-      end
-
-      it "fetches from API and returns parsed JSON" do
-        result = api.get_mods
-        expect(result).to eq(parsed_response)
-      end
-
-      it "stores response in cache" do
-        api.get_mods
-        expect(cache).to have_received(:store).with("https://mods.factorio.com/api/mods", kind_of(Pathname))
-      end
+    before do
+      response = instance_double(Factorix::HTTP::Response, code: 200, body: response_body)
+      allow(client).to receive(:get).and_return(response)
     end
 
-    context "when cache hit" do
-      before do
-        allow(cache).to receive(:read).with("https://mods.factorio.com/api/mods").and_return(response_body)
-      end
+    it "fetches from API and returns parsed JSON" do
+      result = api.get_mods
+      expect(result).to eq(parsed_response)
+    end
 
-      it "returns cached data without making HTTP request" do
-        result = api.get_mods
-        expect(result).to eq(parsed_response)
-        expect(a_request(:get, "https://mods.factorio.com/api/mods")).not_to have_been_made
-      end
+    it "calls client.get with correct URI" do
+      api.get_mods
+      expect(client).to have_received(:get).with(URI("https://mods.factorio.com/api/mods"))
     end
 
     context "with query parameters" do
-      before do
-        allow(cache).to receive(:read).and_return(nil)
-        allow(cache).to receive(:store)
-        response = instance_double(Factorix::HTTP::Response, code: 200, body: response_body)
-        allow(client).to receive(:get).and_return(response)
-      end
-
       it "includes query parameters in request" do
         api.get_mods(page: 2, page_size: 10)
         expect(client).to have_received(:get).with(URI("https://mods.factorio.com/api/mods?page=2&page_size=10"))
@@ -67,47 +44,24 @@ RSpec.describe Factorix::API::MODPortalAPI do
     let(:response_body) { '{"name": "example-mod", "releases": []}' }
     let(:parsed_response) { {name: "example-mod", releases: []} }
 
-    context "when cache miss" do
-      before do
-        allow(cache).to receive(:read).and_return(nil)
-        allow(cache).to receive(:store)
-        response = instance_double(Factorix::HTTP::Response, code: 200, body: response_body)
-        allow(client).to receive(:get).and_return(response)
-      end
-
-      it "fetches MOD info from API" do
-        result = api.get_mod("example-mod")
-        expect(result).to eq(parsed_response)
-      end
-
-      it "stores response in cache" do
-        api.get_mod("example-mod")
-        expect(cache).to have_received(:store)
-      end
+    before do
+      response = instance_double(Factorix::HTTP::Response, code: 200, body: response_body)
+      allow(client).to receive(:get).and_return(response)
     end
 
-    context "when cache hit" do
-      before do
-        allow(cache).to receive(:read).with("https://mods.factorio.com/api/mods/example-mod").and_return(response_body)
-      end
+    it "fetches MOD info from API" do
+      result = api.get_mod("example-mod")
+      expect(result).to eq(parsed_response)
+    end
 
-      it "returns cached data" do
-        result = api.get_mod("example-mod")
-        expect(result).to eq(parsed_response)
-        expect(a_request(:get, "https://mods.factorio.com/api/mods/example-mod")).not_to have_been_made
-      end
+    it "calls client.get with correct URI" do
+      api.get_mod("example-mod")
+      expect(client).to have_received(:get).with(URI("https://mods.factorio.com/api/mods/example-mod"))
     end
 
     context "with MOD name containing spaces" do
       let(:response_body) { '{"name": "Explosive Excavation", "releases": []}' }
       let(:parsed_response) { {name: "Explosive Excavation", releases: []} }
-
-      before do
-        allow(cache).to receive(:read).and_return(nil)
-        allow(cache).to receive(:store)
-        response = instance_double(Factorix::HTTP::Response, code: 200, body: response_body)
-        allow(client).to receive(:get).and_return(response)
-      end
 
       it "encodes spaces as %20 in URL path" do
         api.get_mod("Explosive Excavation")
@@ -122,47 +76,24 @@ RSpec.describe Factorix::API::MODPortalAPI do
     let(:response_body) { '{"name": "example-mod", "changelog": "...", "releases": []}' }
     let(:parsed_response) { {name: "example-mod", changelog: "...", releases: []} }
 
-    context "when cache miss" do
-      before do
-        allow(cache).to receive(:read).and_return(nil)
-        allow(cache).to receive(:store)
-        response = instance_double(Factorix::HTTP::Response, code: 200, body: response_body)
-        allow(client).to receive(:get).and_return(response)
-      end
-
-      it "fetches full MOD info from API" do
-        result = api.get_mod_full("example-mod")
-        expect(result).to eq(parsed_response)
-      end
-
-      it "stores response in cache" do
-        api.get_mod_full("example-mod")
-        expect(cache).to have_received(:store)
-      end
+    before do
+      response = instance_double(Factorix::HTTP::Response, code: 200, body: response_body)
+      allow(client).to receive(:get).and_return(response)
     end
 
-    context "when cache hit" do
-      before do
-        allow(cache).to receive(:read).with("https://mods.factorio.com/api/mods/example-mod/full").and_return(response_body)
-      end
+    it "fetches full MOD info from API" do
+      result = api.get_mod_full("example-mod")
+      expect(result).to eq(parsed_response)
+    end
 
-      it "returns cached data" do
-        result = api.get_mod_full("example-mod")
-        expect(result).to eq(parsed_response)
-        expect(a_request(:get, "https://mods.factorio.com/api/mods/example-mod/full")).not_to have_been_made
-      end
+    it "calls client.get with correct URI" do
+      api.get_mod_full("example-mod")
+      expect(client).to have_received(:get).with(URI("https://mods.factorio.com/api/mods/example-mod/full"))
     end
 
     context "with MOD name containing spaces" do
       let(:response_body) { '{"name": "Explosive Excavation", "changelog": "...", "releases": []}' }
       let(:parsed_response) { {name: "Explosive Excavation", changelog: "...", releases: []} }
-
-      before do
-        allow(cache).to receive(:read).and_return(nil)
-        allow(cache).to receive(:store)
-        response = instance_double(Factorix::HTTP::Response, code: 200, body: response_body)
-        allow(client).to receive(:get).and_return(response)
-      end
 
       it "encodes spaces as %20 in URL path" do
         api.get_mod_full("Explosive Excavation")
@@ -174,11 +105,6 @@ RSpec.describe Factorix::API::MODPortalAPI do
   end
 
   describe "error handling" do
-    before do
-      allow(cache).to receive(:read).and_return(nil)
-      allow(cache).to receive(:store)
-    end
-
     context "when API returns 404 with api_message" do
       before do
         error = Factorix::HTTPNotFoundError.new("404 Not Found", api_message: "Mod not found")
@@ -217,8 +143,6 @@ RSpec.describe Factorix::API::MODPortalAPI do
       let(:response_body) { '{"pagination": {}, "results": []}' }
 
       before do
-        allow(cache).to receive(:read).and_return(nil)
-        allow(cache).to receive(:store)
         response = instance_double(Factorix::HTTP::Response, code: 200, body: response_body)
         allow(client).to receive(:get).and_return(response)
       end


### PR DESCRIPTION
## Summary

Remove redundant double caching in `MODPortalAPI`. Both the API class and its HTTP client were using the same `:api_cache`, causing duplicate cache operations.

## Changes

- Simplify `fetch_with_cache` to delegate caching entirely to `CacheDecorator`
- Remove `store_in_cache` and `fetch_from_api` methods (no longer needed)
- Remove unused `require "tempfile"`
- Update tests to reflect simplified implementation

Fixes #30
