### PR TITLE
:sparkles: Add backend-specific info to cache stat command

### DIFF
--- a/factorix.gemspec
+++ b/factorix.gemspec
@@ -41,6 +41,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "dry-configurable", "~> 1.0"
   spec.add_dependency "dry-core", "~> 1.0"
   spec.add_dependency "dry-events", "~> 1.1"
+  spec.add_dependency "dry-inflector", "~> 1.0"
   spec.add_dependency "dry-logger", "~> 1.2"
   spec.add_dependency "parslet", "~> 2.0"
   spec.add_dependency "retriable", "~> 3.1"

--- a/lib/factorix/cache/base.rb
+++ b/lib/factorix/cache/base.rb
@@ -103,6 +103,14 @@ module Factorix
       # @return [Enumerator] if no block given
       # @abstract
       def each = raise NotImplementedError, "#{self.class}#each must be implemented"
+
+      # Return backend-specific information.
+      #
+      # Subclasses should override this method to provide configuration details
+      # specific to their backend implementation.
+      #
+      # @return [Hash] backend-specific information (empty by default)
+      def backend_info = {}
     end
   end
 end

--- a/lib/factorix/cache/redis.rb
+++ b/lib/factorix/cache/redis.rb
@@ -280,13 +280,7 @@ module Factorix
       # @param url [String, nil] Redis URL
       # @return [String] URL with credentials masked (defaults to redis://localhost:6379/0)
       private def mask_url(url)
-        url ||= DEFAULT_URL
-
-        uri = URI.parse(url)
-        return url unless uri.userinfo
-
-        uri.userinfo = "***:***"
-        uri.to_s
+        URI.parse(url || DEFAULT_URL).tap {|uri| uri.userinfo = "***:***" if uri.userinfo }.to_s
       end
     end
   end

--- a/lib/factorix/cache/redis.rb
+++ b/lib/factorix/cache/redis.rb
@@ -54,7 +54,8 @@ module Factorix
       # @param ttl [Integer, nil] time-to-live in seconds (nil for unlimited)
       def initialize(cache_type:, url: nil, lock_timeout: DEFAULT_LOCK_TIMEOUT, **)
         super(**)
-        @redis = ::Redis.new(url: url || ENV.fetch("REDIS_URL", nil))
+        @url = url || ENV.fetch("REDIS_URL", nil)
+        @redis = ::Redis.new(url: @url)
         @namespace = "factorix-cache:#{cache_type}"
         @lock_timeout = lock_timeout
         logger.info("Initializing Redis cache", namespace: @namespace, ttl: @ttl, lock_timeout: @lock_timeout)
@@ -235,6 +236,18 @@ module Factorix
         end
       end
 
+      # Return backend-specific information.
+      #
+      # @return [Hash] backend configuration
+      def backend_info
+        {
+          type: "redis",
+          url: mask_url(@url),
+          namespace: @namespace,
+          lock_timeout: @lock_timeout
+        }
+      end
+
       # Generate data key for the given logical key.
       #
       # @param logical_key [String] logical key
@@ -258,6 +271,23 @@ module Factorix
       # @param data_k [String] namespaced data key
       # @return [String] logical key
       private def logical_key_from_data_key(data_k) = data_k.delete_prefix("#{@namespace}:")
+
+      DEFAULT_URL = "redis://localhost:6379/0"
+      private_constant :DEFAULT_URL
+
+      # Mask credentials in Redis URL for safe display.
+      #
+      # @param url [String, nil] Redis URL
+      # @return [String] URL with credentials masked (defaults to redis://localhost:6379/0)
+      private def mask_url(url)
+        url ||= DEFAULT_URL
+
+        uri = URI.parse(url)
+        return url unless uri.userinfo
+
+        uri.userinfo = "***:***"
+        uri.to_s
+      end
     end
   end
 end

--- a/sig/factorix/cache/base.rbs
+++ b/sig/factorix/cache/base.rbs
@@ -21,6 +21,8 @@ module Factorix
 
       def each: () -> Enumerator[[String, Entry], void]
               | () { ([String, Entry]) -> void } -> void
+
+      def backend_info: () -> Hash[Symbol, untyped]
     end
   end
 end

--- a/spec/factorix/cache/base_spec.rb
+++ b/spec/factorix/cache/base_spec.rb
@@ -55,4 +55,10 @@ RSpec.describe Factorix::Cache::Base do
       expect { base.each }.to raise_error(NotImplementedError, /each/)
     end
   end
