### PR TITLE
:sparkles: Add --json option to mod show command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Changed
 
 - `mod show` always displays both Latest Version and Installed Version when a MOD is installed; "(update available)" is appended only when the local version is outdated (#82)
+- Add `--json` option to `mod show` for machine-readable output
 
 ## [0.11.1] - 2026-03-03
 

--- a/completion/_factorix.bash
+++ b/completion/_factorix.bash
@@ -122,7 +122,7 @@ _factorix() {
             COMPREPLY=($(compgen -W "$global_opts --enabled --disabled --errors --outdated --json" -- "$cur"))
             ;;
           show)
-            COMPREPLY=($(compgen -W "$global_opts" -- "$cur"))
+            COMPREPLY=($(compgen -W "$global_opts --json" -- "$cur"))
             ;;
           enable|disable)
             if [[ "$cur" == -* ]]; then

--- a/completion/_factorix.fish
+++ b/completion/_factorix.fish
@@ -174,6 +174,9 @@ complete -c factorix -n "__factorix_using_command mod" -a changelog -d 'MOD chan
 complete -c factorix -n "__factorix_using_command mod" -a image -d 'MOD image management'
 complete -c factorix -n "__factorix_using_command mod" -a settings -d 'MOD settings management'
 
+# mod show options
+complete -c factorix -n "__factorix_using_subcommand mod show" -l json -d 'Output in JSON format'
+
 # mod list options
 complete -c factorix -n "__factorix_using_subcommand mod list" -l enabled -d 'Show only enabled MODs'
 complete -c factorix -n "__factorix_using_subcommand mod list" -l disabled -d 'Show only disabled MODs'

--- a/completion/_factorix.zsh
+++ b/completion/_factorix.zsh
@@ -211,6 +211,7 @@ _factorix_mod() {
         show)
           _arguments \
             $global_opts \
+            '--json[Output in JSON format]' \
             '1:MOD name:'
           ;;
         enable)

--- a/doc/components/cli.md
+++ b/doc/components/cli.md
@@ -398,6 +398,9 @@ Show detailed MOD information from Factorio MOD Portal.
 **Arguments**:
 - `mod_name` - MOD name to show (required)
 
+**Options**:
+- `--json` - Output in JSON format
+
 **Output**: Text format showing:
 - Title, summary
 - Status (Enabled/Disabled/Not installed)
@@ -407,6 +410,8 @@ Show detailed MOD information from Factorio MOD Portal.
 - Links (MOD Portal, source URL, homepage)
 - Dependencies (required and optional)
 - Incompatibilities
+
+**JSON output**: Single object with `name`, `title`, `summary`, `author`, `category`, `license`, `factorio_version`, `downloads_count`, `status` (`"enabled"`/`"disabled"`/`"not_installed"`), `latest_version`, `installed_version` (null if not installed), `update_available` (null if not installed, boolean otherwise), `links` (nested: `mod_portal`, `source`, `homepage`), and `dependencies` (strings in info.json format)
 
 **Use case**: View detailed MOD information before installing or to check for updates
 

--- a/doc/factorix.1
+++ b/doc/factorix.1
@@ -125,6 +125,12 @@ Displays title, summary, latest version, author, category, license, Factorio ver
 downloads count, links (portal, source, homepage), dependencies, and
 incompatibilities. When the MOD is locally installed, also shows the installed
 version; "(update available)" is appended when the installed version is outdated.
+.TP
+.B \-\-json
+Output in JSON format. Produces a single object with name, title, summary, author,
+category, license, factorio_version, downloads_count, status, latest_version,
+installed_version, update_available, links (mod_portal, source, homepage), and
+dependencies (strings in info.json format).
 .SS factorix mod install MOD_SPECS
 Install MOD(s) from Factorio MOD Portal. Downloads to MOD directory and enables.
 .PP

--- a/lib/factorix/cli/commands/mod/show.rb
+++ b/lib/factorix/cli/commands/mod/show.rb
@@ -1,5 +1,6 @@
 # frozen_string_literal: true
 
+require "json"
 require "tint_me"
 
 module Factorix
@@ -28,17 +29,21 @@ module Factorix
           desc "Show MOD details from Factorio MOD Portal"
 
           example [
-            "some-mod          # Show details for some-mod"
+            "some-mod          # Show details for some-mod",
+            "some-mod --json   # Show details in JSON format"
           ]
 
           argument :mod_name, required: true, desc: "MOD name to show"
 
