### PR TITLE
Implement S3 cache backend

### DIFF
--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -46,6 +46,7 @@ Naming/PredicateMethod:
   Exclude:
     - lib/factorix/cache/file_system.rb # fetch/store/delete return boolean but are standard cache API names
     - lib/factorix/cache/redis.rb # write_to/store/delete return boolean but are standard cache API names
+    - lib/factorix/cache/s3.rb # store/delete return boolean but are standard cache API names
     - lib/factorix/ser_des/deserializer.rb # read_bool follows binary deserialization naming convention
     - spec/support/test_cache_backend.rb # store/delete return boolean but are standard cache API names
 

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -91,6 +91,10 @@ Metrics/BlockLength:
   Exclude:
     - lib/factorix.rb # Cache configuration block with hierarchical backend settings
 
+Metrics/ModuleLength:
+  Exclude:
+    - lib/factorix.rb # Cache configuration with hierarchical backend settings
+
 ThreadSafety/NewThread:
   Exclude:
     - spec/factorix/runtime/wsl/wsl_path_spec.rb

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,6 +8,12 @@
 
 ### Added
 
+- Add S3 cache backend (`Cache::S3`) for cloud-native deployments (#18)
+  - Optional dependency: requires `aws-sdk-s3` gem in user's Gemfile
+  - Configure with `config.cache.<type>.backend = :s3`
+  - Distributed locking via conditional PUT (`if_none_match: "*"`)
+  - TTL managed via S3 custom metadata, age from native `Last-Modified`
+
 - Add Redis cache backend (`Cache::Redis`) with distributed locking support (#19)
   - Optional dependency: requires `redis` gem (~> 5) in user's Gemfile
   - Configure with `config.cache.<type>.backend = :redis`

--- a/Gemfile
+++ b/Gemfile
@@ -8,6 +8,8 @@ group :development, :test do
   gem "rake", require: false
 
   gem "irb", require: false
+  # AWS SDK for Cache::S3 backend testing
+  gem "aws-sdk-s3", "~> 1", require: false
   # Redis client for Cache::Redis backend testing
   gem "redis", "~> 5", require: false
   gem "repl_type_completor", require: false

--- a/lib/factorix.rb
+++ b/lib/factorix.rb
@@ -51,6 +51,11 @@ module Factorix
         setting :url, default: nil # nil falls back to REDIS_URL env, then localhost:6379
         setting :lock_timeout, default: 30
       end
+      setting :s3 do
+        setting :bucket, default: nil # required when using S3 backend
+        setting :region, default: nil # nil falls back to AWS_REGION env or SDK default
+        setting :lock_timeout, default: 30
+      end
     end
 
     # API cache settings (for API responses)
@@ -65,6 +70,11 @@ module Factorix
         setting :url, default: nil # nil falls back to REDIS_URL env, then localhost:6379
         setting :lock_timeout, default: 30
       end
+      setting :s3 do
+        setting :bucket, default: nil # required when using S3 backend
+        setting :region, default: nil # nil falls back to AWS_REGION env or SDK default
+        setting :lock_timeout, default: 30
+      end
     end
 
     # info.json cache settings (for MOD metadata from ZIP files)
@@ -77,6 +87,11 @@ module Factorix
       end
       setting :redis do
         setting :url, default: nil # nil falls back to REDIS_URL env, then localhost:6379
+        setting :lock_timeout, default: 30
+      end
+      setting :s3 do
+        setting :bucket, default: nil # required when using S3 backend
+        setting :region, default: nil # nil falls back to AWS_REGION env or SDK default
         setting :lock_timeout, default: 30
       end
     end

--- a/lib/factorix/cache/s3.rb
+++ b/lib/factorix/cache/s3.rb
@@ -89,8 +89,7 @@ module Factorix
       def write_to(key, output)
         return false if expired?(key)
 
-        resp = @client.get_object(bucket: @bucket, key: storage_key(key))
-        output.binwrite(resp.body.read)
+        @client.get_object(bucket: @bucket, key: storage_key(key), response_target: output.to_s)
         logger.debug("Cache hit", key:)
         true
       rescue Aws::S3::Errors::NotFound

--- a/lib/factorix/cache/s3.rb
+++ b/lib/factorix/cache/s3.rb
@@ -1,0 +1,385 @@
+# frozen_string_literal: true
+
+begin
+  require "aws-sdk-s3"
+rescue LoadError
+  raise Factorix::Error, "aws-sdk-s3 gem is required for S3 cache backend. Add it to your Gemfile."
+end
+
+require "securerandom"
+
+module Factorix
+  module Cache
+    # S3-based cache storage implementation.
+    #
+    # Stores cache entries in AWS S3 with automatic prefix generation.
+    # TTL is managed via custom metadata on objects.
+    # Supports distributed locking using conditional PUT operations.
+    #
+    # @example Configuration
+    #   Factorix.configure do |config|
+    #     config.cache.download.backend = :s3
+    #     config.cache.download.s3.bucket = "factorix-develop"
+    #     config.cache.download.s3.region = "ap-northeast-1"
+    #     config.cache.download.s3.lock_timeout = 30
+    #   end
+    class S3 < Base
+      # @!parse
+      #   # @return [Dry::Logger::Dispatcher]
+      #   attr_reader :logger
+      include Import[:logger]
+
+      # Default timeout for distributed lock acquisition in seconds.
+      DEFAULT_LOCK_TIMEOUT = 30
+      public_constant :DEFAULT_LOCK_TIMEOUT
+
+      # TTL for distributed locks in seconds.
+      LOCK_TTL = 30
+      private_constant :LOCK_TTL
+
+      # Metadata key for storing expiration timestamp.
+      EXPIRES_AT_KEY = "expires-at"
+      private_constant :EXPIRES_AT_KEY
+
+      # Metadata key for storing creation timestamp.
+      CREATED_AT_KEY = "created-at"
+      private_constant :CREATED_AT_KEY
+
+      # Initialize a new S3 cache storage.
+      #
+      # @param bucket [String] S3 bucket name (required)
+      # @param region [String, nil] AWS region (defaults to AWS_REGION env or SDK default)
+      # @param cache_type [String, Symbol] Cache type for prefix (e.g., :api, :download)
+      # @param lock_timeout [Integer] Timeout for lock acquisition in seconds
+      # @param ttl [Integer, nil] time-to-live in seconds (nil for unlimited)
+      def initialize(bucket:, cache_type:, region: nil, lock_timeout: DEFAULT_LOCK_TIMEOUT, **)
+        super(**)
+        @client = Aws::S3::Client.new(region:)
+        @bucket = bucket
+        @prefix = "cache/#{cache_type}/"
+        @lock_timeout = lock_timeout
+        logger.info("Initializing S3 cache", bucket: @bucket, prefix: @prefix, ttl: @ttl, lock_timeout: @lock_timeout)
+      end
+
+      # Check if a cache entry exists and is not expired.
+      #
+      # @param key [String] logical cache key
+      # @return [Boolean] true if the cache entry exists and is valid
+      def exist?(key)
+        head_object(key)
+        !expired?(key)
+      rescue Aws::S3::Errors::NotFound
+        false
+      end
+
+      # Read a cached entry.
+      #
+      # @param key [String] logical cache key
+      # @return [String, nil] cached content or nil if not found/expired
+      def read(key)
+        return nil if expired?(key)
+
+        resp = @client.get_object(bucket: @bucket, key: storage_key(key))
+        resp.body.read
+      rescue Aws::S3::Errors::NotFound
+        nil
+      end
+
+      # Write cached content to a file.
+      #
+      # @param key [String] logical cache key
+      # @param output [Pathname] path to write the cached content
+      # @return [Boolean] true if written successfully, false if not found/expired
+      def write_to(key, output)
+        return false if expired?(key)
+
+        resp = @client.get_object(bucket: @bucket, key: storage_key(key))
+        output.binwrite(resp.body.read)
+        logger.debug("Cache hit", key:)
+        true
+      rescue Aws::S3::Errors::NotFound
+        false
+      end
+
+      # Store data in the cache.
+      #
+      # @param key [String] logical cache key
+      # @param src [Pathname] path to the source file
+      # @return [Boolean] true if stored successfully
+      def store(key, src)
+        metadata = {CREATED_AT_KEY => Time.now.to_i.to_s}
+        metadata[EXPIRES_AT_KEY] = (Time.now.to_i + @ttl).to_s if @ttl
+
+        @client.put_object(
+          bucket: @bucket,
+          key: storage_key(key),
+          body: src.binread,
+          metadata:
+        )
+
+        logger.debug("Stored in cache", key:, size_bytes: src.size)
+        true
+      end
+
+      # Delete a cache entry.
+      #
+      # @param key [String] logical cache key
+      # @return [Boolean] true if deleted, false if not found
+      def delete(key)
+        return false unless exist_without_expiry_check?(key)
+
+        @client.delete_object(bucket: @bucket, key: storage_key(key))
+        logger.debug("Deleted from cache", key:)
+        true
+      end
+
+      # Clear all cache entries in this prefix.
+      #
+      # @return [void]
+      def clear
+        logger.info("Clearing S3 cache prefix", bucket: @bucket, prefix: @prefix)
+        count = 0
+
+        list_all_objects do |objects|
+          keys_to_delete = objects.filter_map {|obj| {key: obj.key} unless obj.key.end_with?(".lock") }
+          next if keys_to_delete.empty?
+
+          @client.delete_objects(bucket: @bucket, delete: {objects: keys_to_delete})
+          count += keys_to_delete.size
+        end
+
+        logger.info("Cache cleared", objects_removed: count)
+      end
+
+      # Get the age of a cache entry in seconds.
+      #
+      # @param key [String] logical cache key
+      # @return [Integer, nil] age in seconds, or nil if entry doesn't exist
+      def age(key)
+        resp = head_object(key)
+        value = resp.metadata[CREATED_AT_KEY]
+        return nil if value.nil?
+
+        Time.now.to_i - Integer(value, 10)
+      rescue Aws::S3::Errors::NotFound
+        nil
+      end
+
+      # Check if a cache entry has expired based on TTL.
+      #
+      # @param key [String] logical cache key
+      # @return [Boolean] true if expired, false otherwise
+      def expired?(key)
+        return false if @ttl.nil?
+
+        resp = head_object(key)
+        value = resp.metadata[EXPIRES_AT_KEY]
+        return false if value.nil?
+
+        Time.now.to_i > Integer(value, 10)
+      rescue Aws::S3::Errors::NotFound
+        true
+      end
+
+      # Get the size of a cached entry in bytes.
+      #
+      # @param key [String] logical cache key
+      # @return [Integer, nil] size in bytes, or nil if entry doesn't exist/expired
+      def size(key)
+        return nil if expired?(key)
+
+        resp = head_object(key)
+        resp.content_length
+      rescue Aws::S3::Errors::NotFound
+        nil
+      end
+
+      # Execute a block with a distributed lock.
+      # Uses conditional PUT for lock acquisition.
+      #
+      # @param key [String] logical cache key
+      # @yield block to execute with lock held
+      # @raise [LockTimeoutError] if lock cannot be acquired within timeout
+      def with_lock(key)
+        lkey = lock_key(key)
+        lock_value = SecureRandom.uuid
+        deadline = Time.now + @lock_timeout
+
+        loop do
+          if try_acquire_lock(lkey, lock_value)
+            logger.debug("Acquired lock", key:)
+            break
+          end
+
+          cleanup_stale_lock(lkey)
+          raise LockTimeoutError, "Failed to acquire lock for key: #{key}" if Time.now > deadline
+
+          sleep 0.1
+        end
+
+        begin
+          yield
+        ensure
+          @client.delete_object(bucket: @bucket, key: lkey)
+          logger.debug("Released lock", key:)
+        end
+      end
+
+      # Enumerate cache entries.
+      #
+      # @yield [key, entry] logical key and Entry object
+      # @yieldparam key [String] logical cache key
+      # @yieldparam entry [Entry] cache entry metadata
+      # @return [Enumerator] if no block given
+      def each
+        return enum_for(__method__) unless block_given?
+
+        list_all_objects do |objects|
+          objects.each do |obj|
+            next if obj.key.end_with?(".lock")
+
+            logical_key = logical_key_from_storage_key(obj.key)
+            entry = build_entry(obj)
+
+            yield logical_key, entry
+          end
+        end
+      end
+
+      # Return backend-specific information.
+      #
+      # @return [Hash] backend configuration
+      def backend_info
+        {
+          type: "s3",
+          bucket: @bucket,
+          prefix: @prefix,
+          lock_timeout: @lock_timeout
+        }
+      end
+
+      # Generate storage key for the given logical key.
+      #
+      # @param logical_key [String] logical key
+      # @return [String] prefixed storage key
+      private def storage_key(logical_key) = "#{@prefix}#{logical_key}"
+
+      # Generate lock key for the given logical key.
+      #
+      # @param logical_key [String] logical key
+      # @return [String] lock key
+      private def lock_key(logical_key) = "#{@prefix}#{logical_key}.lock"
+
+      # Extract logical key from storage key.
+      #
+      # @param s_key [String] prefixed storage key
+      # @return [String] logical key
+      private def logical_key_from_storage_key(s_key) = s_key.delete_prefix(@prefix)
+
+      # Get object metadata.
+      #
+      # @param key [String] logical key
+      # @return [Aws::S3::Types::HeadObjectOutput] object metadata
+      private def head_object(key)
+        @client.head_object(bucket: @bucket, key: storage_key(key))
+      end
+
+      # Check if object exists without expiry check.
+      #
+      # @param key [String] logical key
+      # @return [Boolean] true if exists
+      private def exist_without_expiry_check?(key)
+        head_object(key)
+        true
+      rescue Aws::S3::Errors::NotFound
+        false
+      end
+
+      # Try to acquire a distributed lock.
+      #
+      # @param lkey [String] lock key
+      # @param lock_value [String] unique lock value
+      # @return [Boolean] true if lock acquired
+      private def try_acquire_lock(lkey, lock_value)
+        lock_body = "#{lock_value}:#{Time.now.to_i + LOCK_TTL}"
+        @client.put_object(
+          bucket: @bucket,
+          key: lkey,
+          body: lock_body,
+          if_none_match: "*"
+        )
+        true
+      rescue Aws::S3::Errors::PreconditionFailed
+        false
+      end
+
+      # Clean up stale lock if expired.
+      #
+      # @param lkey [String] lock key
+      private def cleanup_stale_lock(lkey)
+        resp = @client.get_object(bucket: @bucket, key: lkey)
+        lock_data = resp.body.read
+        _lock_value, expires_at = lock_data.split(":")
+
+        if expires_at && Time.now.to_i > Integer(expires_at, 10)
+          @client.delete_object(bucket: @bucket, key: lkey)
+          logger.debug("Cleaned up stale lock", key: lkey)
+        end
+      rescue Aws::S3::Errors::NotFound
+        # Lock doesn't exist, nothing to clean up
+      end
+
+      # List all objects in the prefix with pagination.
+      #
+      # @yield [Array<Aws::S3::Types::Object>] batch of objects
+      private def list_all_objects
+        continuation_token = nil
+
+        loop do
+          resp = @client.list_objects_v2(
+            bucket: @bucket,
+            prefix: @prefix,
+            continuation_token:
+          )
+
+          yield resp.contents if resp.contents.any?
+
+          break unless resp.is_truncated
+
+          continuation_token = resp.next_continuation_token
+        end
+      end
+
+      # Build an Entry from an S3 object.
+      #
+      # @param obj [Aws::S3::Types::Object] S3 object
+      # @return [Entry] cache entry
+      private def build_entry(obj)
+        age = Time.now - obj.last_modified
+        expired = check_expired_from_metadata(obj.key)
+
+        Entry.new(
+          size: obj.size,
+          age:,
+          expired:
+        )
+      end
+
+      # Check if object is expired by fetching metadata.
+      #
+      # @param storage_key [String] storage key
+      # @return [Boolean] true if expired
+      private def check_expired_from_metadata(storage_key)
+        return false if @ttl.nil?
+
+        resp = @client.head_object(bucket: @bucket, key: storage_key)
+        value = resp.metadata[EXPIRES_AT_KEY]
+        return false if value.nil?
+
+        Time.now.to_i > Integer(value, 10)
+      rescue Aws::S3::Errors::NotFound
+        true
+      end
+    end
+  end
+end

--- a/sig/factorix/cache/s3.rbs
+++ b/sig/factorix/cache/s3.rbs
@@ -1,0 +1,38 @@
+# RBS type signature file
+# NOTE: Do not include private method definitions in RBS files.
+#       Only public interfaces should be documented here.
+
+module Factorix
+  module Cache
+    class S3 < Base
+      DEFAULT_LOCK_TIMEOUT: Integer
+
+      def initialize: (bucket: String, cache_type: String | Symbol, ?region: String?, ?lock_timeout: Integer, ?ttl: Integer?) -> void
+
+      def exist?: (String key) -> bool
+
+      def read: (String key) -> String?
+
+      def write_to: (String key, Pathname output) -> bool
+
+      def store: (String key, Pathname src) -> bool
+
+      def delete: (String key) -> bool
+
+      def clear: () -> void
+
+      def age: (String key) -> Integer?
+
+      def expired?: (String key) -> bool
+
+      def size: (String key) -> Integer?
+
+      def with_lock: [T] (String key) { () -> T } -> T
+
+      def each: () { (String, Entry) -> void } -> void
+              | () -> Enumerator[[String, Entry], void]
+
+      def backend_info: () -> Hash[Symbol, untyped]
+    end
+  end
+end

--- a/spec/factorix/cache/s3_spec.rb
+++ b/spec/factorix/cache/s3_spec.rb
@@ -218,17 +218,16 @@ RSpec.describe Factorix::Cache::S3 do
   end
 
   describe "#age" do
-    context "when object exists with created-at metadata" do
-      let(:created_at) { Time.now.to_i - 3600 }
-
+    context "when object exists" do
       before do
         s3_client.stub_responses(:head_object, {
           content_length: 100,
-          metadata: {"created-at" => created_at.to_s}
+          last_modified: Time.now - 3600,
+          metadata: {}
         })
       end
 
-      it "returns age in seconds" do
+      it "returns age in seconds based on last_modified" do
         expect(cache.age(logical_key)).to be_within(1).of(3600)
       end
     end
@@ -236,16 +235,6 @@ RSpec.describe Factorix::Cache::S3 do
     context "when object does not exist" do
       before do
         s3_client.stub_responses(:head_object, "NotFound")
-      end
-
-      it "returns nil" do
-        expect(cache.age(logical_key)).to be_nil
-      end
-    end
-
-    context "when object exists without created-at metadata" do
-      before do
-        s3_client.stub_responses(:head_object, {content_length: 100, metadata: {}})
       end
 
       it "returns nil" do

--- a/spec/factorix/cache/s3_spec.rb
+++ b/spec/factorix/cache/s3_spec.rb
@@ -1,0 +1,466 @@
+# frozen_string_literal: true
+
+require "fileutils"
+require "pathname"
+require "securerandom"
+require "tmpdir"
+
+RSpec.describe Factorix::Cache::S3 do
+  let(:s3_client) { Aws::S3::Client.new(stub_responses: true) }
+  let(:bucket) { "test-bucket" }
+  let(:cache_type) { "download" }
+  let(:cache) { Factorix::Cache::S3.new(bucket:, cache_type:) }
+  let(:logical_key) { "test-key" }
+  let(:storage_key) { "cache/#{cache_type}/#{logical_key}" }
+  let(:lock_key) { "cache/#{cache_type}/#{logical_key}.lock" }
+
+  before do
+    allow(Aws::S3::Client).to receive(:new).and_return(s3_client)
+  end
+
+  describe "#initialize" do
+    it "creates S3 client with provided region" do
+      Factorix::Cache::S3.new(bucket:, cache_type:, region: "us-west-2")
+      expect(Aws::S3::Client).to have_received(:new).with(region: "us-west-2")
+    end
+
+    it "creates S3 client with nil region when not provided" do
+      Factorix::Cache::S3.new(bucket:, cache_type:)
+      expect(Aws::S3::Client).to have_received(:new).with(region: nil)
+    end
+
+    it "accepts ttl parameter" do
+      cache_with_ttl = Factorix::Cache::S3.new(bucket:, cache_type:, ttl: 3600)
+      expect(cache_with_ttl.ttl).to eq(3600)
+    end
+
+    it "accepts lock_timeout parameter" do
+      expect { Factorix::Cache::S3.new(bucket:, cache_type:, lock_timeout: 60) }.not_to raise_error
+    end
+
+    it "inherits from Base" do
+      expect(Factorix::Cache::S3.superclass).to eq(Factorix::Cache::Base)
+    end
+  end
+
+  describe "#exist?" do
+    context "when object exists and is not expired" do
+      before do
+        s3_client.stub_responses(:head_object, {
+          content_length: 100,
+          last_modified: Time.now,
+          metadata: {}
+        })
+      end
+
+      it "returns true" do
+        expect(cache.exist?(logical_key)).to be true
+      end
+    end
+
+    context "when object does not exist" do
+      before do
+        s3_client.stub_responses(:head_object, "NotFound")
+      end
+
+      it "returns false" do
+        expect(cache.exist?(logical_key)).to be false
+      end
+    end
+
+    context "when object exists but is expired" do
+      let(:cache) { Factorix::Cache::S3.new(bucket:, cache_type:, ttl: 3600) }
+
+      before do
+        s3_client.stub_responses(:head_object, {
+          content_length: 100,
+          last_modified: Time.now - 7200,
+          metadata: {"expires-at" => (Time.now.to_i - 3600).to_s}
+        })
+      end
+
+      it "returns false" do
+        expect(cache.exist?(logical_key)).to be false
+      end
+    end
+  end
+
+  describe "#read" do
+    context "when cache entry exists and is not expired" do
+      before do
+        s3_client.stub_responses(:head_object, {content_length: 100, metadata: {}})
+        s3_client.stub_responses(:get_object, {body: StringIO.new("cached content"), metadata: {}})
+      end
+
+      it "reads data from S3" do
+        expect(cache.read(logical_key)).to eq("cached content")
+      end
+    end
+
+    context "when cache entry does not exist" do
+      before do
+        s3_client.stub_responses(:head_object, "NotFound")
+        s3_client.stub_responses(:get_object, "NotFound")
+      end
+
+      it "returns nil" do
+        expect(cache.read(logical_key)).to be_nil
+      end
+    end
+
+    context "when cache entry is expired" do
+      let(:cache) { Factorix::Cache::S3.new(bucket:, cache_type:, ttl: 3600) }
+
+      before do
+        s3_client.stub_responses(:head_object, {
+          content_length: 100,
+          metadata: {"expires-at" => (Time.now.to_i - 100).to_s}
+        })
+      end
+
+      it "returns nil" do
+        expect(cache.read(logical_key)).to be_nil
+      end
+    end
+  end
+
+  describe "#write_to" do
+    let(:output_file) { Pathname(Dir.mktmpdir("output")) / "file.dat" }
+
+    after { FileUtils.remove_entry(output_file.dirname) }
+
+    context "when cache entry exists and is not expired" do
+      before do
+        s3_client.stub_responses(:head_object, {content_length: 100, metadata: {}})
+        s3_client.stub_responses(:get_object, {body: StringIO.new("cached content"), metadata: {}})
+      end
+
+      it "writes cached content to output file" do
+        expect(cache.write_to(logical_key, output_file)).to be true
+        expect(output_file.read).to eq("cached content")
+      end
+    end
+
+    context "when cache entry does not exist" do
+      before do
+        s3_client.stub_responses(:head_object, "NotFound")
+        s3_client.stub_responses(:get_object, "NotFound")
+      end
+
+      it "returns false" do
+        expect(cache.write_to(logical_key, output_file)).to be false
+      end
+    end
+  end
+
+  describe "#store" do
+    let(:source_file) { Pathname(Dir.mktmpdir("source")) / "file.zip" }
+
+    before do
+      source_file.binwrite("test content")
+      s3_client.stub_responses(:put_object, {})
+    end
+
+    after { FileUtils.remove_entry(source_file.dirname) }
+
+    it "uploads data to S3" do
+      expect(cache.store(logical_key, source_file)).to be true
+    end
+
+    context "with TTL" do
+      let(:cache) { Factorix::Cache::S3.new(bucket:, cache_type:, ttl: 3600) }
+
+      it "stores data successfully" do
+        expect(cache.store(logical_key, source_file)).to be true
+      end
+    end
+  end
+
+  describe "#delete" do
+    context "when object exists" do
+      before do
+        s3_client.stub_responses(:head_object, {content_length: 100, metadata: {}})
+        s3_client.stub_responses(:delete_object, {})
+      end
+
+      it "deletes the object and returns true" do
+        expect(cache.delete(logical_key)).to be true
+      end
+    end
+
+    context "when object does not exist" do
+      before do
+        s3_client.stub_responses(:head_object, "NotFound")
+      end
+
+      it "returns false" do
+        expect(cache.delete(logical_key)).to be false
+      end
+    end
+  end
+
+  describe "#clear" do
+    before do
+      s3_client.stub_responses(:list_objects_v2, {
+        contents: [
+          {key: "cache/download/key1", size: 100, last_modified: Time.now},
+          {key: "cache/download/key2", size: 200, last_modified: Time.now},
+          {key: "cache/download/key3.lock", size: 50, last_modified: Time.now}
+        ],
+        is_truncated: false
+      })
+      s3_client.stub_responses(:delete_objects, {deleted: []})
+    end
+
+    it "deletes all objects except lock files" do
+      expect { cache.clear }.not_to raise_error
+    end
+  end
+
+  describe "#age" do
+    context "when object exists with created-at metadata" do
+      let(:created_at) { Time.now.to_i - 3600 }
+
+      before do
+        s3_client.stub_responses(:head_object, {
+          content_length: 100,
+          metadata: {"created-at" => created_at.to_s}
+        })
+      end
+
+      it "returns age in seconds" do
+        expect(cache.age(logical_key)).to be_within(1).of(3600)
+      end
+    end
+
+    context "when object does not exist" do
+      before do
+        s3_client.stub_responses(:head_object, "NotFound")
+      end
+
+      it "returns nil" do
+        expect(cache.age(logical_key)).to be_nil
+      end
+    end
+
+    context "when object exists without created-at metadata" do
+      before do
+        s3_client.stub_responses(:head_object, {content_length: 100, metadata: {}})
+      end
+
+      it "returns nil" do
+        expect(cache.age(logical_key)).to be_nil
+      end
+    end
+  end
+
+  describe "#expired?" do
+    context "when TTL is nil" do
+      it "returns false" do
+        s3_client.stub_responses(:head_object, {content_length: 100, metadata: {}})
+        expect(cache.expired?(logical_key)).to be false
+      end
+    end
+
+    context "when TTL is set" do
+      let(:cache) { Factorix::Cache::S3.new(bucket:, cache_type:, ttl: 3600) }
+
+      context "when object is not expired" do
+        before do
+          s3_client.stub_responses(:head_object, {
+            content_length: 100,
+            metadata: {"expires-at" => (Time.now.to_i + 1800).to_s}
+          })
+        end
+
+        it "returns false" do
+          expect(cache.expired?(logical_key)).to be false
+        end
+      end
+
+      context "when object is expired" do
+        before do
+          s3_client.stub_responses(:head_object, {
+            content_length: 100,
+            metadata: {"expires-at" => (Time.now.to_i - 100).to_s}
+          })
+        end
+
+        it "returns true" do
+          expect(cache.expired?(logical_key)).to be true
+        end
+      end
+
+      context "when object does not exist" do
+        before do
+          s3_client.stub_responses(:head_object, "NotFound")
+        end
+
+        it "returns true" do
+          expect(cache.expired?(logical_key)).to be true
+        end
+      end
+    end
+  end
+
+  describe "#size" do
+    context "when object exists and is not expired" do
+      before do
+        s3_client.stub_responses(:head_object, {content_length: 1024, metadata: {}})
+      end
+
+      it "returns size in bytes" do
+        expect(cache.size(logical_key)).to eq(1024)
+      end
+    end
+
+    context "when object does not exist" do
+      before do
+        s3_client.stub_responses(:head_object, "NotFound")
+      end
+
+      it "returns nil" do
+        expect(cache.size(logical_key)).to be_nil
+      end
+    end
+  end
+
+  describe "#with_lock" do
+    context "when lock is acquired successfully" do
+      before do
+        s3_client.stub_responses(:put_object, {})
+        s3_client.stub_responses(:delete_object, {})
+      end
+
+      it "executes block and releases lock" do
+        executed = false
+        cache.with_lock(logical_key) { executed = true }
+        expect(executed).to be true
+      end
+
+      it "returns block result" do
+        result = cache.with_lock(logical_key) { "result" }
+        expect(result).to eq("result")
+      end
+    end
+
+    context "when lock acquisition fails due to timeout" do
+      let(:cache) { Factorix::Cache::S3.new(bucket:, cache_type:, lock_timeout: 0.2) }
+
+      before do
+        s3_client.stub_responses(:put_object, "PreconditionFailed")
+        s3_client.stub_responses(:get_object, {
+          body: StringIO.new("uuid:#{Time.now.to_i + 3600}")
+        })
+      end
+
+      it "raises LockTimeoutError" do
+        expect { cache.with_lock(logical_key) { "never executed" } }.to raise_error(Factorix::LockTimeoutError)
+      end
+    end
+
+    context "when lock is stale and gets cleaned up" do
+      before do
+        call_count = 0
+        s3_client.stub_responses(:put_object, ->(_context) {
+          call_count += 1
+          if call_count == 1
+            "PreconditionFailed"
+          else
+            {}
+          end
+        })
+        s3_client.stub_responses(:get_object, {
+          body: StringIO.new("uuid:#{Time.now.to_i - 100}")
+        })
+        s3_client.stub_responses(:delete_object, {})
+      end
+
+      it "cleans up stale lock and acquires new lock" do
+        executed = false
+        cache.with_lock(logical_key) { executed = true }
+        expect(executed).to be true
+      end
+    end
+  end
+
+  describe "#each" do
+    before do
+      s3_client.stub_responses(:list_objects_v2, {
+        contents: [
+          {key: "cache/download/key1", size: 100, last_modified: Time.now - 3600},
+          {key: "cache/download/key2", size: 200, last_modified: Time.now - 1800},
+          {key: "cache/download/key3.lock", size: 50, last_modified: Time.now}
+        ],
+        is_truncated: false
+      })
+      s3_client.stub_responses(:head_object, {content_length: 100, metadata: {}})
+    end
+
+    it "returns an enumerator when no block given" do
+      expect(cache.each).to be_a(Enumerator)
+    end
+
+    it "yields key-entry pairs excluding lock files" do
+      entries = cache.each.to_a
+      expect(entries.size).to eq(2)
+      expect(entries.map(&:first)).to contain_exactly("key1", "key2")
+    end
+
+    it "yields Entry objects with correct attributes" do
+      entries = cache.each.to_a
+      entry = entries.find {|k, _| k == "key1" }&.last
+      expect(entry).to be_a(Factorix::Cache::Entry)
+      expect(entry.size).to eq(100)
+      expect(entry.age).to be_within(10).of(3600)
+    end
+  end
+
+  describe "#each with pagination" do
+    before do
+      s3_client.stub_responses(:list_objects_v2, [
+        {
+          contents: [{key: "cache/download/key1", size: 100, last_modified: Time.now}],
+          is_truncated: true,
+          next_continuation_token: "token1"
+        },
+        {
+          contents: [{key: "cache/download/key2", size: 200, last_modified: Time.now}],
+          is_truncated: false
+        }
+      ])
+      s3_client.stub_responses(:head_object, {content_length: 100, metadata: {}})
+    end
+
+    it "handles pagination correctly" do
+      entries = cache.each.to_a
+      expect(entries.size).to eq(2)
+    end
+  end
+
+  describe "#backend_info" do
+    it "returns type as s3" do
+      expect(cache.backend_info[:type]).to eq("s3")
+    end
+
+    it "returns bucket name" do
+      expect(cache.backend_info[:bucket]).to eq(bucket)
+    end
+
+    it "returns prefix" do
+      expect(cache.backend_info[:prefix]).to eq("cache/download/")
+    end
+
+    it "returns default lock_timeout" do
+      expect(cache.backend_info[:lock_timeout]).to eq(Factorix::Cache::S3::DEFAULT_LOCK_TIMEOUT)
+    end
+
+    context "with custom lock_timeout" do
+      let(:cache) { Factorix::Cache::S3.new(bucket:, cache_type:, lock_timeout: 60) }
+
+      it "returns configured lock_timeout" do
+        expect(cache.backend_info[:lock_timeout]).to eq(60)
+      end
+    end
+  end
+end


### PR DESCRIPTION
## Summary

- Add S3-based cache backend (`Cache::S3`) for cloud-native deployments
- Use S3's native `Last-Modified` header for age calculation (no custom metadata overhead)
- Distributed locking via conditional PUT (`if_none_match: "*"`) with stale lock cleanup
- Refactor container to derive cache backend class dynamically from config using `Dry::Inflector`

Closes #18

## Test plan

- [x] Run `bundle exec rake` (spec + rubocop + steep)
- [x] All 39 S3 spec examples pass using aws-sdk stubbing
- [x] Existing tests unaffected (1414 examples, 0 failures)