### PR TITLE
:sparkles: Show combined sync plan and confirm once in mod sync

### DIFF
--- a/lib/factorix/cli/commands/mod/sync.rb
+++ b/lib/factorix/cli/commands/mod/sync.rb
@@ -238,7 +238,7 @@ module Factorix
             to_enabled = mod_state.enabled?
             to_version = mod_state.version
             enabled_changed = current_enabled != to_enabled
-            version_changed = current_version != to_version
+            version_changed = current_version && current_version != to_version
 
             if enabled_changed
               action = to_enabled ? :enable : :disable

--- a/lib/factorix/cli/commands/mod/sync.rb
+++ b/lib/factorix/cli/commands/mod/sync.rb
@@ -39,15 +39,14 @@ module Factorix
           #
           # @param save_file [String] Path to save file
           # @param jobs [Integer] Number of parallel downloads
+          # @param keep_unlisted [Boolean] Whether to keep unlisted MODs enabled
           # @return [void]
           def call(save_file:, jobs: "4", keep_unlisted: false, **)
             jobs = Integer(jobs)
-            # Load save file
             say "Loading save file: #{save_file}", prefix: :info
             save_data = SaveFile.load(Pathname(save_file))
             say "Loaded save file (version: #{save_data.version}, MOD(s): #{save_data.mods.size})", prefix: :info
 
-            # Load current state
             mod_list = MODList.load
             presenter = Progress::Presenter.new(title: "\u{1F50D}\u{FE0E} Scanning MOD(s)", output: err)
             handler = Progress::ScanHandler.new(presenter)
@@ -56,37 +55,30 @@ module Factorix
 
             raise DirectoryNotFoundError, "MOD directory does not exist: #{runtime.mod_dir}" unless runtime.mod_dir.exist?
 
-            # Find MODs that need to be installed
+            # Plan phase (no side effects)
             mods_to_install = find_mods_to_install(save_data.mods, installed_mods)
+            install_targets = mods_to_install.any? ? plan_installation(mods_to_install, graph, jobs) : []
+            conflict_mods = find_conflict_mods(mod_list, save_data.mods, graph)
+            changes = plan_mod_list_changes(mod_list, save_data.mods)
+            unlisted_mods = keep_unlisted ? [] : find_unlisted_mods(mod_list, save_data.mods, conflict_mods)
 
-            if mods_to_install.any?
-              say "#{mods_to_install.size} MOD(s) need to be installed", prefix: :info
+            # Show combined plan and ask once
+            show_sync_plan(install_targets, conflict_mods, changes, unlisted_mods)
 
-              # Plan installation
-              install_targets = plan_installation(mods_to_install, graph, jobs)
+            return if needs_confirmation?(install_targets, conflict_mods, changes, unlisted_mods) &&
+                      !confirm?("Do you want to apply these changes?")
 
-              # Show plan
-              show_install_plan(install_targets)
-              return unless confirm?("Do you want to install these MOD(s)?")
-
-              # Execute installation
+            # Execute phase
+            if install_targets.any?
               execute_installation(install_targets, jobs)
               say "Installed #{install_targets.size} MOD(s)", prefix: :success
-            else
-              say "All MOD(s) from save file are already installed", prefix: :info
             end
 
-            # Resolve conflicts: disable existing MODs that conflict with new ones
-            resolve_conflicts(mod_list, save_data.mods, graph)
-
-            # Update mod-list.json
-            update_mod_list(mod_list, save_data.mods)
-            disable_unlisted_mods(mod_list, save_data.mods) unless keep_unlisted
+            apply_mod_list_changes(mod_list, conflict_mods, changes, unlisted_mods)
             backup_if_exists(runtime.mod_list_path)
             mod_list.save
             say "Updated mod-list.json", prefix: :success
 
-            # Update mod-settings.dat
             update_mod_settings(save_data.startup_settings, save_data.version)
             say "Updated mod-settings.dat", prefix: :success
 
@@ -95,10 +87,8 @@ module Factorix
 
           private def find_mods_to_install(save_mods, installed_mods)
             save_mods.reject do |mod_name, _mod_state|