+          option :json, type: :flag, default: false, desc: "Output in JSON format"
+
           # Execute the show command
           #
           # @param mod_name [String] MOD name to show details for
+          # @param json [Boolean] output in JSON format
           # @return [void]
           # @raise [BundledMODError] if mod_name is base or an expansion MOD
-          def call(mod_name:, **)
+          def call(mod_name:, json:, **)
             mod = Factorix::MOD[mod_name]
             raise BundledMODError, "Cannot show base MOD" if mod.base?
             raise BundledMODError, "Cannot show expansion MOD: #{mod_name}" if mod.expansion?
@@ -46,11 +51,15 @@ module Factorix
             mod_info = portal.get_mod_full(mod_name)
             local_status = fetch_local_status(mod_name)
 
-            display_header(mod_info)
-            display_basic_info(mod_info, local_status)
-            display_links(mod_info)
-            display_dependencies(mod_info)
-            display_incompatibilities(mod_info)
+            if json
+              output_json(mod_info, local_status)
+            else
+              display_header(mod_info)
+              display_basic_info(mod_info, local_status)
+              display_links(mod_info)
+              display_dependencies(mod_info)
+              display_incompatibilities(mod_info)
+            end
           end
 
           private def fetch_local_status(mod_name)
@@ -104,6 +113,48 @@ module Factorix
               out.puts "#{label.ljust(max_label_width)}  #{value}"
             end
             out.puts
+          end
+
+          private def output_json(mod_info, local_status)
+            latest_release = mod_info.latest_release || mod_info.releases.max_by(&:version)
+            factorio_version = latest_release&.info_json&.dig(:factorio_version)
+            latest_ver = latest_release&.version&.to_s
+
+            installed_version = local_status[:installed] ? local_status[:local_version]&.to_s : nil
+            update_available = if local_status[:installed] && local_status[:local_version]
+                                 local_status[:local_version].to_s != latest_ver
+                               end
+
+            data = {
+              name: mod_info.name,
+              title: mod_info.title,
+              summary: mod_info.summary,
+              author: mod_info.owner,
+              category: mod_info.category.name,
+              license: mod_info.detail&.license&.title,
+              factorio_version:,
+              downloads_count: mod_info.downloads_count,
+              status: json_status(local_status),
+              latest_version: latest_ver,
+              installed_version:,
+              update_available:,
+              links: {
+                mod_portal: "https://mods.factorio.com/mod/#{mod_info.name}",
+                source: mod_info.detail&.source_url&.to_s,
+                homepage: mod_info.detail&.homepage&.to_s
+              },
+              dependencies: latest_release&.info_json&.dig(:dependencies) || []
+            }
+
+            out.puts JSON.pretty_generate(data)
+          end
+
+          private def json_status(local_status)
+            if local_status[:installed]
+              local_status[:enabled] ? "enabled" : "disabled"
+            else
+              "not_installed"
+            end
           end
 
           private def format_status(local_status)

--- a/spec/factorix/cli/commands/mod/show_spec.rb
+++ b/spec/factorix/cli/commands/mod/show_spec.rb
@@ -146,6 +146,141 @@ RSpec.describe Factorix::CLI::Commands::MOD::Show do
     end
   end
 
