### PR TITLE
:bug: Fix parallel downloads sharing event handlers

### DIFF
--- a/doc/components/api-portal.md
+++ b/doc/components/api-portal.md
@@ -238,13 +238,14 @@ Retrieves full MOD information including dependencies (Full API).
 
 **Return**: `API::MODInfo` (with Detail if available)
 
-#### `Portal#download_mod(release, output)`
+#### `Portal#download_mod(release, output, handler: nil)`
 
 Downloads a MOD file.
 
 **Parameters**:
 - `release`: `API::Release` object with download_url
 - `output`: `Pathname` output path
+- `handler`: Optional event handler for progress tracking (receives `download.started`, `download.progress`, `download.completed` events)
 
 **Note**: Use `releases.max_by(&:released_at)` to get the latest release (order not guaranteed)
 

--- a/lib/factorix/cli/commands/download_support.rb
+++ b/lib/factorix/cli/commands/download_support.rb
@@ -97,17 +97,13 @@ module Factorix
 
           futures = targets.map {|target|
             Concurrent::Future.execute(executor: pool) do
-              downloader = portal.mod_download_api.downloader
-
               presenter = multi_presenter.register(
                 target[:mod].name,
                 title: target[:release].file_name
               )
               handler = Progress::DownloadHandler.new(presenter)
 
-              downloader.subscribe(handler)
-              portal.download_mod(target[:release], target[:output_path])
-              downloader.unsubscribe(handler)
+              portal.download_mod(target[:release], target[:output_path], handler:)
             end
           }
 

--- a/lib/factorix/container.rb
+++ b/lib/factorix/container.rb
@@ -30,12 +30,10 @@ module Factorix
     end
     private_class_method :build_cache
 
-    # Some items are registered with memoize: false to support independent event handlers
+    # :downloader is registered with memoize: false to support independent event handlers
     # for each parallel download task (e.g., progress tracking).
-    # Items registered with memoize: false:
-    # - :downloader (event handlers for progress tracking)
-    # - :mod_download_api (contains :downloader)
-    # - :portal (contains :mod_download_api)
+    # MODDownloadAPI resolves :downloader lazily per download call, allowing
+    # :mod_download_api and :portal to be safely memoized.
 
     # Register runtime detector
     register(:runtime, memoize: true) do
@@ -132,7 +130,7 @@ module Factorix
     end
 
     # Register MOD Download API client
-    register(:mod_download_api, memoize: false) do
+    register(:mod_download_api, memoize: true) do
       API::MODDownloadAPI.new
     end
 
@@ -148,7 +146,7 @@ module Factorix
     end
 
     # Register portal (high-level API wrapper)
-    register(:portal, memoize: false) do
+    register(:portal, memoize: true) do
       Portal.new
     end
   end

--- a/lib/factorix/portal.rb
+++ b/lib/factorix/portal.rb
@@ -72,12 +72,13 @@ module Factorix
     #
     # @param release [API::Release] release object containing download_url and sha1
     # @param output [Pathname] output file path
+    # @param handler [Object, nil] event handler for download progress (optional)
     # @return [void]
     # @raise [DigestMismatchError] if SHA1 verification fails
-    def download_mod(release, output)
+    def download_mod(release, output, handler: nil)
       # Extract path from URI::HTTPS
       download_path = release.download_url.path
-      mod_download_api.download(download_path, output, expected_sha1: release.sha1)
+      mod_download_api.download(download_path, output, expected_sha1: release.sha1, handler:)
     end
 
     # Upload a MOD file to the portal

--- a/sig/factorix/api/mod_download_api.rbs
+++ b/sig/factorix/api/mod_download_api.rbs
@@ -7,12 +7,11 @@ module Factorix
     class MODDownloadAPI
       BASE_URL: String
 
-      attr_reader downloader: Transfer::Downloader
       attr_reader logger: Dry::Logger::Dispatcher
 
       def initialize: (**untyped deps) -> void
 
-      def download: (String download_url, Pathname output, ?expected_sha1: String?) -> void
+      def download: (String download_url, Pathname output, ?expected_sha1: String?, ?handler: untyped?) -> void
     end
   end
 end

--- a/sig/factorix/portal.rbs
+++ b/sig/factorix/portal.rbs
@@ -18,7 +18,7 @@ module Factorix
 
     def get_mod_full: (String name) -> API::MODInfo
 
-    def download_mod: (API::Release release, Pathname output) -> void
+    def download_mod: (API::Release release, Pathname output, ?handler: untyped?) -> void
 
     def upload_mod: (String mod_name, Pathname file_path, **untyped metadata) -> void
 

--- a/spec/factorix/api/mod_download_api_spec.rb
+++ b/spec/factorix/api/mod_download_api_spec.rb
@@ -3,14 +3,17 @@
 RSpec.describe Factorix::API::MODDownloadAPI do
   let(:service_credential) { instance_double(Factorix::ServiceCredential, username: "test_user", token: "test_token") }
   let(:downloader) { instance_double(Factorix::Transfer::Downloader) }
-  let(:api) { Factorix::API::MODDownloadAPI.new(downloader:) }
+  let(:api) { Factorix::API::MODDownloadAPI.new }
   let(:download_url) { "/download/example-mod/abc123" }
   let(:output) { Pathname("/tmp/example-mod.zip") }
 
   before do
-    # Stub service_credential in Application container for lazy loading
+    # Stub Container to return our mocks
     allow(Factorix::Container).to receive(:[]).and_call_original
     allow(Factorix::Container).to receive(:[]).with(:service_credential).and_return(service_credential)
