### PR TITLE
:sparkles: Disable unlisted MODs by default in mod sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [Unreleased]
 
+### Changed
+
+- `mod sync` now disables enabled MODs (including expansion MODs) not listed in the save file by default (#70)
+- Add `--keep-unlisted` option to `mod sync` to preserve MODs not listed in the save file (#70)
+
 ## [0.10.0] - 2026-02-21
 
 ### Changed

--- a/completion/_factorix.bash
+++ b/completion/_factorix.bash
@@ -165,7 +165,7 @@ _factorix() {
             ;;
           sync)
             if [[ "$cur" == -* ]]; then
-              COMPREPLY=($(compgen -W "$global_opts $confirmable_opts -j --jobs" -- "$cur"))
+              COMPREPLY=($(compgen -W "$global_opts $confirmable_opts -j --jobs --keep-unlisted" -- "$cur"))
             else
               COMPREPLY=($(compgen -f -X '!*.zip' -- "$cur"))
             fi

--- a/completion/_factorix.fish
+++ b/completion/_factorix.fish
@@ -228,6 +228,7 @@ complete -c factorix -n "__factorix_using_subcommand mod search" -l json -d 'Out
 # mod sync options
 complete -c factorix -n "__factorix_using_subcommand mod sync" -s y -l yes -d 'Skip confirmation prompts'
 complete -c factorix -n "__factorix_using_subcommand mod sync" -s j -l jobs -d 'Number of parallel downloads' -r
+complete -c factorix -n "__factorix_using_subcommand mod sync" -l keep-unlisted -d 'Keep MODs not listed in save file enabled'
 complete -c factorix -n "__factorix_using_subcommand mod sync" -ra '(__fish_complete_suffix .zip)'
 
 # mod changelog subcommands

--- a/completion/_factorix.zsh
+++ b/completion/_factorix.zsh
@@ -256,6 +256,7 @@ _factorix_mod() {
             $global_opts \
             $confirmable_opts \
             '(-j --jobs)'{-j,--jobs}'[Number of parallel downloads]:jobs:' \
+            '--keep-unlisted[Keep MODs not listed in save file enabled]' \
             '1:save file:_files -g "*.zip"'
           ;;
         changelog)

--- a/doc/components/cli.md
+++ b/doc/components/cli.md
@@ -374,10 +374,15 @@ Show detailed MOD information from Factorio MOD Portal.
 
 Synchronize MOD states from a save file.
 
+**Options**:
+- `-j`, `--jobs` - Number of parallel downloads (default: 4)
+- `--keep-unlisted` - Keep MODs not listed in the save file enabled (default: disable them)
+
 **Features**:
 - Extracts MOD information from save file
 - Downloads missing MODs concurrently
-- Enables MODs to match save file state
+- Enables/disables MODs to match save file state
+- Disables enabled MODs (including expansion MODs) not listed in the save file (unless `--keep-unlisted` is specified)
 - Preserves existing MOD files when possible
 
 **Use case**: Set up MOD environment to match a specific save file

--- a/doc/factorix.1
+++ b/doc/factorix.1
@@ -178,12 +178,16 @@ Disable all MOD(s) except base.
 Validate MOD dependencies. Reports missing, disabled, or incompatible dependencies.
 .SS factorix mod sync SAVE_FILE
 Sync MOD states and startup settings from a save file.
+Enabled MODs not listed in the save file are disabled by default.
 .TP
 .BR \-y ", " \-\-yes
 Skip confirmation prompts.
 .TP
 .BR \-j ", " \-\-jobs =\fIVALUE\fR
 Number of parallel downloads (default: 4).
+.TP
+.B \-\-keep\-unlisted
+Keep MODs not listed in the save file enabled.
 .SS factorix mod changelog add ENTRY
 Add an entry to MOD changelog.
 .TP


### PR DESCRIPTION
## Summary

`mod sync` now disables enabled MODs (including expansion MODs) not listed in the save file by default, preventing dangling MODs when switching save files.

## Changes

- Add `--keep-unlisted` flag to preserve MODs not in the save file (opt-out of new behavior)
- Disable regular and expansion MODs absent from the save file by default

## Before

MODs not present in the save file were left untouched, resulting in enabled MODs with no dependents (e.g., syncing a Space Age save disabled Krastorio2 via conflict resolution, but its dependency ChangeInserterDropeLane remained enabled).

## After

All enabled MODs not listed in the save file are disabled, including expansion MODs (e.g., `space-age`, `quality`). Use `--keep-unlisted` to preserve previous behavior.

Closes #70