+  describe "--json option" do
+    let(:json) { JSON.parse(run_command(command, %w[test-mod --json]).stdout) }
+
+    it "includes basic MOD fields" do
+      expect(json).to include(
+        "name" => "test-mod",
+        "title" => "Test MOD Title",
+        "summary" => "A test MOD summary",
+        "author" => "test-author",
+        "latest_version" => "1.2.3",
+        "downloads_count" => 12_345
+      )
+    end
+
+    context "when MOD is not installed" do
+      it "reports not_installed status" do
+        expect(json["status"]).to eq("not_installed")
+      end
+
+      it "has null installed_version and update_available" do
+        expect(json["installed_version"]).to be_nil
+        expect(json["update_available"]).to be_nil
+      end
+    end
+
+    context "when MOD is installed and enabled" do
+      let(:installed_mod) do
+        instance_double(
+          Factorix::InstalledMOD,
+          mod: Factorix::MOD["test-mod"],
+          version: Factorix::MODVersion.from_string("1.2.3")
+        )
+      end
+
+      before do
+        mod_list = instance_double(Factorix::MODList)
+        allow(mod_list).to receive_messages(exist?: true, enabled?: true)
+        allow(Factorix::MODList).to receive(:load).and_return(mod_list)
+        allow(Factorix::InstalledMOD).to receive(:all).and_return([installed_mod])
+      end
+
+      it "reports enabled status and installed version" do
+        expect(json["status"]).to eq("enabled")
+        expect(json["installed_version"]).to eq("1.2.3")
+      end
+
+      it "reports update_available as false when up to date" do
+        expect(json["update_available"]).to be(false)
+      end
+    end
+
+    context "when MOD is installed and disabled" do
+      let(:installed_mod) do
+        instance_double(
+          Factorix::InstalledMOD,
+          mod: Factorix::MOD["test-mod"],
+          version: Factorix::MODVersion.from_string("1.2.3")
+        )
+      end
+
+      before do
+        mod_list = instance_double(Factorix::MODList)
+        allow(mod_list).to receive_messages(exist?: true, enabled?: false)
+        allow(Factorix::MODList).to receive(:load).and_return(mod_list)
+        allow(Factorix::InstalledMOD).to receive(:all).and_return([installed_mod])
+      end
+
+      it "reports disabled status" do
+        expect(json["status"]).to eq("disabled")
+      end
+    end
+
+    context "when installed MOD is outdated" do
+      let(:installed_mod) do
+        instance_double(
+          Factorix::InstalledMOD,
+          mod: Factorix::MOD["test-mod"],
+          version: Factorix::MODVersion.from_string("1.0.0")
+        )
+      end
+
+      before do
+        mod_list = instance_double(Factorix::MODList)
+        allow(mod_list).to receive_messages(exist?: true, enabled?: true)
+        allow(Factorix::MODList).to receive(:load).and_return(mod_list)
+        allow(Factorix::InstalledMOD).to receive(:all).and_return([installed_mod])
+      end
+
+      it "reports update_available as true with installed version" do
+        expect(json["update_available"]).to be(true)
+        expect(json["installed_version"]).to eq("1.0.0")
+      end
+    end
+
+    it "outputs dependencies in info.json format" do
+      expect(json["dependencies"]).to eq([
+        "base >= 2.0",
+        "? optional-dep >= 1.0",
+        "! incompatible-mod"
+      ])
+    end
+
+    it "outputs nested links" do
+      expect(json["links"]).to eq(
+        "mod_portal" => "https://mods.factorio.com/mod/test-mod",
+        "source" => "https://github.com/test/test-mod",
+        "homepage" => "https://example.com"
+      )
+    end
+
+    context "when MOD has no detail" do
+      let(:mod_info_without_detail) do
+        Factorix::API::MODInfo[
+          name: "test-mod",
+          title: "Test MOD Title",
+          owner: "test-author",
+          summary: "A test MOD summary",
+          downloads_count: 12_345,
+          category: "utilities",
+          releases: [release_data]
+        ]
+      end
+
+      before do
+        allow(portal).to receive(:get_mod_full).with("test-mod").and_return(mod_info_without_detail)
+      end
+
+      it "outputs null for license and link fields" do
+        expect(json["license"]).to be_nil
+        expect(json["links"]["source"]).to be_nil
+        expect(json["links"]["homepage"]).to be_nil
+      end
+    end
+  end
+
   describe "installed MOD detection" do
     let(:installed_mod) do
       instance_double(


### PR DESCRIPTION
## Summary

Add `--json` option to `mod show` command for machine-readable output of MOD details.

## Changes

- Add `--json` flag to output MOD details as a JSON object
- `dependencies` are output as raw strings in info.json format (e.g. `"base >= 2.0"`, `"? optional-mod"`)
- `links` are output as a nested object (`mod_portal`, `source`, `homepage`)
- `installed_version` and `update_available` are `null` when the MOD is not installed
- `status` is `"enabled"`, `"disabled"`, or `"not_installed"`
- Fix `nil.empty?` crash when MOD has no detail and links were being built
- Add 11 RSpec examples covering all status/version/links/dependencies scenarios
- Update `doc/components/cli.md`, `doc/factorix.1`, and `CHANGELOG.md`
