### PR TITLE
:package: Bump retriable to 4.0

### DIFF
--- a/factorix.gemspec
+++ b/factorix.gemspec
@@ -45,7 +45,7 @@ Gem::Specification.new do |spec|
   spec.add_dependency "dry-logger", "~> 1.2"
   spec.add_dependency "parslet", "~> 2.0"
   spec.add_dependency "rcon-client", "~> 0.5"
-  spec.add_dependency "retriable", "~> 3.1"
+  spec.add_dependency "retriable", "~> 4.0"
   spec.add_dependency "rubyzip", "~> 3.2"
   spec.add_dependency "tint_me", "~> 1.1"
   spec.add_dependency "tsort", "~> 0.2"


### PR DESCRIPTION
## Summary
Bump the retriable dependency from 3.x to 4.x.

## Changes
- Update `retriable` constraint from `~> 3.1` to `~> 4.0`

## Notes
- The removed `timeout:` option was not used in this codebase
- All 1572 tests pass with retriable 4.2.0
