### PR TITLE
:bug: Fix mod sync saving files when nothing changed

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,10 @@
 ## [Unreleased]
 
+### Fixed
+
+- Fix `mod sync` incorrectly saving `mod-list.json` and `mod-settings.dat` when nothing changed (#74)
+- Include startup settings changes in the `mod sync` plan and confirmation flow (#74)
+
 ## [0.11.0] - 2026-03-03
 
 ### Added

--- a/lib/factorix/cli/commands/mod/sync.rb
+++ b/lib/factorix/cli/commands/mod/sync.rb
@@ -61,12 +61,17 @@ module Factorix
             conflict_mods = find_conflict_mods(mod_list, save_data.mods, graph)
             changes = plan_mod_list_changes(mod_list, save_data.mods)
             unlisted_mods = keep_unlisted ? [] : find_unlisted_mods(mod_list, save_data.mods, conflict_mods)
+            mod_list_changed = needs_confirmation?(install_targets, conflict_mods, changes, unlisted_mods)
+            settings_changed = startup_settings_changed?(save_data.startup_settings)
 
             # Show combined plan and ask once
-            show_sync_plan(install_targets, conflict_mods, changes, unlisted_mods)
+            unless mod_list_changed || settings_changed
+              say "Nothing to change", prefix: :info
+              return
+            end
 
-            return if needs_confirmation?(install_targets, conflict_mods, changes, unlisted_mods) &&
-                      !confirm?("Do you want to apply these changes?")
+            show_sync_plan(install_targets, conflict_mods, changes, unlisted_mods, settings_changed)
+            return unless confirm?("Do you want to apply these changes?")
 
             # Execute phase
             if install_targets.any?
@@ -74,13 +79,17 @@ module Factorix
               say "Installed #{install_targets.size} MOD(s)", prefix: :success
             end
 
-            apply_mod_list_changes(mod_list, conflict_mods, changes, unlisted_mods)
-            backup_if_exists(runtime.mod_list_path)
-            mod_list.save
-            say "Updated mod-list.json", prefix: :success
+            if mod_list_changed
+              apply_mod_list_changes(mod_list, conflict_mods, changes, unlisted_mods)
+              backup_if_exists(runtime.mod_list_path)
+              mod_list.save
+              say "Updated mod-list.json", prefix: :success
+            end
 
-            update_mod_settings(save_data.startup_settings, save_data.version)
-            say "Updated mod-settings.dat", prefix: :success
+            if settings_changed
+              update_mod_settings(save_data.startup_settings, save_data.version)
+              say "Updated mod-settings.dat", prefix: :success
+            end
 
             say "Sync completed successfully", prefix: :success
           end
@@ -289,13 +298,9 @@ module Factorix
           # @param conflict_mods [Array<Hash>] MODs to disable due to conflicts
           # @param changes [Array<Hash>] MOD list changes from save file
           # @param unlisted_mods [Array<MOD>] MODs to disable as unlisted
+          # @param settings_changed [Boolean] Whether startup settings will be updated
           # @return [void]
-          private def show_sync_plan(install_targets, conflict_mods, changes, unlisted_mods)
-            unless needs_confirmation?(install_targets, conflict_mods, changes, unlisted_mods)
-              say "Nothing to change", prefix: :info
-              return
-            end
-
+          private def show_sync_plan(install_targets, conflict_mods, changes, unlisted_mods, settings_changed)
             say "Planning to sync MOD(s):", prefix: :info
 
             if install_targets.any?
@@ -319,10 +324,12 @@ module Factorix
             end
 
             update_changes = changes.select {|c| c[:action] == :update }
-            return if update_changes.none?
+            if update_changes.any?
+              say "  Update:"
+              update_changes.each {|c| say "    - #{c[:mod]} (#{c[:from_version]} \u2192 #{c[:to_version]})" }
+            end
 
-            say "  Update:"
-            update_changes.each {|c| say "    - #{c[:mod]} (#{c[:from_version]} \u2192 #{c[:to_version]})" }
+            say "  Update startup settings" if settings_changed
           end
 
           # Apply all mod-list.json changes
@@ -426,6 +433,20 @@ module Factorix
               conflict_mods.any? ||
               changes.any? {|c| c[:action] != :add || c[:to_enabled] } ||
               unlisted_mods.any?
+          end
+
+          # Check whether startup settings from the save file differ from the current mod-settings.dat
+          #
+          # @param startup_settings [MODSettings::Section] Startup settings from save file
+          # @return [Boolean]
+          private def startup_settings_changed?(startup_settings)
+            return true unless runtime.mod_settings_path.exist?
+
+            mod_settings = MODSettings.load(runtime.mod_settings_path)
+            startup_section = mod_settings["startup"]
+            startup_settings.any? do |key, value|
+              startup_section[key] != value
+            end
           end
         end
       end

--- a/spec/factorix/cli/commands/mod/sync_spec.rb
+++ b/spec/factorix/cli/commands/mod/sync_spec.rb
@@ -104,17 +104,28 @@ RSpec.describe Factorix::CLI::Commands::MOD::Sync do
   end
 
   describe "#call" do
-    context "when mod-list.json is already in sync with the save file" do
+    context "when mod-list.json is already in sync with the save file and startup settings have not changed" do
       before do
         mod_list.add(Factorix::MOD[name: "base"], enabled: true, version: base_mod_version)
         mod_list.add(Factorix::MOD[name: "test-mod"], enabled: true, version: Factorix::MODVersion.from_string("1.0.0"))
       end
 
-      it "saves mod-list.json without asking for confirmation" do
+      it "does not ask for confirmation" do
         run_command(command, %W[#{save_file_path}])
 
         expect(command).not_to have_received(:confirm?)
-        expect(mod_list).to have_received(:save).with(no_args)
+      end
+
+      it "does not save mod-list.json" do
+        run_command(command, %W[#{save_file_path}])
+
+        expect(mod_list).not_to have_received(:save)
+      end
+
+      it "does not update mod-settings.dat" do
+        run_command(command, %W[#{save_file_path}])
+
+        expect(mod_settings).not_to have_received(:save)
       end
     end
 


### PR DESCRIPTION
## Summary

Fix `mod sync` incorrectly saving `mod-list.json` and `mod-settings.dat` even when nothing changed, causing misleading output like "Nothing to change" followed by "Updated mod-list.json".

## Changes

- Skip saving `mod-list.json` when no MOD list changes are needed
- Skip saving `mod-settings.dat` when startup settings are unchanged
- Detect actual startup settings changes by comparing save file settings against current `mod-settings.dat`
- Include startup settings changes in the combined plan and confirmation flow

## Before

```
ℹ Nothing to change
✓ Updated mod-list.json
✓ Updated mod-settings.dat
✓ Sync completed successfully
```

## After

```
ℹ Nothing to change
```

Closes #74