-              # Skip base MOD (always installed)
               next true if mod_name == "base"
 
-              # Check if MOD is installed
               mod = Factorix::MOD[name: mod_name]
               installed_mods.any? {|installed| installed.mod == mod }
             end
@@ -111,18 +101,13 @@ module Factorix
           # @param jobs [Integer] Number of parallel jobs
           # @return [Array<Hash>] Installation targets with MOD info and releases
           private def plan_installation(mods_to_install, graph, jobs)
-            # Create progress presenter for info fetching
             presenter = Progress::Presenter.new(title: "\u{1F50D}\u{FE0E} Fetching MOD info", output: err)
-
-            # Fetch info for MODs to install
             target_infos = fetch_target_mod_info(mods_to_install, jobs, presenter)
 
-            # Add to graph
             target_infos.each do |info|
               graph.add_uninstalled_mod(info[:mod_info], info[:release])
             end
 
-            # Build install targets
             build_install_targets(target_infos, runtime.mod_dir)
           end
 
@@ -158,10 +143,7 @@ module Factorix
           # @param version [MODVersion] Target version
           # @return [Hash] {mod_name:, mod_info:, release:, version:}
           private def fetch_single_mod_info(mod_name, version)
-            # Fetch full MOD info from portal
             mod_info = portal.get_mod_full(mod_name)
-
-            # Find the specific version release
             release = mod_info.releases.find {|r| r.version == version }
 
             unless release
@@ -171,117 +153,240 @@ module Factorix
             {mod_name:, mod_info:, release:, version:}
           end
 
-          # Show the installation plan
-          #
-          # @param targets [Array<Hash>] Installation targets
-          # @return [void]
-          private def show_install_plan(targets)
-            say "Planning to install #{targets.size} MOD(s):", prefix: :info
-            targets.each do |target|
-              say "  - #{target[:mod]}@#{target[:release].version}"
-            end
-          end
-
           # Execute the installation
           #
           # @param targets [Array<Hash>] Installation targets
           # @param jobs [Integer] Number of parallel jobs
           # @return [void]
           private def execute_installation(targets, jobs)
-            # Download all MODs
             download_mods(targets, jobs)
           end
 
-          # Resolve conflicts between save file MODs and existing enabled MODs
+          # Find MODs that conflict with enabled MODs from the save file
           #
           # @param mod_list [MODList] Current MOD list
           # @param save_mods [Hash<String, MODState>] MODs from save file
           # @param graph [Dependency::Graph] Dependency graph
-          # @return [void]
-          private def resolve_conflicts(mod_list, save_mods, graph)
+          # @return [Array<Hash>] Conflict entries: {mod:, conflicts_with:}
+          private def find_conflict_mods(mod_list, save_mods, graph)
+            conflicts = []
+            seen = Set.new
+
             save_mods.each do |mod_name, mod_state|
               next unless mod_state.enabled?
 
-              mod = Factorix::MOD[name: mod_name]
+              save_mod = Factorix::MOD[name: mod_name]
 
-              graph.edges_from(mod).each do |edge|
+              graph.edges_from(save_mod).each do |edge|
                 next unless edge.incompatible?
 
                 conflicting_mod = edge.to_mod
                 next unless mod_list.exist?(conflicting_mod) && mod_list.enabled?(conflicting_mod)
+                next unless seen.add?(conflicting_mod)
 
-                mod_list.disable(conflicting_mod)
-                say "Disabled #{conflicting_mod} (conflicts with #{mod} from save file)", prefix: :warn
-                logger.debug("Disabled conflicting MOD", mod_name: conflicting_mod.name, conflicts_with: mod.name)
+                conflicts << {mod: conflicting_mod, conflicts_with: save_mod}
               end
 
-              graph.edges_to(mod).each do |edge|
+              graph.edges_to(save_mod).each do |edge|
                 next unless edge.incompatible?
 
                 conflicting_mod = edge.from_mod
                 next unless mod_list.exist?(conflicting_mod) && mod_list.enabled?(conflicting_mod)
+                next unless seen.add?(conflicting_mod)
 
