### PR TITLE
:arrow_up: Update Ruby versions

### DIFF
--- a/.github/workflows/ci.yml
+++ b/.github/workflows/ci.yml
@@ -17,7 +17,7 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        ruby: ["3.2", "3.3", "3.4", "4.0"]
+        ruby: ["3.3", "3.4", "4.0"]
 
     steps:
       - uses: actions/checkout@v5

--- a/.github/workflows/release-publish.yml
+++ b/.github/workflows/release-publish.yml
@@ -39,7 +39,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: "3.2"
+        ruby-version: "3.3"
         bundler-cache: true
 
     - name: Build gem

--- a/.github/workflows/release-validation.yml
+++ b/.github/workflows/release-validation.yml
@@ -27,7 +27,7 @@ jobs:
     - name: Set up Ruby
       uses: ruby/setup-ruby@v1
       with:
-        ruby-version: "3.2"
+        ruby-version: "3.3"
         bundler-cache: true
 
     - name: Extract version from branch name

--- a/.rubocop.yml
+++ b/.rubocop.yml
@@ -9,7 +9,7 @@ AllCops:
     - example/**/*
   ExtraDetails: true
   NewCops: enable
-  TargetRubyVersion: 3.2
+  TargetRubyVersion: 3.3
   UseCache: true
 
 inherit_mode:

--- a/factorix.gemspec
+++ b/factorix.gemspec
@@ -12,7 +12,7 @@ Gem::Specification.new do |spec|
   spec.description = "Manage Factorio MODs with dependency resolution, sync settings from saves, and launch the game"
   spec.homepage = "https://github.com/sakuro/factorix"
   spec.license = "MIT"
-  spec.required_ruby_version = ">= 3.2"
+  spec.required_ruby_version = ">= 3.3"
 
   spec.metadata["homepage_uri"] = spec.homepage
   spec.metadata["source_code_uri"] = "#{spec.homepage}.git"

--- a/mise.toml
+++ b/mise.toml
@@ -1,5 +1,5 @@
 [tools]
-ruby = "3.2"
+ruby = "3.3"
 
 [env]
 _.path = ["bin", "exe"]


### PR DESCRIPTION
Automated update of maintained Ruby versions from Ruby's official branches.yml.

This PR updates:
- `.github/workflows/ci.yml` test matrix to include all maintained Ruby versions
- `.github/workflows/release-*.yml` ruby-version to match the minimum Ruby version
- `.rubocop.yml` TargetRubyVersion to match the minimum Ruby version
- `*.gemspec` required_ruby_version to match the minimum Ruby version
- `mise.toml` ruby version to match the minimum Ruby version