+    allow(Factorix::Container).to receive(:[]).with(:downloader).and_return(downloader)
+    allow(downloader).to receive(:subscribe)
+    allow(downloader).to receive(:unsubscribe)
   end
 
   describe "#download" do

--- a/spec/factorix/cli/commands/mod/download_spec.rb
+++ b/spec/factorix/cli/commands/mod/download_spec.rb
@@ -6,7 +6,6 @@ RSpec.describe Factorix::CLI::Commands::MOD::Download do
   let(:portal) { instance_double(Factorix::Portal) }
   let(:logger) { instance_double(Dry::Logger::Dispatcher, debug: nil, info: nil, warn: nil, error: nil) }
   let(:runtime) { instance_double(Factorix::Runtime::Base, mod_dir: Pathname("/fake/mods")) }
-  let(:downloader) { instance_double(Factorix::Transfer::Downloader) }
   let(:command) { Factorix::CLI::Commands::MOD::Download.new(logger:, runtime:) }
   let(:mod_info) do
     Factorix::API::MODInfo.new(
@@ -47,12 +46,6 @@ RSpec.describe Factorix::CLI::Commands::MOD::Download do
     allow(Factorix::Container).to receive(:[]).with(:logger).and_return(logger)
     allow(portal).to receive(:get_mod_full).with("test-mod").and_return(mod_info)
     allow(portal).to receive(:download_mod)
-    allow(downloader).to receive(:subscribe)
-    allow(downloader).to receive(:unsubscribe)
-
-    mod_download_api = instance_double(Factorix::API::MODDownloadAPI)
-    allow(portal).to receive(:mod_download_api).and_return(mod_download_api)
-    allow(mod_download_api).to receive(:downloader).and_return(downloader)
   end
 
   describe "#call" do

--- a/spec/factorix/cli/commands/mod/install_spec.rb
+++ b/spec/factorix/cli/commands/mod/install_spec.rb
@@ -70,14 +70,8 @@ RSpec.describe Factorix::CLI::Commands::MOD::Install do
     allow(graph).to receive_messages(nodes: [], node?: false, node: nil, edges_from: [], cyclic?: false)
     allow(command).to receive(:load_current_state).and_return([graph, mod_list, []])
     allow(mod_dir).to receive_messages(exist?: true, "/": Pathname("/fake/path/mods/mod-a_1.0.0.zip"))
-    allow(portal).to receive(:download_mod)
+    allow(portal).to receive_messages(download_mod: nil, get_mod_full: mod_info_a)
     allow(Factorix::Container).to receive(:[]).with(:portal).and_return(portal)
-
-    downloader = instance_double(Factorix::Transfer::Downloader)
-    allow(downloader).to receive(:subscribe)
-    allow(downloader).to receive(:unsubscribe)
-    mod_download_api = instance_double(Factorix::API::MODDownloadAPI, downloader:)
-    allow(portal).to receive_messages(get_mod_full: mod_info_a, mod_download_api:)
   end
 
   describe "#call" do

--- a/spec/factorix/cli/commands/mod/update_spec.rb
+++ b/spec/factorix/cli/commands/mod/update_spec.rb
@@ -78,11 +78,7 @@ RSpec.describe Factorix::CLI::Commands::MOD::Update do
     allow(mod_list).to receive_messages(save: nil, exist?: true, enabled?: true, remove: nil, add: nil)
     allow(mod_dir).to receive(:/).and_return(Pathname("/fake/path/mods/mod-a_2.0.0.zip"))
 
-    downloader = instance_double(Factorix::Transfer::Downloader)
-    allow(downloader).to receive(:subscribe)
-    allow(downloader).to receive(:unsubscribe)
-    mod_download_api = instance_double(Factorix::API::MODDownloadAPI, downloader:)
-    allow(portal).to receive_messages(get_mod_full: mod_info_a, mod_download_api:, download_mod: nil)
+    allow(portal).to receive_messages(get_mod_full: mod_info_a, download_mod: nil)
 
     # Simulate user confirmation
     allow(command).to receive(:confirm?).and_return(true)

--- a/spec/factorix/portal_spec.rb
+++ b/spec/factorix/portal_spec.rb
@@ -129,11 +129,11 @@ RSpec.describe Factorix::Portal do
 
     it "downloads the MOD file to the specified path with SHA1 verification" do
       output_path = Pathname(Dir.tmpdir) / "test-mod.zip"
-      allow(mod_download_api).to receive(:download).with("/download/test-mod/1.0.0", output_path, expected_sha1: "abc123")
+      allow(mod_download_api).to receive(:download).with("/download/test-mod/1.0.0", output_path, expected_sha1: "abc123", handler: nil)
 
       portal.download_mod(release, output_path)
 
-      expect(mod_download_api).to have_received(:download).with("/download/test-mod/1.0.0", output_path, expected_sha1: "abc123")
+      expect(mod_download_api).to have_received(:download).with("/download/test-mod/1.0.0", output_path, expected_sha1: "abc123", handler: nil)
     end
   end
 


### PR DESCRIPTION
## Summary

Fix parallel downloads sharing event handlers by injecting handler into download method instead of requiring thread-local Portal instances.

## Changes

- `MODDownloadAPI#download` accepts `handler:` parameter and resolves downloader lazily per call
- `Portal#download_mod` passes through handler parameter
- Change `portal` and `mod_download_api` to `memoize: true` (safe now)
- Simplify `download_support.rb` by removing manual subscribe/unsubscribe

Fixes #40
