### PR TITLE
:sparkles: Add download command for Factorio game files

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,12 @@
 ## [Unreleased]
 
+### Added
+
+- Add `download` command to download Factorio game files from the official Download API (#51)
+  - Supports alpha, expansion, demo, and headless builds
+  - Auto-detects platform (Windows, Linux, macOS, WSL)
+  - Resolves latest version from stable/experimental channels
+
 ## [0.7.0] - 2026-01-24
 
 ### Added

--- a/README.md
+++ b/README.md
@@ -20,6 +20,7 @@ Factorix simplifies Factorio MOD management by providing:
 - **Settings Management**: Export/import MOD settings in JSON format
 - **MOD Portal Integration**: Upload new MODs or update existing ones, edit metadata
 - **Game Control**: Launch Factorio from the command line
+- **Game Download**: Download Factorio game files (alpha, expansion, demo, headless)
 - **Cross-platform Support**: Works on Windows, Linux, macOS, and WSL
 
 ## Requirements
@@ -37,6 +38,8 @@ export FACTORIO_API_KEY=your_api_key_here
 ```
 
 API key is not required for downloading, installing, or managing local MODs.
+
+For downloading the game itself (`factorix download`), service credentials are required. These are automatically loaded from `player-data.json` if you have logged into Factorio, or you can set `FACTORIO_USERNAME` and `FACTORIO_TOKEN` environment variables.
 
 ## Configuration
 

--- a/completion/_factorix.bash
+++ b/completion/_factorix.bash
@@ -17,7 +17,7 @@ _factorix() {
   local confirmable_opts="-y --yes"
 
   # Top-level commands
-  local commands="version man launch path mod cache completion"
+  local commands="version man launch path download mod cache completion"
 
   # mod subcommands
   local mod_commands="check list show enable disable install uninstall update download upload edit search sync image settings"
@@ -49,6 +49,20 @@ _factorix() {
         COMPREPLY=($(compgen -W "zsh bash fish" -- "$cur"))
       else
         COMPREPLY=($(compgen -W "$global_opts" -- "$cur"))
+      fi
+      return
+      ;;
+    download)
+      if [[ "$cur" == -* ]]; then
+        COMPREPLY=($(compgen -W "$global_opts -b --build -p --platform -c --channel -d --directory -o --output" -- "$cur"))
+      elif [[ "$prev" == "--build" ]] || [[ "$prev" == "-b" ]]; then
+        COMPREPLY=($(compgen -W "alpha expansion demo headless" -- "$cur"))
+      elif [[ "$prev" == "--platform" ]] || [[ "$prev" == "-p" ]]; then
+        COMPREPLY=($(compgen -W "win64 win64-manual osx linux64" -- "$cur"))
+      elif [[ "$prev" == "--channel" ]] || [[ "$prev" == "-c" ]]; then
+        COMPREPLY=($(compgen -W "stable experimental" -- "$cur"))
+      elif [[ "$prev" == "--directory" ]] || [[ "$prev" == "-d" ]]; then
+        COMPREPLY=($(compgen -d -- "$cur"))
       fi
       return
       ;;

--- a/completion/_factorix.fish
+++ b/completion/_factorix.fish
@@ -73,13 +73,14 @@ complete -c factorix -l log-level -d 'Set log level' -xa 'debug info warn error 
 complete -c factorix -s q -l quiet -d 'Suppress non-essential output'
 
 # Top-level commands
-complete -c factorix -n "not __factorix_using_command version; and not __factorix_using_command man; and not __factorix_using_command launch; and not __factorix_using_command path; and not __factorix_using_command mod; and not __factorix_using_command cache; and not __factorix_using_command completion" -a version -d 'Display Factorix version'
-complete -c factorix -n "not __factorix_using_command version; and not __factorix_using_command man; and not __factorix_using_command launch; and not __factorix_using_command path; and not __factorix_using_command mod; and not __factorix_using_command cache; and not __factorix_using_command completion" -a man -d 'Display the Factorix manual page'
-complete -c factorix -n "not __factorix_using_command version; and not __factorix_using_command man; and not __factorix_using_command launch; and not __factorix_using_command path; and not __factorix_using_command mod; and not __factorix_using_command cache; and not __factorix_using_command completion" -a launch -d 'Launch Factorio game'
-complete -c factorix -n "not __factorix_using_command version; and not __factorix_using_command man; and not __factorix_using_command launch; and not __factorix_using_command path; and not __factorix_using_command mod; and not __factorix_using_command cache; and not __factorix_using_command completion" -a path -d 'Display Factorio and Factorix paths'
-complete -c factorix -n "not __factorix_using_command version; and not __factorix_using_command man; and not __factorix_using_command launch; and not __factorix_using_command path; and not __factorix_using_command mod; and not __factorix_using_command cache; and not __factorix_using_command completion" -a mod -d 'MOD management commands'
-complete -c factorix -n "not __factorix_using_command version; and not __factorix_using_command man; and not __factorix_using_command launch; and not __factorix_using_command path; and not __factorix_using_command mod; and not __factorix_using_command cache; and not __factorix_using_command completion" -a cache -d 'Cache management commands'
-complete -c factorix -n "not __factorix_using_command version; and not __factorix_using_command man; and not __factorix_using_command launch; and not __factorix_using_command path; and not __factorix_using_command mod; and not __factorix_using_command cache; and not __factorix_using_command completion" -a completion -d 'Generate shell completion script'
+complete -c factorix -n "not __factorix_using_command version; and not __factorix_using_command man; and not __factorix_using_command launch; and not __factorix_using_command path; and not __factorix_using_command download; and not __factorix_using_command mod; and not __factorix_using_command cache; and not __factorix_using_command completion" -a version -d 'Display Factorix version'
+complete -c factorix -n "not __factorix_using_command version; and not __factorix_using_command man; and not __factorix_using_command launch; and not __factorix_using_command path; and not __factorix_using_command download; and not __factorix_using_command mod; and not __factorix_using_command cache; and not __factorix_using_command completion" -a man -d 'Display the Factorix manual page'
+complete -c factorix -n "not __factorix_using_command version; and not __factorix_using_command man; and not __factorix_using_command launch; and not __factorix_using_command path; and not __factorix_using_command download; and not __factorix_using_command mod; and not __factorix_using_command cache; and not __factorix_using_command completion" -a launch -d 'Launch Factorio game'
+complete -c factorix -n "not __factorix_using_command version; and not __factorix_using_command man; and not __factorix_using_command launch; and not __factorix_using_command path; and not __factorix_using_command download; and not __factorix_using_command mod; and not __factorix_using_command cache; and not __factorix_using_command completion" -a path -d 'Display Factorio and Factorix paths'
+complete -c factorix -n "not __factorix_using_command version; and not __factorix_using_command man; and not __factorix_using_command launch; and not __factorix_using_command path; and not __factorix_using_command download; and not __factorix_using_command mod; and not __factorix_using_command cache; and not __factorix_using_command completion" -a download -d 'Download Factorio game files'
+complete -c factorix -n "not __factorix_using_command version; and not __factorix_using_command man; and not __factorix_using_command launch; and not __factorix_using_command path; and not __factorix_using_command download; and not __factorix_using_command mod; and not __factorix_using_command cache; and not __factorix_using_command completion" -a mod -d 'MOD management commands'
+complete -c factorix -n "not __factorix_using_command version; and not __factorix_using_command man; and not __factorix_using_command launch; and not __factorix_using_command path; and not __factorix_using_command download; and not __factorix_using_command mod; and not __factorix_using_command cache; and not __factorix_using_command completion" -a cache -d 'Cache management commands'
+complete -c factorix -n "not __factorix_using_command version; and not __factorix_using_command man; and not __factorix_using_command launch; and not __factorix_using_command path; and not __factorix_using_command download; and not __factorix_using_command mod; and not __factorix_using_command cache; and not __factorix_using_command completion" -a completion -d 'Generate shell completion script'
 
 # launch options
 complete -c factorix -n "__factorix_using_command launch" -s w -l wait -d 'Wait for the game to finish'
@@ -89,6 +90,13 @@ complete -c factorix -n "__factorix_using_command path" -l json -d 'Output in JS
 
 # completion shell argument
 complete -c factorix -n "__factorix_using_command completion" -a 'zsh bash fish' -d 'Shell type'
+
+# download options
+complete -c factorix -n "__factorix_using_command download" -s b -l build -d 'Build type' -xa 'alpha expansion demo headless'
+complete -c factorix -n "__factorix_using_command download" -s p -l platform -d 'Platform' -xa 'win64 win64-manual osx linux64'
+complete -c factorix -n "__factorix_using_command download" -s c -l channel -d 'Release channel' -xa 'stable experimental'
+complete -c factorix -n "__factorix_using_command download" -s d -l directory -d 'Download directory' -ra '(__fish_complete_directories)'
+complete -c factorix -n "__factorix_using_command download" -s o -l output -d 'Output filename' -r
 
 # cache subcommands
 complete -c factorix -n "__factorix_using_command cache" -a stat -d 'Display cache statistics'

--- a/completion/_factorix.zsh
+++ b/completion/_factorix.zsh
@@ -39,6 +39,7 @@ _factorix() {
         'man:Display the Factorix manual page'
         'launch:Launch Factorio game'
         'path:Display Factorio and Factorix paths'
+        'download:Download Factorio game files'
         'mod:MOD management commands'
         'cache:Cache management commands'
         'completion:Generate shell completion script'
@@ -60,6 +61,9 @@ _factorix() {
           _arguments \
             $global_opts \
             '--json[Output in JSON format]'
+          ;;
+        download)
+          _factorix_download
           ;;
         completion)
           _factorix_completion
@@ -86,6 +90,24 @@ _factorix_completion() {
   _arguments \
     $global_opts \
     '1:shell:(zsh bash fish)'
+}
+
+_factorix_download() {
+  local -a global_opts
+  global_opts=(
+    '(-c --config-path)'{-c,--config-path}'[Path to configuration file]:config file:_files'
+    '--log-level[Set log level]:level:(debug info warn error fatal)'
+    '(-q --quiet)'{-q,--quiet}'[Suppress non-essential output]'
+  )
+
+  _arguments \
+    $global_opts \
+    '(-b --build)'{-b,--build}'[Build type]:build:(alpha expansion demo headless)' \
+    '(-p --platform)'{-p,--platform}'[Platform]:platform:(win64 win64-manual osx linux64)' \
+    '(-c --channel)'{-c,--channel}'[Release channel]:channel:(stable experimental)' \
+    '(-d --directory)'{-d,--directory}'[Download directory]:directory:_files -/' \
+    '(-o --output)'{-o,--output}'[Output filename]:filename:' \
+    '1:version:'
 }
 
 _factorix_mod() {

--- a/doc/components/cli.md
+++ b/doc/components/cli.md
@@ -129,6 +129,56 @@ factorix completion fish | source  # fish shell
 
 **Use case**: Enable tab completion for factorix commands
 
+### Download
+
+Download Factorio game files from the official download API.
+
+**Arguments**:
+- `version` (optional) - Version to download (e.g., `2.0.73`, `latest`). Defaults to `latest`.
+
+**Options**:
+- `-b`, `--build` - Build type: `alpha`, `expansion`, `demo`, `headless` (default: `alpha`)
+- `-p`, `--platform` - Platform: `win64`, `win64-manual`, `osx`, `linux64` (default: auto-detect)
+- `-c`, `--channel` - Release channel: `stable`, `experimental` (default: `stable`)
+- `-d`, `--directory` - Download directory (default: current directory)
+- `-o`, `--output` - Output filename (default: from server response)
+
+**Platform Auto-Detection**:
+
+| Runtime | Default Platform |
+|---------|------------------|
+| MacOS | `osx` |
+| Linux | `linux64` |
+| Windows | `win64` |
+| WSL | `win64` |
+
+**Examples**:
+```bash
+# Download latest stable version (auto-detect platform)
+factorix download
+
+# Download specific version
+factorix download 2.0.73
+
+# Download expansion build
+factorix download --build expansion
+
+# Download headless server for Linux
+factorix download --build headless --platform linux64
+
+# Download experimental release
+factorix download --channel experimental
+
+# Specify output filename
+factorix download -o factorio-server.tar.xz
+```
+
+**Restrictions**:
+- Only Factorio 2.x versions are supported
+- Requires service credentials (username/token from player-data.json)
+
+**Use case**: Download Factorio game files for installation or server deployment
+
 ### Launch
 
 Launch the game.

--- a/doc/overview.md
+++ b/doc/overview.md
@@ -14,6 +14,7 @@ Provide a command-line interface for Factorio MOD management, including dependen
 - Retrieve Factorio installation paths and directories
 - Launch Factorio with custom options
 - Automatic process management for certain commands
+- Download Factorio game files (alpha, expansion, demo, headless)
 
 ### MOD Management
 - **Discovery**: List and search MODs from MOD Portal

--- a/lib/factorix.rb
+++ b/lib/factorix.rb
@@ -129,6 +129,7 @@ module Factorix
     "installed_mod" => "InstalledMOD",
     "mac_os" => "MacOS",
     "mod" => "MOD",
+    "game_download_api" => "GameDownloadAPI",
     "mod_download_api" => "MODDownloadAPI",
     "mod_info" => "MODInfo",
     "mod_management_api" => "MODManagementAPI",

--- a/lib/factorix/api/game_download_api.rb
+++ b/lib/factorix/api/game_download_api.rb
@@ -1,0 +1,154 @@
+# frozen_string_literal: true
+
+require "json"
+require "uri"
+
+module Factorix
+  module API
+    # API client for downloading Factorio game files
+    #
+    # Corresponds to: https://wiki.factorio.com/Download_API
+    class GameDownloadAPI
+      # @!parse
+      #   # @return [Dry::Logger::Dispatcher]
+      #   attr_reader :logger
+      #   # @return [HTTP::Client]
+      #   attr_reader :client
+      include Import[:logger, client: :api_http_client]
+
+      # Base URL for game downloads
+      DOWNLOAD_BASE_URL = "https://www.factorio.com"
+      private_constant :DOWNLOAD_BASE_URL
+
+      # Base URL for API endpoints
+      API_BASE_URL = "https://factorio.com"
+      private_constant :API_BASE_URL
+
+      # Valid build types
+      BUILDS = %w[alpha expansion demo headless].freeze
+      public_constant :BUILDS
+
+      # Valid platforms
+      PLATFORMS = %w[win64 win64-manual osx linux64].freeze
+      public_constant :PLATFORMS
+
+      # Valid release channels
+      CHANNELS = %w[stable experimental].freeze
+      public_constant :CHANNELS
+
+      # Initialize with thread-safe credential loading
+      #
+      # @param args [Hash] dependency injection arguments
+      def initialize(...)
+        super
+        @service_credential_mutex = Mutex.new
+      end
+
+      # Fetch latest release information
+      #
+      # @return [Hash{Symbol => Hash}] Hash containing stable and experimental release info
+      # @example Response format
+      #   {
+      #     stable: { alpha: "2.0.28", expansion: "2.0.28", headless: "2.0.28" },
+      #     experimental: { alpha: "2.0.29", expansion: "2.0.29", headless: "2.0.29" }
+      #   }
+      def latest_releases
+        logger.debug "Fetching latest releases"
+        uri = URI.join(API_BASE_URL, "/api/latest-releases")
+        response = client.get(uri)
+        JSON.parse((+response.body).force_encoding(Encoding::UTF_8), symbolize_names: true)
+      end
+
+      # Get the latest version for a specific channel and build
+      #
+      # @param channel [String] Release channel (stable, experimental)
+      # @param build [String] Build type (alpha, expansion, demo, headless)
+      # @return [String, nil] Version string or nil if not available
+      def latest_version(channel:, build:)
+        releases = latest_releases
+        releases.dig(channel.to_sym, build.to_sym)
+      end
+
+      # Resolve the download filename by making a HEAD request
+      #
+      # @param version [String] Game version (e.g., "2.0.28")
+      # @param build [String] Build type (alpha, expansion, demo, headless)
+      # @param platform [String] Platform (win64, win64-manual, osx, linux64)
+      # @return [String] Filename extracted from final redirect URL
+      # @raise [ArgumentError] if build or platform is invalid
+      def resolve_filename(version:, build:, platform:)
+        validate_build!(build)
+        validate_platform!(platform)
+
+        uri = build_download_uri(version, build, platform)
+        response = client.head(uri)
+        File.basename(response.uri.path)
+      end
+
+      # Download the game to the specified output path
+      #
+      # @param version [String] Game version (e.g., "2.0.28")
+      # @param build [String] Build type (alpha, expansion, demo, headless)
+      # @param platform [String] Platform (win64, win64-manual, osx, linux64)
+      # @param output [Pathname] Output file path
+      # @param handler [Object, nil] Event handler for download progress (optional)
+      # @return [void]
+      # @raise [ArgumentError] if build or platform is invalid
+      def download(version:, build:, platform:, output:, handler: nil)
+        validate_build!(build)
+        validate_platform!(platform)
+
+        uri = build_download_uri(version, build, platform)
+        downloader = Container[:downloader]
+        downloader.subscribe(handler) if handler
+        begin
+          downloader.download(uri, output)
+        ensure
+          downloader.unsubscribe(handler) if handler
+        end
+      end
+
+      # Build the download URI with authentication
+      #
+      # @param version [String] Game version
+      # @param build [String] Build type
+      # @param platform [String] Platform
+      # @return [URI::HTTPS] Complete download URI with credentials
+      private def build_download_uri(version, build, platform)
+        path = "/get-download/#{version}/#{build}/#{platform}"
+        uri = URI.join(DOWNLOAD_BASE_URL, path)
+        params = {username: service_credential.username, token: service_credential.token}
+        uri.query = URI.encode_www_form(params)
+        uri
+      end
+
+      private def service_credential
+        return @service_credential if defined?(@service_credential)
+
+        @service_credential_mutex.synchronize do
+          @service_credential ||= Container[:service_credential]
+        end
+      end
+
+      # Validate build type
+      #
+      # @param build [String] Build type to validate
+      # @raise [ArgumentError] if build type is invalid
+      private def validate_build!(build)
+        return if BUILDS.include?(build)
+
+        raise ArgumentError, "Invalid build type: #{build}. Valid types: #{BUILDS.join(", ")}"
+      end
+
+      # Validate platform
+      #
+      # @param platform [String] Platform to validate
+      # @raise [ArgumentError] if platform is invalid
+      private def validate_platform!(platform)
+        return if PLATFORMS.include?(platform)
+
+        raise ArgumentError, "Invalid platform: #{platform}. Valid platforms: #{PLATFORMS.join(", ")}"
+      end
+    end
+  end
+end

--- a/lib/factorix/cli.rb
+++ b/lib/factorix/cli.rb
@@ -17,6 +17,7 @@ module Factorix
     register "man", Commands::Man
     register "launch", Commands::Launch
     register "path", Commands::Path
+    register "download", Commands::Download
     register "completion", Commands::Completion
     register "mod check", Commands::MOD::Check
     register "mod list", Commands::MOD::List

--- a/lib/factorix/cli/commands/download.rb
+++ b/lib/factorix/cli/commands/download.rb
@@ -1,0 +1,161 @@
+# frozen_string_literal: true
+
+module Factorix
+  class CLI
+    module Commands
+      # Download Factorio game files from the official download API
+      class Download < Base
+        # @!parse
+        #   # @return [Dry::Logger::Dispatcher]
+        #   attr_reader :logger
+        #   # @return [Runtime]
+        #   attr_reader :runtime
+        #   # @return [API::GameDownloadAPI]
+        #   attr_reader :game_download_api
+        include Import[:logger, :runtime, :game_download_api]
+
+        # Platform mapping from Runtime to API platform identifier
+        PLATFORM_MAP = {
+          "MacOS" => "osx",
+          "Linux" => "linux64",
+          "Windows" => "win64",
+          "WSL" => "win64"
+        }.freeze
+        private_constant :PLATFORM_MAP
+
+        desc "Download Factorio game files"
+
+        argument :version, required: false, default: "latest", desc: "Version (e.g., 2.0.73, latest)"
+
+        option :build,
+          aliases: ["-b"],
+          default: "alpha",
+          values: API::GameDownloadAPI::BUILDS,
+          desc: "Build type"
+        option :platform,
+          aliases: ["-p"],
+          values: API::GameDownloadAPI::PLATFORMS,
+          desc: "Platform (default: auto-detect)"
+        option :channel,
+          aliases: ["-c"],
+          default: "stable",
+          values: API::GameDownloadAPI::CHANNELS,
+          desc: "Release channel"
+        option :directory, aliases: ["-d"], default: ".", desc: "Download directory"
+        option :output, aliases: ["-o"], desc: "Output filename (default: from server)"
+
+        example [
+          "                           # Download latest stable version (auto-detect platform)",
+          "2.0.73                     # Download specific version",
+          "--build expansion          # Download expansion build",
+          "--build headless -p linux64 # Download headless server for Linux",
+          "--channel experimental     # Download experimental release",
+          "-o factorio-server.tar.xz  # Specify output filename"
+        ]
+
+        # Execute the download command
+        #
+        # @param version [String] Version to download
+        # @param build [String] Build type
+        # @param platform [String, nil] Platform (nil for auto-detect)
+        # @param channel [String] Release channel
+        # @param directory [String] Download directory
+        # @param output [String, nil] Output filename
+        # @return [void]
+        def call(version: "latest", build: "alpha", platform: nil, channel: "stable", directory: ".", output: nil, **)
+          platform ||= detect_platform
+          resolved_version = resolve_version(version, channel, build)
+
+          download_dir = Pathname(directory).expand_path
+          raise DirectoryNotFoundError, "Download directory does not exist: #{download_dir}" unless download_dir.exist?
+
+          filename = output || resolve_filename(resolved_version, build, platform)
+          output_path = download_dir / filename
+
+          say "Downloading Factorio #{resolved_version} (#{build}/#{platform})...", prefix: :info
+
+          download_game(resolved_version, build, platform, output_path)
+
+          say "Downloaded to #{output_path}", prefix: :success
+        end
+
+        # Detect platform from Runtime
+        #
+        # @return [String] Platform identifier
+        private def detect_platform
+          runtime_class = runtime.class.name.split("::").last
+          platform = PLATFORM_MAP[runtime_class]
+          raise UnsupportedPlatformError, "Cannot auto-detect platform for #{runtime_class}" unless platform
+
+          logger.debug("Auto-detected platform", platform:)
+          platform
+        end
+
+        # Minimum supported major version
+        MINIMUM_MAJOR_VERSION = 2
+        private_constant :MINIMUM_MAJOR_VERSION
+
+        # Resolve version, handling "latest" by fetching from API
+        #
+        # @param version [String] Version or "latest"
+        # @param channel [String] Release channel
+        # @param build [String] Build type
+        # @return [String] Resolved version
+        # @raise [InvalidArgumentError] if version is invalid or < 2.0
+        private def resolve_version(version, channel, build)
+          resolved = if version == "latest"
+                       v = game_download_api.latest_version(channel:, build:)
+                       raise InvalidArgumentError, "No #{channel} version available for #{build}" unless v
+
+                       logger.debug("Resolved latest version", channel:, build:, version: v)
+                       v
+                     else
+                       version
+                     end
+
+          validate_version!(resolved)
+          resolved
+        end
+
+        # Validate version format and minimum version requirement
+        #
+        # @param version [String] Version string
+        # @return [void]
+        # @raise [InvalidArgumentError] if version is invalid or < 2.0
+        private def validate_version!(version)
+          game_version = GameVersion.from_string(version)
+
+          return if game_version.major >= MINIMUM_MAJOR_VERSION
+
+          raise InvalidArgumentError, "Version #{version} is not supported. Minimum version is #{MINIMUM_MAJOR_VERSION}.0.0"
+        rescue VersionParseError => e
+          raise InvalidArgumentError, "Invalid version format: #{e.message}"
+        end
+
+        # Resolve filename by making HEAD request
+        #
+        # @param version [String] Version
+        # @param build [String] Build type
+        # @param platform [String] Platform
+        # @return [String] Filename
+        private def resolve_filename(version, build, platform)
+          game_download_api.resolve_filename(version:, build:, platform:)
+        end
+
+        # Download the game with progress tracking
+        #
+        # @param version [String] Version
+        # @param build [String] Build type
+        # @param platform [String] Platform
+        # @param output_path [Pathname] Output file path
+        # @return [void]
+        private def download_game(version, build, platform, output_path)
+          presenter = Progress::Presenter.new(title: output_path.basename.to_s, output: err)
+          handler = Progress::DownloadHandler.new(presenter)
+
+          game_download_api.download(version:, build:, platform:, output: output_path, handler:)
+        end
+      end
+    end
+  end
+end

--- a/lib/factorix/cli/commands/download.rb
+++ b/lib/factorix/cli/commands/download.rb
@@ -27,20 +27,9 @@ module Factorix
 
         argument :version, required: false, default: "latest", desc: "Version (e.g., 2.0.73, latest)"
 
-        option :build,
-          aliases: ["-b"],
-          default: "alpha",
-          values: API::GameDownloadAPI::BUILDS,
-          desc: "Build type"
-        option :platform,
-          aliases: ["-p"],
-          values: API::GameDownloadAPI::PLATFORMS,
-          desc: "Platform (default: auto-detect)"
-        option :channel,
-          aliases: ["-c"],
-          default: "stable",
-          values: API::GameDownloadAPI::CHANNELS,
-          desc: "Release channel"
+        option :build, aliases: ["-b"], default: "alpha", values: API::GameDownloadAPI::BUILDS, desc: "Build type"
+        option :platform, aliases: ["-p"], values: API::GameDownloadAPI::PLATFORMS, desc: "Platform (default: auto-detect)"
+        option :channel, aliases: ["-c"], default: "stable", values: API::GameDownloadAPI::CHANNELS, desc: "Release channel"
         option :directory, aliases: ["-d"], default: ".", desc: "Download directory"
         option :output, aliases: ["-o"], desc: "Output filename (default: from server)"
 

--- a/lib/factorix/container.rb
+++ b/lib/factorix/container.rb
@@ -136,6 +136,11 @@ module Factorix
       API::MODDownloadAPI.new
     end
 
+    # Register Game Download API client
+    register(:game_download_api, memoize: true) do
+      API::GameDownloadAPI.new
+    end
+
     # Register API credential (for MOD upload/management)
     register(:api_credential, memoize: true) { APICredential.load }
 

--- a/lib/factorix/http/cache_decorator.rb
+++ b/lib/factorix/http/cache_decorator.rb
@@ -94,6 +94,13 @@ module Factorix
       # @return [Response] response object
       def post(uri, body:, headers: {}, content_type: nil) = client.post(uri, body:, headers:, content_type:)
 
+      # Execute a HEAD request (never cached)
+      #
+      # @param uri [URI::HTTPS] target URI
+      # @param headers [Hash<String, String>] request headers
+      # @return [Response] response object
+      def head(uri, headers: {}) = client.head(uri, headers:)
+
       private def with_temporary_file
         temp_file = Tempfile.new("http_cache")
         yield temp_file

--- a/lib/factorix/http/cache_decorator.rb
+++ b/lib/factorix/http/cache_decorator.rb
@@ -56,7 +56,7 @@ module Factorix
         if cached_body
           logger.debug("Cache hit", uri: uri.to_s)
           publish("cache.hit", url: uri.to_s)
-          return CachedResponse.new(cached_body)
+          return CachedResponse.new(cached_body, uri:)
         end
 
         logger.debug("Cache miss", uri: uri.to_s)
@@ -68,7 +68,7 @@ module Factorix
           cached_body = cache.read(cache_key)
           if cached_body
             publish("cache.hit", url: uri.to_s)
-            return CachedResponse.new(cached_body)
+            return CachedResponse.new(cached_body, uri:)
           end
 
           response = client.get(uri, headers:)

--- a/lib/factorix/http/cached_response.rb
+++ b/lib/factorix/http/cached_response.rb
@@ -12,12 +12,15 @@ module Factorix
       attr_reader :body
       attr_reader :code
       attr_reader :headers
+      attr_reader :uri
 
       # @param body [String] cached response body
-      def initialize(body)
+      # @param uri [URI, nil] original request URI (not stored in cache, always nil)
+      def initialize(body, uri: nil)
         @body = body
         @code = 200
         @headers = {"content-type" => ["application/octet-stream"]}
+        @uri = uri
       end
 
       # Always returns true for cached responses

--- a/lib/factorix/http/client.rb
+++ b/lib/factorix/http/client.rb
@@ -58,6 +58,13 @@ module Factorix
       # @return [Response] response object
       def get(uri, headers: {}, &) = request(:get, uri, headers:, &)
 
+      # Execute a HEAD request
+      #
+      # @param uri [URI::HTTPS] target URI
+      # @param headers [Hash<String, String>] request headers
+      # @return [Response] response object
+      def head(uri, headers: {}) = request(:head, uri, headers:)
+
       # Execute a POST request
       #
       # @param uri [URI::HTTPS] target URI
@@ -86,11 +93,11 @@ module Factorix
         result
       end
 
-      private def handle_response(response, _method, _uri, redirect_count, &block)
+      private def handle_response(response, _method, uri, redirect_count, &block)
         case response
         when Net::HTTPSuccess, Net::HTTPPartialContent
           yield(response) if block
-          Response.new(response)
+          Response.new(response, uri:)
 
         when Net::HTTPRedirection
           location = response["Location"]
@@ -139,6 +146,7 @@ module Factorix
       private def build_request(method, uri, headers:, body:)
         request = case method
                   when :get then Net::HTTP::Get.new(uri)
+                  when :head then Net::HTTP::Head.new(uri)
                   when :post then Net::HTTP::Post.new(uri)
                   when :put then Net::HTTP::Put.new(uri)
                   when :delete then Net::HTTP::Delete.new(uri)

--- a/lib/factorix/http/client.rb
+++ b/lib/factorix/http/client.rb
@@ -93,7 +93,7 @@ module Factorix
         result
       end
 
-      private def handle_response(response, _method, uri, redirect_count, &block)
+      private def handle_response(response, method, uri, redirect_count, &block)
         case response
         when Net::HTTPSuccess, Net::HTTPPartialContent
           yield(response) if block
@@ -104,7 +104,9 @@ module Factorix
           redirect_url = URI(location)
           logger.info("Following redirect", location: mask_credentials(redirect_url))
 
-          perform_request(:get, redirect_url, redirect_count: redirect_count + 1, headers: {}, body: nil, &block)
+          # HEAD stays HEAD, others become GET (standard redirect behavior)
+          redirect_method = method == :head ? :head : :get
+          perform_request(redirect_method, redirect_url, redirect_count: redirect_count + 1, headers: {}, body: nil, &block)
 
         when Net::HTTPNotFound
           api_error, api_message = parse_api_error(response)

--- a/lib/factorix/http/response.rb
+++ b/lib/factorix/http/response.rb
@@ -8,13 +8,16 @@ module Factorix
       attr_reader :body
       attr_reader :headers
       attr_reader :raw_response
+      attr_reader :uri
 
       # @param net_http_response [Net::HTTPResponse] Raw Net::HTTP response
-      def initialize(net_http_response)
+      # @param uri [URI, nil] Final URI after following redirects
+      def initialize(net_http_response, uri: nil)
         @code = Integer(net_http_response.code, 10)
         @body = net_http_response.body
         @headers = net_http_response.to_hash
         @raw_response = net_http_response
+        @uri = uri
       end
 
       # Check if response is successful (2xx)

--- a/lib/factorix/http/retry_decorator.rb
+++ b/lib/factorix/http/retry_decorator.rb
@@ -54,6 +54,17 @@ module Factorix
           client.post(uri, body:, headers:, content_type:)
         end
       end
+
+      # Execute a HEAD request with retry
+      #
+      # @param uri [URI::HTTPS] target URI
+      # @param headers [Hash<String, String>] request headers
+      # @return [Response] response object
+      def head(uri, headers: {})
+        retry_strategy.with_retry do
+          client.head(uri, headers:)
+        end
+      end
     end
   end
 end

--- a/spec/factorix/api/game_download_api_spec.rb
+++ b/spec/factorix/api/game_download_api_spec.rb
@@ -1,0 +1,196 @@
+# frozen_string_literal: true
+
+RSpec.describe Factorix::API::GameDownloadAPI do
+  let(:logger) { instance_double(Dry::Logger::Dispatcher, debug: nil) }
+  let(:client) { instance_double(Factorix::HTTP::Client) }
+  let(:service_credential) { instance_double(Factorix::ServiceCredential, username: "test_user", token: "test_token") }
+  let(:downloader) { instance_double(Factorix::Transfer::Downloader) }
+  let(:api) { Factorix::API::GameDownloadAPI.new(logger:, client:) }
+
+  before do
+    allow(Factorix::Container).to receive(:[]).and_call_original
+    allow(Factorix::Container).to receive(:[]).with(:service_credential).and_return(service_credential)
+    allow(Factorix::Container).to receive(:[]).with(:downloader).and_return(downloader)
+    allow(downloader).to receive(:subscribe)
+    allow(downloader).to receive(:unsubscribe)
+  end
+
+  describe "#latest_releases" do
+    let(:releases_json) do
+      {
+        stable: {alpha: "2.0.28", expansion: "2.0.28", headless: "2.0.28"},
+        experimental: {alpha: "2.0.29", expansion: "2.0.29", headless: "2.0.29"}
+      }.to_json
+    end
+
+    before do
+      response = instance_double(Factorix::HTTP::Response, body: releases_json)
+      allow(client).to receive(:get).and_return(response)
+    end
+
+    it "fetches latest releases from API" do
+      api.latest_releases
+
+      expect(client).to have_received(:get).with(URI("https://factorio.com/api/latest-releases"))
+    end
+
+    it "returns parsed release information" do
+      result = api.latest_releases
+
+      expect(result[:stable][:alpha]).to eq("2.0.28")
+      expect(result[:experimental][:alpha]).to eq("2.0.29")
+    end
+  end
+
+  describe "#latest_version" do
+    let(:releases_json) do
+      {
+        stable: {alpha: "2.0.28", expansion: "2.0.28", headless: "2.0.28"},
+        experimental: {alpha: "2.0.29", expansion: "2.0.29", headless: "2.0.29"}
+      }.to_json
+    end
+
+    before do
+      response = instance_double(Factorix::HTTP::Response, body: releases_json)
+      allow(client).to receive(:get).and_return(response)
+    end
+
+    it "returns stable alpha version" do
+      result = api.latest_version(channel: "stable", build: "alpha")
+
+      expect(result).to eq("2.0.28")
+    end
+
+    it "returns experimental headless version" do
+      result = api.latest_version(channel: "experimental", build: "headless")
+
+      expect(result).to eq("2.0.29")
+    end
+
+    it "returns nil for unavailable build" do
+      result = api.latest_version(channel: "stable", build: "demo")
+
+      expect(result).to be_nil
+    end
+  end
+
+  describe "#resolve_filename" do
+    let(:final_uri) { URI("https://www.factorio.com/get-download/stable/2.0.28/alpha/osx/Factorio_2.0.28.dmg") }
+    let(:response) { instance_double(Factorix::HTTP::Response, uri: final_uri) }
+
+    before do
+      allow(client).to receive(:head).and_return(response)
+    end
+
+    it "makes HEAD request to download endpoint" do
+      api.resolve_filename(version: "2.0.28", build: "alpha", platform: "osx")
+
+      expect(client).to have_received(:head) do |uri|
+        expect(uri.host).to eq("www.factorio.com")
+        expect(uri.path).to eq("/get-download/2.0.28/alpha/osx")
+      end
+    end
+
+    it "extracts filename from final redirect URL" do
+      result = api.resolve_filename(version: "2.0.28", build: "alpha", platform: "osx")
+
+      expect(result).to eq("Factorio_2.0.28.dmg")
+    end
+
+    it "includes authentication parameters in request" do
+      api.resolve_filename(version: "2.0.28", build: "alpha", platform: "osx")
+
+      expect(client).to have_received(:head) do |uri|
+        expect(uri.query).to include("username=test_user")
+        expect(uri.query).to include("token=test_token")
+      end
+    end
+
+    context "with invalid build type" do
+      it "raises ArgumentError" do
+        expect {
+          api.resolve_filename(version: "2.0.28", build: "invalid", platform: "osx")
+        }.to raise_error(ArgumentError, /Invalid build type/)
+      end
+    end
+
+    context "with invalid platform" do
+      it "raises ArgumentError" do
+        expect {
+          api.resolve_filename(version: "2.0.28", build: "alpha", platform: "invalid")
+        }.to raise_error(ArgumentError, /Invalid platform/)
+      end
+    end
+  end
+
+  describe "#download" do
+    let(:output) { Pathname("/tmp/Factorio.dmg") }
+
+    before do
+      allow(downloader).to receive(:download)
+    end
+
+    it "downloads via downloader" do
+      api.download(version: "2.0.28", build: "alpha", platform: "osx", output:)
+
+      expect(downloader).to have_received(:download).with(kind_of(URI::HTTPS), output)
+    end
+
+    it "builds correct download URI" do
+      api.download(version: "2.0.28", build: "alpha", platform: "osx", output:)
+
+      expect(downloader).to have_received(:download) do |uri, _output|
+        expect(uri.host).to eq("www.factorio.com")
+        expect(uri.path).to eq("/get-download/2.0.28/alpha/osx")
+        expect(uri.query).to include("username=test_user")
+        expect(uri.query).to include("token=test_token")
+      end
+    end
+
+    it "subscribes handler when provided" do
+      handler = instance_double(Object)
+
+      api.download(version: "2.0.28", build: "alpha", platform: "osx", output:, handler:)
+
+      expect(downloader).to have_received(:subscribe).with(handler)
+      expect(downloader).to have_received(:unsubscribe).with(handler)
+    end
+
+    it "does not subscribe when handler is nil" do
+      api.download(version: "2.0.28", build: "alpha", platform: "osx", output:)
+
+      expect(downloader).not_to have_received(:subscribe)
+      expect(downloader).not_to have_received(:unsubscribe)
+    end
+
+    context "with invalid build type" do
+      it "raises ArgumentError" do
+        expect {
+          api.download(version: "2.0.28", build: "invalid", platform: "osx", output:)
+        }.to raise_error(ArgumentError, /Invalid build type/)
+      end
+    end
+
+    context "with invalid platform" do
+      it "raises ArgumentError" do
+        expect {
+          api.download(version: "2.0.28", build: "alpha", platform: "invalid", output:)
+        }.to raise_error(ArgumentError, /Invalid platform/)
+      end
+    end
+  end
+
+  describe "constants" do
+    it "defines valid BUILDS" do
+      expect(Factorix::API::GameDownloadAPI::BUILDS).to eq(%w[alpha expansion demo headless])
+    end
+
+    it "defines valid PLATFORMS" do
+      expect(Factorix::API::GameDownloadAPI::PLATFORMS).to eq(%w[win64 win64-manual osx linux64])
+    end
+
+    it "defines valid CHANNELS" do
+      expect(Factorix::API::GameDownloadAPI::CHANNELS).to eq(%w[stable experimental])
+    end
+  end
+end

--- a/spec/factorix/cli/commands/download_spec.rb
+++ b/spec/factorix/cli/commands/download_spec.rb
@@ -1,0 +1,225 @@
+# frozen_string_literal: true
+
+RSpec.describe Factorix::CLI::Commands::Download do
+  let(:logger) { instance_double(Dry::Logger::Dispatcher, debug: nil) }
+  let(:runtime) { instance_double(Factorix::Runtime::MacOS) }
+  let(:game_download_api) { instance_double(Factorix::API::GameDownloadAPI) }
+  let(:command) { Factorix::CLI::Commands::Download.new(logger:, runtime:, game_download_api:) }
+
+  before do
+    allow(runtime).to receive(:class).and_return(Factorix::Runtime::MacOS)
+    allow(game_download_api).to receive_messages(latest_version: "2.0.28", resolve_filename: "Factorio_2.0.28.dmg")
+    allow(game_download_api).to receive(:download)
+  end
+
+  describe "#call" do
+    let(:download_dir) { Pathname(Dir.mktmpdir) }
+
+    after do
+      FileUtils.rm_rf(download_dir)
+    end
+
+    context "with default options" do
+      it "downloads latest stable alpha for auto-detected platform" do
+        run_command(command, ["--directory", download_dir.to_s])
+
+        expect(game_download_api).to have_received(:download).with(
+          version: "2.0.28",
+          build: "alpha",
+          platform: "osx",
+          output: download_dir / "Factorio_2.0.28.dmg",
+          handler: anything
+        )
+      end
+
+      it "resolves filename from API" do
+        run_command(command, ["--directory", download_dir.to_s])
+
+        expect(game_download_api).to have_received(:resolve_filename).with(
+          version: "2.0.28",
+          build: "alpha",
+          platform: "osx"
+        )
+      end
+    end
+
+    context "with specific version" do
+      it "downloads the specified version" do
+        run_command(command, ["2.0.73", "--directory", download_dir.to_s])
+
+        expect(game_download_api).to have_received(:download).with(
+          hash_including(version: "2.0.73")
+        )
+      end
+
+      it "does not call latest_version API" do
+        run_command(command, ["2.0.73", "--directory", download_dir.to_s])
+
+        expect(game_download_api).not_to have_received(:latest_version)
+      end
+    end
+
+    context "with latest version" do
+      it "resolves latest version from API" do
+        run_command(command, ["latest", "--directory", download_dir.to_s])
+
+        expect(game_download_api).to have_received(:latest_version).with(
+          channel: "stable",
+          build: "alpha"
+        )
+      end
+    end
+
+    context "with build option" do
+      it "uses specified build type" do
+        run_command(command, ["--build", "headless", "--directory", download_dir.to_s])
+
+        expect(game_download_api).to have_received(:download).with(
+          hash_including(build: "headless")
+        )
+      end
+    end
+
+    context "with platform option" do
+      it "uses specified platform" do
+        run_command(command, ["--platform", "linux64", "--directory", download_dir.to_s])
+
+        expect(game_download_api).to have_received(:download).with(
+          hash_including(platform: "linux64")
+        )
+      end
+    end
+
+    context "with channel option" do
+      it "resolves version from experimental channel" do
+        allow(game_download_api).to receive(:latest_version).with(
+          channel: "experimental",
+          build: "alpha"
+        ).and_return("2.0.29")
+
+        run_command(command, ["--channel", "experimental", "--directory", download_dir.to_s])
+
+        expect(game_download_api).to have_received(:latest_version).with(
+          channel: "experimental",
+          build: "alpha"
+        )
+      end
+    end
+
+    context "with output option" do
+      it "uses specified output filename" do
+        run_command(command, ["--output", "custom.dmg", "--directory", download_dir.to_s])
+
+        expect(game_download_api).to have_received(:download).with(
+          hash_including(output: download_dir / "custom.dmg")
+        )
+      end
+
+      it "does not resolve filename from API" do
+        run_command(command, ["--output", "custom.dmg", "--directory", download_dir.to_s])
+
+        expect(game_download_api).not_to have_received(:resolve_filename)
+      end
+    end
+
+    context "when directory does not exist" do
+      it "raises DirectoryNotFoundError" do
+        expect {
+          run_command(command, ["--directory", "/nonexistent/path"])
+        }.to raise_error(Factorix::DirectoryNotFoundError, /does not exist/)
+      end
+    end
+
+    context "when no version is available" do
+      before do
+        allow(game_download_api).to receive(:latest_version).and_return(nil)
+      end
+
+      it "raises InvalidArgumentError" do
+        expect {
+          run_command(command, ["latest", "--directory", download_dir.to_s])
+        }.to raise_error(Factorix::InvalidArgumentError, /No stable version available/)
+      end
+    end
+
+    context "with invalid version format" do
+      it "raises InvalidArgumentError" do
+        expect {
+          run_command(command, ["invalid", "--directory", download_dir.to_s])
+        }.to raise_error(Factorix::InvalidArgumentError, /Invalid version format/)
+      end
+    end
+
+    context "with version < 2.0" do
+      it "raises InvalidArgumentError" do
+        expect {
+          run_command(command, ["1.1.107", "--directory", download_dir.to_s])
+        }.to raise_error(Factorix::InvalidArgumentError, /not supported.*Minimum version is 2\.0\.0/)
+      end
+    end
+  end
+
+  describe "platform auto-detection" do
+    let(:download_dir) { Pathname(Dir.mktmpdir) }
+
+    after do
+      FileUtils.rm_rf(download_dir)
+    end
+
+    context "with MacOS runtime" do
+      before do
+        allow(runtime).to receive(:class).and_return(Factorix::Runtime::MacOS)
+      end
+
+      it "detects osx platform" do
+        run_command(command, ["--directory", download_dir.to_s])
+
+        expect(game_download_api).to have_received(:download).with(
+          hash_including(platform: "osx")
+        )
+      end
+    end
+
+    context "with Linux runtime" do
+      before do
+        allow(runtime).to receive(:class).and_return(Factorix::Runtime::Linux)
+      end
+
+      it "detects linux64 platform" do
+        run_command(command, ["--directory", download_dir.to_s])
+
+        expect(game_download_api).to have_received(:download).with(
+          hash_including(platform: "linux64")
+        )
+      end
+    end
+
+    context "with Windows runtime" do
+      before do
+        allow(runtime).to receive(:class).and_return(Factorix::Runtime::Windows)
+      end
+
+      it "detects win64 platform" do
+        run_command(command, ["--directory", download_dir.to_s])
+
+        expect(game_download_api).to have_received(:download).with(
+          hash_including(platform: "win64")
+        )
+      end
+    end
+
+    context "with WSL runtime" do
+      before do
+        allow(runtime).to receive(:class).and_return(Factorix::Runtime::WSL)
+      end
+
+      it "detects win64 platform" do
+        run_command(command, ["--directory", download_dir.to_s])
+
+        expect(game_download_api).to have_received(:download).with(
+          hash_including(platform: "win64")
+        )
+      end
+    end
+  end
+end

--- a/spec/factorix/http/cache_decorator_spec.rb
+++ b/spec/factorix/http/cache_decorator_spec.rb
@@ -213,4 +213,27 @@ RSpec.describe Factorix::HTTP::CacheDecorator do
       expect(result).to eq(response)
     end
   end
+
+  describe "#head" do
+    it "delegates to client.head without caching" do
+      allow(cache).to receive(:read)
+      allow(cache).to receive(:store)
+      allow(client).to receive(:head).and_return(response)
+
+      result = decorator.head(uri, headers: {"Authorization" => "Bearer token"})
+
+      expect(cache).not_to have_received(:read)
+      expect(cache).not_to have_received(:store)
+      expect(client).to have_received(:head).with(uri, headers: {"Authorization" => "Bearer token"})
+      expect(result).to eq(response)
+    end
+
+    it "defaults headers to empty hash" do
+      allow(client).to receive(:head).and_return(response)
+
+      decorator.head(uri)
+
+      expect(client).to have_received(:head).with(uri, headers: {})
+    end
+  end
 end

--- a/spec/factorix/http/retry_decorator_spec.rb
+++ b/spec/factorix/http/retry_decorator_spec.rb
@@ -126,4 +126,25 @@ RSpec.describe Factorix::HTTP::RetryDecorator do
       )
     end
   end
+
+  describe "#head" do
+    before do
+      allow(retry_strategy).to receive(:with_retry).and_yield
+      allow(client).to receive(:head).and_return(response)
+    end
+
+    it "delegates to client.head with retry" do
+      result = decorator.head(uri, headers: {"Authorization" => "Bearer token"})
+
+      expect(retry_strategy).to have_received(:with_retry)
+      expect(client).to have_received(:head).with(uri, headers: {"Authorization" => "Bearer token"})
+      expect(result).to eq(response)
+    end
+
+    it "defaults headers to empty hash" do
+      decorator.head(uri)
+
+      expect(client).to have_received(:head).with(uri, headers: {})
+    end
+  end
 end


### PR DESCRIPTION
## Summary

Add `factorix download` command to download Factorio game files from the official Download API.

## Changes

- Add `GameDownloadAPI` for Factorio game download operations
- Add `download` CLI command with platform auto-detection
- Add HEAD method to HTTP client for filename resolution
- Add `uri` attribute to Response/CachedResponse for redirect tracking
- Update shell completions and documentation

## Test Plan

```bash
bundle exec rake  # All 1444 tests pass
factorix download --help
factorix download --platform linux64 --build headless -d /tmp
```

Fixes #51
