### PR TITLE
:sparkles: Add `mod changelog release` command

### DIFF
--- a/completion/_factorix.bash
+++ b/completion/_factorix.bash
@@ -172,7 +172,7 @@ _factorix() {
             ;;
           changelog)
             if [[ $cword -eq 3 ]]; then
-              COMPREPLY=($(compgen -W "add check" -- "$cur"))
+              COMPREPLY=($(compgen -W "add check release" -- "$cur"))
             else
               case "${words[3]}" in
                 add)
@@ -192,6 +192,13 @@ _factorix() {
                     COMPREPLY=($(compgen -f -- "$cur"))
                   elif [[ "$cur" == -* ]]; then
                     COMPREPLY=($(compgen -W "$global_opts --release --changelog --info-json" -- "$cur"))
+                  fi
+                  ;;
+                release)
+                  if [[ "$prev" == "--changelog" ]] || [[ "$prev" == "--info-json" ]]; then
+                    COMPREPLY=($(compgen -f -- "$cur"))
+                  elif [[ "$cur" == -* ]]; then
+                    COMPREPLY=($(compgen -W "$global_opts --version --date --changelog --info-json" -- "$cur"))
                   fi
                   ;;
                 *)

--- a/completion/_factorix.fish
+++ b/completion/_factorix.fish
@@ -233,6 +233,7 @@ complete -c factorix -n "__factorix_using_subcommand mod sync" -ra '(__fish_comp
 # mod changelog subcommands
 complete -c factorix -n "__factorix_using_subcommand mod changelog" -a add -d 'Add an entry to MOD changelog'
 complete -c factorix -n "__factorix_using_subcommand mod changelog" -a check -d 'Validate MOD changelog structure'
+complete -c factorix -n "__factorix_using_subcommand mod changelog" -a release -d 'Release Unreleased changelog section with a version'
 
 # mod changelog add options
 complete -c factorix -n "__factorix_using_sub_subcommand mod changelog add" -l version -d 'Version (X.Y.Z or Unreleased)' -ra 'Unreleased'
@@ -243,6 +244,12 @@ complete -c factorix -n "__factorix_using_sub_subcommand mod changelog add" -l c
 complete -c factorix -n "__factorix_using_sub_subcommand mod changelog check" -l release -d 'Disallow Unreleased section'
 complete -c factorix -n "__factorix_using_sub_subcommand mod changelog check" -l changelog -d 'Path to changelog file' -rF
 complete -c factorix -n "__factorix_using_sub_subcommand mod changelog check" -l info-json -d 'Path to info.json file' -rF
+
+# mod changelog release options
+complete -c factorix -n "__factorix_using_sub_subcommand mod changelog release" -l version -d 'Version (X.Y.Z)' -r
+complete -c factorix -n "__factorix_using_sub_subcommand mod changelog release" -l date -d 'Release date (YYYY-MM-DD)' -r
+complete -c factorix -n "__factorix_using_sub_subcommand mod changelog release" -l changelog -d 'Path to changelog file' -rF
+complete -c factorix -n "__factorix_using_sub_subcommand mod changelog release" -l info-json -d 'Path to info.json file' -rF
 
 # mod image subcommands
 complete -c factorix -n "__factorix_using_subcommand mod image" -a list -d 'List MOD images'