-                mod_list.disable(conflicting_mod)
-                say "Disabled #{conflicting_mod} (conflicts with #{mod} from save file)", prefix: :warn
-                logger.debug("Disabled conflicting MOD", mod_name: conflicting_mod.name, conflicts_with: mod.name)
+                conflicts << {mod: conflicting_mod, conflicts_with: save_mod}
               end
             end
+
+            conflicts
           end
 
-          # Update mod-list.json with MODs from save file
+          # Compute changes needed to bring mod-list.json in sync with save file
           #
           # @param mod_list [MODList] Current MOD list
           # @param save_mods [Hash<String, MODState>] MODs from save file
-          # @return [void]
-          private def update_mod_list(mod_list, save_mods)
+          # @return [Array<Hash>] Change entries: {mod:, action:, ...}
+          private def plan_mod_list_changes(mod_list, save_mods)
+            changes = []
+
             save_mods.each do |mod_name, mod_state|
               mod = Factorix::MOD[name: mod_name]
-
-              # base MOD: don't update version or enabled state
-              if mod.base?
-                logger.debug("Skipping base MOD (no changes allowed)", mod_name:)
-                next
-              end
+              next if mod.base?
 
               if mod_list.exist?(mod)
-                # expansion MOD: only update enabled state (not version)
-                if mod.expansion?
-                  if mod_state.enabled? && !mod_list.enabled?(mod)
-                    mod_list.enable(mod)
-                    logger.debug("Enabled expansion MOD in mod-list.json", mod_name:)
-                  elsif !mod_state.enabled? && mod_list.enabled?(mod)
-                    mod_list.disable(mod)
-                    logger.debug("Disabled expansion MOD in mod-list.json", mod_name:)
-                  end
-                else
-                  # Regular MOD: update both version and enabled state
-                  # Remove and re-add to update version
-                  mod_list.remove(mod)
-                  mod_list.add(mod, enabled: mod_state.enabled?, version: mod_state.version)
-                  logger.debug("Updated MOD in mod-list.json", mod_name:, version: mod_state.version&.to_s, enabled: mod_state.enabled?)
-                end
+                changes.concat(plan_existing_mod_changes(mod_list, mod, mod_state))
               else
-                # Add new entry (version from save file)
-                mod_list.add(mod, enabled: mod_state.enabled?, version: mod_state.version)
-                logger.debug("Added to mod-list.json", mod_name:, version: mod_state.version&.to_s)
+                # Not in list: add it (silently if disabled)
+                changes << {mod:, action: :add, to_enabled: mod_state.enabled?, to_version: mod_state.version}
               end
+            end
+
+            changes
+          end
+
+          # Plan changes for a single MOD that already exists in mod-list.json
+          #
+          # @param mod_list [MODList] Current MOD list
+          # @param mod [MOD] The MOD to plan changes for
+          # @param mod_state [MODState] MOD state from save file
+          # @return [Array<Hash>] Change entries for this MOD
+          private def plan_existing_mod_changes(mod_list, mod, mod_state)
+            current_enabled = mod_list.enabled?(mod)
+            return plan_expansion_mod_changes(mod, mod_state, current_enabled) if mod.expansion?
+
+            current_version = mod_list.version(mod)
+            to_enabled = mod_state.enabled?
+            to_version = mod_state.version
+            enabled_changed = current_enabled != to_enabled
+            version_changed = current_version != to_version
+
+            if enabled_changed
+              action = to_enabled ? :enable : :disable
+              [{mod:, action:, from_version: current_version, to_version:, from_enabled: current_enabled}]
+            elsif version_changed
+              [{mod:, action: :update, from_version: current_version, to_version:, from_enabled: current_enabled}]
+            else
+              []
             end
           end
 
