### PR TITLE
Fix S3 backend ignoring SDK default region resolution

### DIFF
--- a/lib/factorix/cache/s3.rb
+++ b/lib/factorix/cache/s3.rb
@@ -50,7 +50,7 @@ module Factorix
       # @param ttl [Integer, nil] time-to-live in seconds (nil for unlimited)
       def initialize(bucket:, cache_type:, region: nil, lock_timeout: DEFAULT_LOCK_TIMEOUT, **)
         super(**)
-        @client = Aws::S3::Client.new(region:)
+        @client = Aws::S3::Client.new(**{region:}.compact)
         @bucket = bucket
         @prefix = "cache/#{cache_type}/"
         @lock_timeout = lock_timeout

--- a/spec/factorix/cache/s3_spec.rb
+++ b/spec/factorix/cache/s3_spec.rb
@@ -24,9 +24,9 @@ RSpec.describe Factorix::Cache::S3 do
       expect(Aws::S3::Client).to have_received(:new).with(region: "us-west-2")
     end
 
-    it "creates S3 client with nil region when not provided" do
+    it "creates S3 client without region when not provided (uses SDK default)" do
       Factorix::Cache::S3.new(bucket:, cache_type:)
-      expect(Aws::S3::Client).to have_received(:new).with(region: nil)
+      expect(Aws::S3::Client).to have_received(:new).with(no_args)
     end
 
     it "accepts ttl parameter" do


### PR DESCRIPTION
## Summary
- Fix S3 cache backend ignoring AWS SDK default region resolution when `region` config is nil
- Use `**{region:}.compact` to only pass region when explicitly configured

## Test plan
- [x] All tests pass
- [x] RuboCop clean
- [x] Steep type check passes

Closes #44