### PR TITLE
:bug: Reject blank entry text in `Changelog#add_entry`

### DIFF
--- a/lib/factorix/changelog.rb
+++ b/lib/factorix/changelog.rb
@@ -64,6 +64,8 @@ module Factorix
     # @return [void]
     # @raise [InvalidArgumentError] if the entry already exists
     def add_entry(version, category, entry)
+      raise InvalidArgumentError, "entry must not be blank" if entry.strip.empty?
+
       section = find_or_create_section(version)
       entries = (section.categories[category] ||= [])
       raise InvalidArgumentError, "duplicate entry: #{entry}" if entries.include?(entry)

--- a/lib/factorix/changelog.rb
+++ b/lib/factorix/changelog.rb
@@ -64,7 +64,7 @@ module Factorix
     # @return [void]
     # @raise [InvalidArgumentError] if the entry already exists
     def add_entry(version, category, entry)
-      raise InvalidArgumentError, "entry must not be blank" if entry.strip.empty?
+      raise InvalidArgumentError, "entry must not be blank" if entry.match?(/\A[[:space:]]*\z/)
 
       section = find_or_create_section(version)
       entries = (section.categories[category] ||= [])

--- a/spec/factorix/changelog_spec.rb
+++ b/spec/factorix/changelog_spec.rb
@@ -115,6 +115,15 @@ RSpec.describe Factorix::Changelog do
         changelog.add_entry(version, "Features", "   ")
       }.to raise_error(Factorix::InvalidArgumentError, /entry must not be blank/)
     end
+
+    it "raises InvalidArgumentError for full-width whitespace-only entry" do
+      changelog = Factorix::Changelog.load(fixtures_dir / "basic.txt")
+      version = Factorix::MODVersion.from_string("1.1.0")
+
+      expect {
+        changelog.add_entry(version, "Features", "\u3000")
+      }.to raise_error(Factorix::InvalidArgumentError, /entry must not be blank/)
+    end
   end
 
   describe "#release_section" do

--- a/spec/factorix/changelog_spec.rb
+++ b/spec/factorix/changelog_spec.rb
@@ -97,6 +97,24 @@ RSpec.describe Factorix::Changelog do
         changelog.add_entry(version, "Features", "Added new feature A")
       }.to raise_error(Factorix::InvalidArgumentError, /duplicate entry/)
     end
+
+    it "raises InvalidArgumentError for empty string entry" do
+      changelog = Factorix::Changelog.load(fixtures_dir / "basic.txt")
+      version = Factorix::MODVersion.from_string("1.1.0")
+
+      expect {
+        changelog.add_entry(version, "Features", "")
+      }.to raise_error(Factorix::InvalidArgumentError, /entry must not be blank/)
+    end
+
+    it "raises InvalidArgumentError for whitespace-only entry" do
+      changelog = Factorix::Changelog.load(fixtures_dir / "basic.txt")
+      version = Factorix::MODVersion.from_string("1.1.0")
+
+      expect {
+        changelog.add_entry(version, "Features", "   ")
+      }.to raise_error(Factorix::InvalidArgumentError, /entry must not be blank/)
+    end
   end
 
   describe "#release_section" do


### PR DESCRIPTION
## Summary
Validate that entry text is non-blank in `Changelog#add_entry` to prevent creating empty entries like `    - ` in changelog.txt.

## Changes
- Raise `InvalidArgumentError` for empty or whitespace-only entry text
- Use POSIX `[[:space:]]` character class to cover Unicode whitespace (e.g. full-width space U+3000)
- Add specs for empty string, ASCII whitespace-only, and full-width whitespace-only cases

Fixes #63