--- a/completion/_factorix.zsh
+++ b/completion/_factorix.zsh
@@ -293,6 +293,7 @@ _factorix_mod_changelog() {
       subcommands=(
         'add:Add an entry to MOD changelog'
         'check:Validate MOD changelog structure'
+        'release:Release Unreleased changelog section with a version'
       )
       _describe -t subcommands 'changelog subcommand' subcommands
       ;;
@@ -310,6 +311,14 @@ _factorix_mod_changelog() {
           _arguments \
             $global_opts \
             '--release[Disallow Unreleased section]' \
+            '--changelog[Path to changelog file]:changelog file:_files' \
+            '--info-json[Path to info.json file]:info.json file:_files'
+          ;;
+        release)
+          _arguments \
+            $global_opts \
+            '--version[Version (X.Y.Z)]:version:' \
+            '--date[Release date (YYYY-MM-DD)]:date:' \
             '--changelog[Path to changelog file]:changelog file:_files' \
             '--info-json[Path to info.json file]:info.json file:_files'
           ;;

--- a/doc/components/cli.md
+++ b/doc/components/cli.md
@@ -475,6 +475,18 @@ Add an entry to a MOD's changelog.txt file.
 **Arguments**:
 - `entry` - Entry text (remaining arguments joined with spaces)
 
+### MOD::Changelog::Release
+
+Convert the Unreleased section in a MOD changelog to a versioned release.
+
+**Options**:
+- `--version` - Target version (X.Y.Z, default: from info.json)
+- `--date` - Release date (YYYY-MM-DD, default: today UTC)
+- `--changelog` - Path to changelog file (default: ./changelog.txt)
+- `--info-json` - Path to info.json file (default: ./info.json, used for default version)
+
+**Use case**: Stamp the Unreleased section with a version and date as part of the release workflow
+
 ### MOD::Changelog::Check
 
 Validate the structure of a MOD changelog.txt file.

--- a/lib/factorix/changelog.rb
+++ b/lib/factorix/changelog.rb
@@ -71,6 +71,18 @@ module Factorix
       entries << entry
     end
 
+    # Replace the first section (Unreleased) with a versioned section
+    # @param version [MODVersion] target version
+    # @param date [String] release date (YYYY-MM-DD)
+    # @return [void]
+    def release_section(version, date:)
+      raise InvalidOperationError, "First section is not Unreleased" unless @sections.first&.version == UNRELEASED
+      raise InvalidOperationError, "Version #{version} already exists" if @sections.any? {|s| s.version == version }
+
+      unreleased = @sections.first
+      @sections[0] = Section[version:, date:, categories: unreleased.categories]
+    end
+
     # Render the changelog as a string
     #
     # @return [String]

--- a/lib/factorix/cli.rb
+++ b/lib/factorix/cli.rb
@@ -21,6 +21,7 @@ module Factorix
     register "completion", Commands::Completion
     register "mod changelog add", Commands::MOD::Changelog::Add
     register "mod changelog check", Commands::MOD::Changelog::Check
+    register "mod changelog release", Commands::MOD::Changelog::Release
     register "mod check", Commands::MOD::Check
     register "mod list", Commands::MOD::List
     register "mod show", Commands::MOD::Show

--- a/lib/factorix/cli/commands/mod/changelog/release.rb
+++ b/lib/factorix/cli/commands/mod/changelog/release.rb
@@ -1,0 +1,45 @@
+# frozen_string_literal: true
+
+module Factorix
+  class CLI
+    module Commands
+      module MOD
+        module Changelog
+          # Convert the Unreleased section to a versioned release
+          class Release < Base
+            desc "Release Unreleased changelog section with a version"
+
+            option :version, desc: "Version (X.Y.Z, default: from info.json)"
+            option :date, desc: "Release date (YYYY-MM-DD, default: today UTC)"
+            option :changelog, default: "changelog.txt", desc: "Path to changelog file"
+            option :info_json, default: "info.json", desc: "Path to info.json file"
+
+            # @param version [String, nil] version string (X.Y.Z)
+            # @param date [String, nil] release date (YYYY-MM-DD)
+            # @param changelog [String] path to changelog file
+            # @param info_json [String] path to info.json file
+            # @return [void]
+            def call(version: nil, date: nil, changelog: "changelog.txt", info_json: "info.json", **)
+              parsed_version = resolve_version(version, Pathname(info_json))
+              release_date = date || Time.now.utc.strftime("%Y-%m-%d")
+              path = Pathname(changelog)
+              log = Factorix::Changelog.load(path)
+              log.release_section(parsed_version, date: release_date)
+              log.save(path)
+              say "Released #{parsed_version} (#{release_date})", prefix: :success
+            end
+
+            private def resolve_version(version, info_json_path)
+              if version
+                MODVersion.from_string(version)
+              else
+                info = InfoJSON.from_json(info_json_path.read)
+                info.version
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/sig/factorix/changelog.rbs
+++ b/sig/factorix/changelog.rbs
@@ -25,6 +25,8 @@ module Factorix
 
     def add_entry: (MODVersion | String version, String category, String entry) -> void
 
+    def release_section: (MODVersion version, date: String) -> void
+
     attr_reader sections: Array[Section]
 
     def to_s: () -> String

--- a/sig/factorix/cli/commands/mod/changelog/release.rbs
+++ b/sig/factorix/cli/commands/mod/changelog/release.rbs
@@ -1,0 +1,17 @@
+# RBS type signature file
+# NOTE: Do not include private method definitions in RBS files.
+#       Only public interfaces should be documented here.
+
+module Factorix
+  class CLI
+    module Commands
+      module MOD
+        module Changelog
+          class Release < Base
+            def call: (?version: String?, ?date: String?, ?changelog: String, ?info_json: String, **untyped) -> void
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/factorix/cli/commands/mod/changelog/release_spec.rb
+++ b/spec/factorix/cli/commands/mod/changelog/release_spec.rb
@@ -1,0 +1,79 @@
+# frozen_string_literal: true
+
+RSpec.describe Factorix::CLI::Commands::MOD::Changelog::Release do
+  let(:command) { Factorix::CLI::Commands::MOD::Changelog::Release.new }
+  let(:tmpdir) { Dir.mktmpdir }
+  let(:fixtures_dir) { Pathname(__dir__).join("../../../../../fixtures/changelog") }
+
+  after do
+    FileUtils.rm_rf(tmpdir) if tmpdir && File.exist?(tmpdir)
+  end
+
+  describe "#call" do
+    it "releases Unreleased section with specified version and date" do
+      changelog_path = File.join(tmpdir, "changelog.txt")
+      FileUtils.cp(fixtures_dir.join("with_unreleased.txt"), changelog_path)
+
+      result = run_command(command, %W[--version=1.1.0 --date=2025-06-15 --changelog=#{changelog_path}])
+
+      expect(result).to be_success
+      expect(result.stdout).to include("Released 1.1.0 (2025-06-15)")
+
+      content = File.read(changelog_path)
+      expect(content).to include("Version: 1.1.0")
+      expect(content).to include("Date: 2025-06-15")
+      expect(content).not_to include("Unreleased")
+    end
+
+    it "defaults version to info.json version when --version is omitted" do
+      changelog_path = File.join(tmpdir, "changelog.txt")
+      FileUtils.cp(fixtures_dir.join("with_unreleased.txt"), changelog_path)
+      info_json_path = File.join(tmpdir, "info.json")
+      File.write(info_json_path, '{"name":"test-mod","version":"2.0.0","title":"Test","author":"Test"}')
+
+      result = run_command(command, %W[--date=2025-06-15 --changelog=#{changelog_path} --info-json=#{info_json_path}])
+
+      expect(result).to be_success
+      expect(result.stdout).to include("Released 2.0.0 (2025-06-15)")
+    end
+
+    it "defaults date to today UTC when --date is omitted" do
+      changelog_path = File.join(tmpdir, "changelog.txt")
+      FileUtils.cp(fixtures_dir.join("with_unreleased.txt"), changelog_path)
+      today = Time.now.utc.strftime("%Y-%m-%d")
+
+      result = run_command(command, %W[--version=1.1.0 --changelog=#{changelog_path}])
+
+      expect(result).to be_success
+      expect(result.stdout).to include("Released 1.1.0 (#{today})")
+    end
+
+    it "raises error when first section is not Unreleased" do
+      changelog_path = fixtures_dir.join("basic.txt").to_s
+      tmp_changelog = File.join(tmpdir, "changelog.txt")
+      FileUtils.cp(changelog_path, tmp_changelog)
+
+      expect {
+        run_command(command, %W[--version=2.0.0 --date=2025-06-15 --changelog=#{tmp_changelog}])
+      }.to raise_error(Factorix::InvalidOperationError, /First section is not Unreleased/)
+    end
+
+    it "raises error when target version already exists in changelog" do
+      changelog_path = File.join(tmpdir, "changelog.txt")
+      FileUtils.cp(fixtures_dir.join("with_unreleased.txt"), changelog_path)
+
+      expect {
+        run_command(command, %W[--version=1.0.0 --date=2025-06-15 --changelog=#{changelog_path}])
+      }.to raise_error(Factorix::InvalidOperationError, /Version 1.0.0 already exists/)
+    end
+
+    it "raises error for invalid version string" do
+      changelog_path = File.join(tmpdir, "changelog.txt")
+      FileUtils.cp(fixtures_dir.join("with_unreleased.txt"), changelog_path)
+
+      expect {
+        run_command(command, %W[--version=invalid --date=2025-06-15 --changelog=#{changelog_path}])
+      }.to raise_error(Factorix::VersionParseError)
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Add `mod changelog release` command that converts an Unreleased section in changelog.txt to a versioned section with a date, supporting the MOD release workflow.

## Changes
- Add `Changelog#release_section` method to replace Unreleased section with a versioned release
- Create `MOD::Changelog::Release` CLI command with `--version`, `--date`, `--changelog`, `--info-json` options
- Default version from info.json, default date to today (UTC)
- Update shell completions (bash, zsh, fish)

## Test Plan
- `bundle exec rake` passes (spec + rubocop + steep)
- 10 new specs covering both `Changelog#release_section` and the CLI command

Closes #59