+
+  describe "#backend_info" do
+    it "returns an empty hash by default" do
+      expect(base.backend_info).to eq({})
+    end
+  end
 end

--- a/spec/factorix/cache/redis_spec.rb
+++ b/spec/factorix/cache/redis_spec.rb
@@ -278,4 +278,48 @@ RSpec.describe Factorix::Cache::Redis do
       expect(entries.first.expired?).to be false
     end
   end
+
+  describe "#backend_info" do
+    it "returns type as redis" do
+      expect(cache.backend_info[:type]).to eq("redis")
+    end
+
+    it "returns namespace" do
+      expect(cache.backend_info[:namespace]).to eq("factorix-cache:api")
+    end
+
+    it "returns default lock_timeout" do
+      expect(cache.backend_info[:lock_timeout]).to eq(Factorix::Cache::Redis::DEFAULT_LOCK_TIMEOUT)
+    end
+
+    context "with custom lock_timeout" do
+      let(:cache) { Factorix::Cache::Redis.new(cache_type: "api", lock_timeout: 60) }
+
+      it "returns configured lock_timeout" do
+        expect(cache.backend_info[:lock_timeout]).to eq(60)
+      end
+    end
+
+    context "with URL without credentials" do
+      let(:cache) { Factorix::Cache::Redis.new(cache_type: "api", url: "redis://localhost:6379/0") }
+
+      it "returns URL as-is" do
+        expect(cache.backend_info[:url]).to eq("redis://localhost:6379/0")
+      end
+    end
+
+    context "with URL containing credentials" do
+      let(:cache) { Factorix::Cache::Redis.new(cache_type: "api", url: "redis://user:password@localhost:6379/0") }
+
+      it "masks credentials in URL" do
+        expect(cache.backend_info[:url]).to eq("redis://***:***@localhost:6379/0")
+      end
+    end
+
+    context "without URL" do
+      it "returns default URL" do
+        expect(cache.backend_info[:url]).to eq("redis://localhost:6379/0")
+      end
+    end
+  end
 end

--- a/spec/factorix/cli/commands/cache/stat_spec.rb
+++ b/spec/factorix/cli/commands/cache/stat_spec.rb
@@ -89,4 +89,28 @@ RSpec.describe Factorix::CLI::Commands::Cache::Stat do
       expect(result.stdout).to include("KiB")
     end
   end
+
+  describe "backend info output" do
+    it "outputs backend-specific information section" do
+      result = run_command(Factorix::CLI::Commands::Cache::Stat)
+
+      expect(result.stdout).to include("Backend:")
+    end
+
+    it "outputs test backend type" do
+      result = run_command(Factorix::CLI::Commands::Cache::Stat)
+
+      expect(result.stdout).to include("Type:")
+      expect(result.stdout).to include("memory")
+    end
+
+    it "includes backend_info in JSON output" do
+      result = run_command(Factorix::CLI::Commands::Cache::Stat, %w[--json])
+
+      json = JSON.parse(result.stdout, symbolize_names: true)
+      expect(json[:download]).to have_key(:backend_info)
+      expect(json[:download][:backend_info]).to have_key(:type)
+      expect(json[:download][:backend_info][:type]).to eq("memory")
+    end
+  end
 end

--- a/spec/support/test_cache_backend.rb
+++ b/spec/support/test_cache_backend.rb
@@ -163,6 +163,16 @@ module Factorix
           size: content.bytesize
         }
       end
+
+      # Return backend-specific information.
+      #
+      # @return [Hash] test backend configuration
+      def backend_info
+        {
+          type: "memory",
+          entries_count: @entries.size
+        }
+      end
     end
   end
 end


### PR DESCRIPTION
## Summary
Add backend-specific information display to the `cache stat` command, allowing users to see configuration details relevant to their cache backend.

## Changes
- Add `backend_info` method to `Cache::Base` (returns empty hash by default)
- Implement `backend_info` in `FileSystem` backend (directory, max_file_size, compression_threshold, stale_locks)
- Implement `backend_info` in `Redis` backend (url with masked credentials, namespace, lock_timeout)
- Display backend info section in stat command output

## Test Plan
- Run `bundle exec rake` to verify all tests pass
- Run `bin/factorix cache stat` to see backend info in output

Fixes #24
