### PR TITLE
Rescue API-specific exceptions in S3 cache backend

### DIFF
--- a/lib/factorix/cache/s3.rb
+++ b/lib/factorix/cache/s3.rb
@@ -77,7 +77,7 @@ module Factorix
 
         resp = @client.get_object(bucket: @bucket, key: storage_key(key))
         resp.body.read
-      rescue Aws::S3::Errors::NotFound
+      rescue Aws::S3::Errors::NoSuchKey
         nil
       end
 
@@ -92,7 +92,7 @@ module Factorix
         @client.get_object(bucket: @bucket, key: storage_key(key), response_target: output.to_s)
         logger.debug("Cache hit", key:)
         true
-      rescue Aws::S3::Errors::NotFound
+      rescue Aws::S3::Errors::NoSuchKey
         false
       end
 
@@ -316,7 +316,7 @@ module Factorix
           @client.delete_object(bucket: @bucket, key: lkey)
           logger.debug("Cleaned up stale lock", key: lkey)
         end
-      rescue Aws::S3::Errors::NotFound
+      rescue Aws::S3::Errors::NoSuchKey
         # Lock doesn't exist, nothing to clean up
       end
 

--- a/spec/factorix/cache/s3_spec.rb
+++ b/spec/factorix/cache/s3_spec.rb
@@ -100,7 +100,7 @@ RSpec.describe Factorix::Cache::S3 do
     context "when cache entry does not exist" do
       before do
         s3_client.stub_responses(:head_object, "NotFound")
-        s3_client.stub_responses(:get_object, "NotFound")
+        s3_client.stub_responses(:get_object, "NoSuchKey")
       end
 
       it "returns nil" do
@@ -144,7 +144,7 @@ RSpec.describe Factorix::Cache::S3 do
     context "when cache entry does not exist" do
       before do
         s3_client.stub_responses(:head_object, "NotFound")
-        s3_client.stub_responses(:get_object, "NotFound")
+        s3_client.stub_responses(:get_object, "NoSuchKey")
       end
 
       it "returns false" do


### PR DESCRIPTION
## Summary
- `head_object` raises `NotFound` (HEAD requests have no response body, SDK returns generic 404)
- `get_object` raises `NoSuchKey` (response body contains specific error code)

Each method now rescues only the exception that corresponds to its S3 API call.

## Test plan
- [x] All tests pass
- [x] RuboCop clean
- [x] Steep type check passes

Closes #46