### PR TITLE
:sparkles: Add `mod changelog extract` command

### DIFF
--- a/completion/_factorix.bash
+++ b/completion/_factorix.bash
@@ -172,7 +172,7 @@ _factorix() {
             ;;
           changelog)
             if [[ $cword -eq 3 ]]; then
-              COMPREPLY=($(compgen -W "add check release" -- "$cur"))
+              COMPREPLY=($(compgen -W "add check extract release" -- "$cur"))
             else
               case "${words[3]}" in
                 add)
@@ -192,6 +192,15 @@ _factorix() {
                     COMPREPLY=($(compgen -f -- "$cur"))
                   elif [[ "$cur" == -* ]]; then
                     COMPREPLY=($(compgen -W "$global_opts --release --changelog --info-json" -- "$cur"))
+                  fi
+                  ;;
+                extract)
+                  if [[ "$prev" == "--changelog" ]]; then
+                    COMPREPLY=($(compgen -f -- "$cur"))
+                  elif [[ "$prev" == "--version" ]]; then
+                    COMPREPLY=($(compgen -W "Unreleased" -- "$cur"))
+                  elif [[ "$cur" == -* ]]; then
+                    COMPREPLY=($(compgen -W "$global_opts --version --json --changelog" -- "$cur"))
                   fi
                   ;;
                 release)

--- a/completion/_factorix.fish
+++ b/completion/_factorix.fish
@@ -233,12 +233,18 @@ complete -c factorix -n "__factorix_using_subcommand mod sync" -ra '(__fish_comp
 # mod changelog subcommands
 complete -c factorix -n "__factorix_using_subcommand mod changelog" -a add -d 'Add an entry to MOD changelog'
 complete -c factorix -n "__factorix_using_subcommand mod changelog" -a check -d 'Validate MOD changelog structure'
+complete -c factorix -n "__factorix_using_subcommand mod changelog" -a extract -d 'Extract a changelog section for a specific version'
 complete -c factorix -n "__factorix_using_subcommand mod changelog" -a release -d 'Release Unreleased changelog section with a version'
 
 # mod changelog add options
 complete -c factorix -n "__factorix_using_sub_subcommand mod changelog add" -l version -d 'Version (X.Y.Z or Unreleased)' -ra 'Unreleased'
 complete -c factorix -n "__factorix_using_sub_subcommand mod changelog add" -l category -d 'Category name' -xa "'Major Features' Features 'Minor Features' Graphics Sounds Optimizations Balancing 'Combat Balancing' 'Circuit Network' Changes Bugfixes Modding Scripting Gui Control Translation Debug 'Ease of use' Info Locale Compatibility"
 complete -c factorix -n "__factorix_using_sub_subcommand mod changelog add" -l changelog -d 'Path to changelog file' -rF
+
+# mod changelog extract options
+complete -c factorix -n "__factorix_using_sub_subcommand mod changelog extract" -l version -d 'Version (X.Y.Z or Unreleased)' -ra 'Unreleased'
+complete -c factorix -n "__factorix_using_sub_subcommand mod changelog extract" -l json -d 'Output in JSON format'
+complete -c factorix -n "__factorix_using_sub_subcommand mod changelog extract" -l changelog -d 'Path to changelog file' -rF
 
 # mod changelog check options
 complete -c factorix -n "__factorix_using_sub_subcommand mod changelog check" -l release -d 'Disallow Unreleased section'

--- a/completion/_factorix.zsh
+++ b/completion/_factorix.zsh
@@ -293,6 +293,7 @@ _factorix_mod_changelog() {
       subcommands=(
         'add:Add an entry to MOD changelog'
         'check:Validate MOD changelog structure'
+        'extract:Extract a changelog section for a specific version'
         'release:Release Unreleased changelog section with a version'
       )
       _describe -t subcommands 'changelog subcommand' subcommands
@@ -313,6 +314,13 @@ _factorix_mod_changelog() {
             '--release[Disallow Unreleased section]' \
             '--changelog[Path to changelog file]:changelog file:_files' \
             '--info-json[Path to info.json file]:info.json file:_files'
+          ;;
+        extract)
+          _arguments \
+            $global_opts \
+            '--version[Version (X.Y.Z or Unreleased)]:version:(Unreleased)' \
+            '--json[Output in JSON format]' \
+            '--changelog[Path to changelog file]:changelog file:_files'
           ;;
         release)
           _arguments \

