### PR TITLE
:sparkles: Always show installed version in mod show command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Changed
+
+- `mod show` always displays both Latest Version and Installed Version when a MOD is installed; "(update available)" is appended only when the local version is outdated (#82)
+
 ## [0.11.1] - 2026-03-03
 
 ### Fixed

--- a/doc/components/cli.md
+++ b/doc/components/cli.md
@@ -401,9 +401,9 @@ Show detailed MOD information from Factorio MOD Portal.
 **Output**: Text format showing:
 - Title, summary
 - Status (Enabled/Disabled/Not installed)
-- Version (latest from portal)
+- Latest Version (from portal)
+- Installed Version (when installed; "(update available)" appended when outdated)
 - Author, category, license, Factorio version, downloads count
-- Installed version with update indicator (if installed)
 - Links (MOD Portal, source URL, homepage)
 - Dependencies (required and optional)
 - Incompatibilities

--- a/doc/factorix.1
+++ b/doc/factorix.1
@@ -121,9 +121,10 @@ Output in JSON format.
 .SS factorix mod show MOD_NAME
 Show MOD details from Factorio MOD Portal.
 .PP
-Displays title, summary, version, author, category, license, Factorio version,
+Displays title, summary, latest version, author, category, license, Factorio version,
 downloads count, links (portal, source, homepage), dependencies, and
-incompatibilities. Shows installation status if the MOD is locally installed.
+incompatibilities. When the MOD is locally installed, also shows the installed
+version; "(update available)" is appended when the installed version is outdated.
 .SS factorix mod install MOD_SPECS
 Install MOD(s) from Factorio MOD Portal. Downloads to MOD directory and enables.
 .PP

--- a/lib/factorix/cli/commands/mod/show.rb
+++ b/lib/factorix/cli/commands/mod/show.rb
@@ -86,13 +86,12 @@ module Factorix
 
             rows = []
             rows << ["Status", format_status(local_status)]
-            rows << ["Version", latest_release&.version&.to_s || "N/A"]
+            rows << ["Latest Version", latest_release&.version&.to_s || "N/A"]
             if local_status[:installed] && local_status[:local_version]
               local_ver = local_status[:local_version].to_s
               latest_ver = latest_release&.version&.to_s
-              if latest_ver && local_ver != latest_ver
-                rows << ["Installed Version", "#{local_ver} (update available)"]
-              end
+              update_note = latest_ver && local_ver != latest_ver ? " (update available)" : ""
+              rows << ["Installed Version", "#{local_ver}#{update_note}"]
             end
             rows << ["Author", mod_info.owner]
             rows << ["Category", mod_info.category.name]


### PR DESCRIPTION
## Summary

Always show version information in `mod show` command, differentiating between update-available and up-to-date states.

## Changes

- Rename "Version" label to "Latest Version"
- Always show "Installed Version" when a MOD is installed (previously only shown when outdated)
- Append "(update available)" to "Installed Version" only when local version differs from latest

## Before

- "Version" shown always (latest from portal)
- "Installed Version: X.X.X (update available)" shown only when local version is older

## After

- "Latest Version" shown always
- "Installed Version: X.X.X" shown whenever MOD is installed
- "Installed Version: X.X.X (update available)" shown when an update exists
