### PR TITLE
:package: Add tsort as explicit dependency for Ruby 4.1 compatibility

### DIFF
--- a/factorix.gemspec
+++ b/factorix.gemspec
@@ -47,6 +47,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "retriable", "~> 3.1"
   spec.add_dependency "rubyzip", "~> 3.2"
   spec.add_dependency "tint_me", "~> 1.1"
+  spec.add_dependency "tsort", "~> 0.2"
   spec.add_dependency "tty-progressbar", "~> 0.18"
   spec.add_dependency "zeitwerk", "~> 2.7"
 end


### PR DESCRIPTION
## Summary
Add `tsort` as an explicit gem dependency for Ruby 4.1 compatibility.

## Changes
- Add `tsort` (~> 0.2) to gemspec dependencies
- `tsort` will become a bundled gem in Ruby 4.1 (formerly Ruby 3.6)

## References
- [Feature #21442: Make tsort to bundled gems](https://bugs.ruby-lang.org/issues/21442)

Fixes #54