--- a/doc/components/cli.md
+++ b/doc/components/cli.md
@@ -487,6 +487,21 @@ Convert the Unreleased section in a MOD changelog to a versioned release.
 
 **Use case**: Stamp the Unreleased section with a version and date as part of the release workflow
 
+### MOD::Changelog::Extract
+
+Extract a specific version's changelog section.
+
+**Options**:
+- `--version` (required) - Version to extract (X.Y.Z or `Unreleased`)
+- `--json` - Output in JSON format
+- `--changelog` - Path to changelog file (default: ./changelog.txt)
+
+**Plain text output**: Section body (version, date, categories with entries)
+
+**JSON output**: `{version, date, entries}` where `entries` is a hash of category names to entry arrays
+
+**Use case**: Extract release notes for CI pipelines, GitHub releases, or other automation
+
 ### MOD::Changelog::Check
 
 Validate the structure of a MOD changelog.txt file.

--- a/lib/factorix/changelog.rb
+++ b/lib/factorix/changelog.rb
@@ -89,21 +89,24 @@ module Factorix
     #
     # @return [String]
     def to_s
-      @sections.map {|section| format_section(section) }.join("\n") + "\n"
+      @sections.map {|section| "#{SEPARATOR}\n#{format_section(section)}" }.join("\n") + "\n"
     end
 
-    private def find_or_create_section(version)
-      @sections.find {|s| s.version == version } || create_section(version)
+    # Find a section by version
+    #
+    # @param version [MODVersion, String] target version (or Changelog::UNRELEASED)
+    # @return [Section]
+    # @raise [InvalidArgumentError] if the version is not found
+    def find_section(version)
+      @sections.find {|s| s.version == version } or raise InvalidArgumentError, "version not found: #{version}"
     end
 
-    private def create_section(version)
-      section = Section[version:, date: nil, categories: {}]
-      @sections.unshift(section)
-      section
-    end
-
-    private def format_section(section)
-      lines = [SEPARATOR]
+    # Format a section as plain text (without separator line)
+    #
+    # @param section [Section] changelog section
+    # @return [String]
+    def format_section(section)
+      lines = []
       lines << "Version: #{section.version}"
       lines << "Date: #{section.date}" if section.date
       section.categories.each do |cat, entries|
@@ -115,6 +118,16 @@ module Factorix
         end
       end
       lines.join("\n")
+    end
+
+    private def find_or_create_section(version)
+      @sections.find {|s| s.version == version } || create_section(version)
+    end
+
+    private def create_section(version)
+      section = Section[version:, date: nil, categories: {}]
+      @sections.unshift(section)
+      section
     end
 
     # Parslet grammar for Factorio changelog.txt

--- a/lib/factorix/cli.rb
+++ b/lib/factorix/cli.rb
@@ -21,6 +21,7 @@ module Factorix
     register "completion", Commands::Completion
     register "mod changelog add", Commands::MOD::Changelog::Add
     register "mod changelog check", Commands::MOD::Changelog::Check
+    register "mod changelog extract", Commands::MOD::Changelog::Extract
     register "mod changelog release", Commands::MOD::Changelog::Release
     register "mod check", Commands::MOD::Check
     register "mod list", Commands::MOD::List