-          # Disable enabled MODs that are not listed in the save file
+          # Plan enable/disable changes for an expansion MOD
+          #
+          # @param mod [MOD] The expansion MOD
+          # @param mod_state [MODState] MOD state from save file
+          # @param current_enabled [Boolean] Current enabled state in mod-list.json
+          # @return [Array<Hash>] Change entries (0 or 1 element)
+          private def plan_expansion_mod_changes(mod, mod_state, current_enabled)
+            if mod_state.enabled? && !current_enabled
+              [{mod:, action: :enable}]
+            elsif !mod_state.enabled? && current_enabled
+              [{mod:, action: :disable}]
+            else
+              []
+            end
+          end
+
+          # Find enabled MODs not listed in the save file (excluding conflict MODs)
           #
           # @param mod_list [MODList] Current MOD list
           # @param save_mods [Hash<String, MODState>] MODs from save file
-          # @return [void]
-          private def disable_unlisted_mods(mod_list, save_mods)
-            mod_list.each_mod do |mod|
-              next if mod.base?
-              next unless mod_list.enabled?(mod)
-              next if save_mods.key?(mod.name)
+          # @param conflict_mods [Array<Hash>] Already-planned conflict disables
+          # @return [Array<MOD>] MODs to disable
+          private def find_unlisted_mods(mod_list, save_mods, conflict_mods)
+            conflict_mod_set = Set.new(conflict_mods.map {|c| c[:mod] })
 
+            mod_list.each_mod.select do |mod|
+              !mod.base? &&
+                mod_list.enabled?(mod) &&
+                !save_mods.key?(mod.name) &&
+                !conflict_mod_set.include?(mod)
+            end
+          end
+
+          # Show the combined sync plan
+          #
+          # @param install_targets [Array<Hash>] MODs to install
+          # @param conflict_mods [Array<Hash>] MODs to disable due to conflicts
+          # @param changes [Array<Hash>] MOD list changes from save file
+          # @param unlisted_mods [Array<MOD>] MODs to disable as unlisted
+          # @return [void]
+          private def show_sync_plan(install_targets, conflict_mods, changes, unlisted_mods)
+            unless needs_confirmation?(install_targets, conflict_mods, changes, unlisted_mods)
+              say "Nothing to change", prefix: :info
+              return
+            end
+
+            say "Planning to sync MOD(s):", prefix: :info
+
+            if install_targets.any?
+              say "  Install:"
+              install_targets.each {|t| say "    - #{t[:mod]}@#{t[:release].version}" }
+            end
+
+            enable_changes = changes.select {|c| c[:action] == :enable }
+            if enable_changes.any?
+              say "  Enable:"
+              enable_changes.each {|c| say "    - #{c[:mod]}" }
+            end
+
+            disable_changes = changes.select {|c| c[:action] == :disable }
+            all_disables = conflict_mods.map {|c| {mod: c[:mod], reason: "(conflicts with #{c[:conflicts_with]})"} } +
+                           disable_changes.map {|c| {mod: c[:mod], reason: "(disabled in save file)"} } +
+                           unlisted_mods.map {|m| {mod: m, reason: "(not listed in save file)"} }
+            if all_disables.any?
+              say "  Disable:"
+              all_disables.each {|d| say "    - #{d[:mod]} #{d[:reason]}" }
+            end
+
+            update_changes = changes.select {|c| c[:action] == :update }
+            return if update_changes.none?
+
+            say "  Update:"
+            update_changes.each {|c| say "    - #{c[:mod]} (#{c[:from_version]} \u2192 #{c[:to_version]})" }
+          end
+
+          # Apply all mod-list.json changes
+          #
+          # @param mod_list [MODList] MOD list to modify
+          # @param conflict_mods [Array<Hash>] Conflict entries to disable
+          # @param changes [Array<Hash>] MOD list changes
+          # @param unlisted_mods [Array<MOD>] Unlisted MODs to disable
+          # @return [void]
+          private def apply_mod_list_changes(mod_list, conflict_mods, changes, unlisted_mods)
+            conflict_mods.each do |conflict|
+              mod_list.disable(conflict[:mod])
+              logger.debug("Disabled conflicting MOD", mod_name: conflict[:mod].name, conflicts_with: conflict[:conflicts_with].name)
+            end
+
+            changes.each {|change| apply_single_change(mod_list, change) }
+
+            unlisted_mods.each do |mod|
               mod_list.disable(mod)
