### PR TITLE
:bug: Fix Redis backend class lookup by adding uncountable inflection

### DIFF
--- a/lib/factorix/container.rb
+++ b/lib/factorix/container.rb
@@ -14,7 +14,9 @@ module Factorix
   class Container
     extend Dry::Core::Container::Mixin
 
-    INFLECTOR = Dry::Inflector.new
+    INFLECTOR = Dry::Inflector.new do |inflections|
+      inflections.uncountable("redis")
+    end
     private_constant :INFLECTOR
 
     # Build a cache instance from configuration.


### PR DESCRIPTION
## Summary

Fix Redis cache backend class lookup failing because `Dry::Inflector.classify("redis")` returns `"Redi"`.

## Changes

- Add `redis` as uncountable word in inflector configuration

Fixes #42