--- a/lib/factorix/cli/commands/mod/changelog/extract.rb
+++ b/lib/factorix/cli/commands/mod/changelog/extract.rb
@@ -1,0 +1,38 @@
+# frozen_string_literal: true
+
+require "json"
+
+module Factorix
+  class CLI
+    module Commands
+      module MOD
+        module Changelog
+          # Extract a specific version's changelog section
+          class Extract < Base
+            desc "Extract a changelog section for a specific version"
+
+            option :version, required: true, desc: "Version (X.Y.Z or Unreleased)"
+            option :json, type: :flag, default: false, desc: "Output in JSON format"
+            option :changelog, default: "changelog.txt", desc: "Path to changelog file"
+
+            # @param version [String] version string (X.Y.Z or Unreleased)
+            # @param json [Boolean] output in JSON format
+            # @param changelog [String] path to changelog file
+            # @return [void]
+            def call(version:, json: false, changelog: "changelog.txt", **)
+              target_version = version.casecmp("unreleased").zero? ? Factorix::Changelog::UNRELEASED : MODVersion.from_string(version)
+              log = Factorix::Changelog.load(Pathname(changelog))
+              section = log.find_section(target_version)
+
+              if json
+                out.puts JSON.pretty_generate(version: section.version.to_s, date: section.date, entries: section.categories)
+              else
+                out.puts log.format_section(section)
+              end
+            end
+          end
+        end
+      end
+    end
+  end
+end

--- a/spec/factorix/cli/commands/mod/changelog/extract_spec.rb
+++ b/spec/factorix/cli/commands/mod/changelog/extract_spec.rb
@@ -1,0 +1,58 @@
+# frozen_string_literal: true
+
+RSpec.describe Factorix::CLI::Commands::MOD::Changelog::Extract do
+  let(:command) { Factorix::CLI::Commands::MOD::Changelog::Extract.new }
+  let(:fixtures_dir) { Pathname(__dir__).join("../../../../../fixtures/changelog") }
+
+  describe "#call" do
+    it "outputs plain text for an existing version" do
+      result = run_command(command, %W[--version=1.0.0 --changelog=#{fixtures_dir.join("basic.txt")}])
+
+      expect(result).to be_success
+      expect(result.stdout).to include("Version: 1.0.0")
+      expect(result.stdout).to include("  Features:")
+      expect(result.stdout).to include("    - Initial release")
+    end
+
+    it "outputs JSON for an existing version" do
+      result = run_command(command, %W[--version=2.0.0 --json --changelog=#{fixtures_dir.join("with_date.txt")}])
+
+      expect(result).to be_success
+      json = JSON.parse(result.stdout)
+      expect(json["version"]).to eq("2.0.0")
+      expect(json["date"]).to eq("2025-01-15")
+      expect(json["entries"]).to eq("Features" => ["Major overhaul"])
+    end
+
+    it "raises error when version not found" do
+      expect {
+        run_command(command, %W[--version=9.9.9 --changelog=#{fixtures_dir.join("basic.txt")}])
+      }.to raise_error(Factorix::InvalidArgumentError, /version not found/)
+    end
+
+    it "extracts the Unreleased section" do
+      result = run_command(command, %W[--version=Unreleased --changelog=#{fixtures_dir.join("with_unreleased.txt")}])
+
+      expect(result).to be_success
+      expect(result.stdout).to include("Version: Unreleased")
+      expect(result.stdout).to include("  Features:")
+      expect(result.stdout).to include("    - Added new experimental feature")
+      expect(result.stdout).to include("  Bugfixes:")
+      expect(result.stdout).to include("    - Fixed edge case in parser")
+    end
+
+    it "includes date in plain text output when present" do
+      result = run_command(command, %W[--version=2.0.0 --changelog=#{fixtures_dir.join("with_date.txt")}])
+
+      expect(result).to be_success
+      expect(result.stdout).to include("Date: 2025-01-15")
+    end
+
+    it "omits date in plain text output when absent" do
+      result = run_command(command, %W[--version=1.0.0 --changelog=#{fixtures_dir.join("basic.txt")}])
+
+      expect(result).to be_success
+      expect(result.stdout).not_to include("Date:")
+    end
+  end
+end


### PR DESCRIPTION
## Summary
Add `mod changelog extract` command to extract a specific version's changelog section for use in release notes, CI pipelines, and other automation.

## Changes
- Add `Changelog#find_section` to look up a section by version
- Make `Changelog#format_section` public (separator moved to `to_s`) so formatting logic is shared
- Add `mod changelog extract` command with `--version`, `--json`, and `--changelog` options
- Add shell completions for bash, fish, and zsh
- Add specs and CLI documentation

Closes #66