-              say "Disabled #{mod} (not listed in save file)", prefix: :info
               logger.debug("Disabled unlisted MOD", mod_name: mod.name)
+            end
+          end
+
+          # Apply a single change entry to mod-list.json
+          #
+          # @param mod_list [MODList] MOD list to modify
+          # @param change [Hash] Change entry from plan_mod_list_changes
+          # @return [void]
+          private def apply_single_change(mod_list, change)
+            mod = change[:mod]
+            case change[:action]
+            when :enable
+              if mod_list.exist?(mod)
+                if mod.expansion?
+                  mod_list.enable(mod)
+                else
+                  mod_list.remove(mod)
+                  mod_list.add(mod, enabled: true, version: change[:to_version])
+                end
+              else
+                mod_list.add(mod, enabled: true, version: change[:to_version])
+              end
+              logger.debug("Enabled MOD in mod-list.json", mod_name: mod.name)
+            when :disable
+              if mod_list.exist?(mod)
+                if mod.expansion?
+                  mod_list.disable(mod)
+                else
+                  mod_list.remove(mod)
+                  mod_list.add(mod, enabled: false, version: change[:to_version])
+                end
+              else
+                mod_list.add(mod, enabled: false, version: change[:to_version])
+              end
+              logger.debug("Disabled MOD in mod-list.json", mod_name: mod.name)
+            when :update
+              mod_list.remove(mod)
+              mod_list.add(mod, enabled: change[:from_enabled], version: change[:to_version])
+              logger.debug("Updated MOD in mod-list.json", mod_name: mod.name, version: change[:to_version]&.to_s)
+            when :add
+              mod_list.add(mod, enabled: change[:to_enabled], version: change[:to_version])
+              logger.debug("Added MOD to mod-list.json", mod_name: mod.name, version: change[:to_version]&.to_s, enabled: change[:to_enabled])
+            else
+              raise ArgumentError, "Unexpected change action: #{change[:action]}"
             end
           end
 
@@ -291,26 +396,36 @@ module Factorix
           # @param game_version [GameVersion] Game version from save file
           # @return [void]
           private def update_mod_settings(startup_settings, game_version)
-            # Load existing settings or create new
             mod_settings = if runtime.mod_settings_path.exist?
                              MODSettings.load(runtime.mod_settings_path)
                            else
-                             # Create new MODSettings with all sections
                              sections = MODSettings::VALID_SECTIONS.to_h {|section_name|
                                [section_name, MODSettings::Section.new(section_name)]
                              }
                              MODSettings.new(game_version, sections)
                            end
 
-            # Merge startup settings from save file
             startup_section = mod_settings["startup"]
             startup_settings.each do |key, value|
               startup_section[key] = value
             end
 
-            # Save updated settings
             backup_if_exists(runtime.mod_settings_path)
             mod_settings.save(runtime.mod_settings_path)
+          end
+
+          # Check whether user-visible changes exist that require confirmation
+          #
+          # @param install_targets [Array<Hash>] MODs to install
+          # @param conflict_mods [Array<Hash>] MODs to disable due to conflicts
+          # @param changes [Array<Hash>] MOD list changes
+          # @param unlisted_mods [Array<MOD>] MODs to disable as unlisted
+          # @return [Boolean]
+          private def needs_confirmation?(install_targets, conflict_mods, changes, unlisted_mods)
+            install_targets.any? ||
+              conflict_mods.any? ||
+              changes.any? {|c| c[:action] != :add || c[:to_enabled] } ||
+              unlisted_mods.any?
           end
         end
       end


### PR DESCRIPTION
## Summary

Show a combined plan of all pending changes before asking for confirmation once, rather than asking separately for installs and silently applying other changes.

## Changes

- Plan all changes (install, enable/disable, conflict resolution, unlisted disable) in a single phase before showing them together
- Ask for confirmation once; skip confirmation entirely when there is nothing to change
- Extract `plan_existing_mod_changes`, `plan_expansion_mod_changes`, and `apply_single_change` helpers to reduce block nesting and length
- Add specs for exactly-one confirmation, no-confirmation-when-clean, and declined-confirmation-prevents-both-install-and-save
