### PR TITLE
:sparkles: Implement binary format SerDes (Phase 2)

### DIFF
--- a/doc/go-migration-roadmap.md
+++ b/doc/go-migration-roadmap.md
@@ -223,15 +223,16 @@ RCON needs no internal package — `gorcon/rcon` is used directly from the CLI l
 
 The Ruby implementation uses `pack`/`unpack`. In Go, use `encoding/binary` with `io.Reader`/`io.Writer`.
 
-- [ ] `internal/serdes/deserializer.go`
+- [x] `internal/serdes/deserializer.go`
   - `ReadU8`, `ReadU16`, `ReadU32`, `ReadBool`, `ReadStr`, `ReadOptimU16`, `ReadOptimU32`
   - `ReadGameVersion`, `ReadMODVersion`
   - `ReadPropertyTree` — returns `PropertyTree`
-- [ ] `internal/serdes/serializer.go`
+- [x] `internal/serdes/serializer.go`
   - Symmetric write methods
-- [ ] `internal/serdes/property_tree.go`
+- [x] `internal/serdes/property_tree.go`
   - `PropertyTree` type with `Kind` (None/Bool/Number/String/List/Dict/SignedInt/UnsignedInt)
-- [ ] Round-trip tests against the binary fixtures in `spec/fixtures`
+- [x] Round-trip tests (byte fixtures ported from the Ruby specs; `spec/fixtures`
+      has no standalone binary files until the save-file tests in Phase 3)
 
 ---
 
@@ -443,10 +444,14 @@ const (
 )
 
 type PropertyTree struct {
-    Kind  PropertyTreeKind
-    Value any // bool | float64 | string | []PropertyTree | map[string]PropertyTree | int64 | uint64
+    Kind  Kind
+    Value any // bool | float64 | string | []PropertyTree | []DictEntry | int64 | uint64
 }
 ```
+
+Dictionaries are `[]DictEntry` (ordered key-value pairs) rather than a Go map:
+map iteration order is random, and a load-and-save round trip must preserve
+file order byte for byte.
 
 This is still runtime-checked — type assertions move inside kind-checked accessor
 methods rather than disappearing. The gain over bare `any` is a single, tested

--- a/internal/serdes/deserializer.go
+++ b/internal/serdes/deserializer.go
@@ -173,33 +173,10 @@ func (d *Deserializer) ReadMODVersion() (mod.MODVersion, error) {
 	return mod.NewMODVersion(parts[0], parts[1], parts[2])
 }
 
-// ReadList reads a property tree list. The binary structure is identical to
-// a dictionary; the per-item keys are empty and discarded.
-//
-// See https://wiki.factorio.com/Property_tree#List
-func (d *Deserializer) ReadList() ([]PropertyTree, error) {
-	count, err := d.ReadU32()
-	if err != nil {
-		return nil, err
-	}
-	var items []PropertyTree
-	for range count {
-		if _, err := d.ReadStrProperty(); err != nil {
-			return nil, err
-		}
-		item, err := d.ReadPropertyTree()
-		if err != nil {
-			return nil, err
-		}
-		items = append(items, item)
-	}
-	return items, nil
-}
-
-// ReadDictionary reads a property tree dictionary, preserving entry order.
-//
-// See https://wiki.factorio.com/Property_tree#Dictionary
-func (d *Deserializer) ReadDictionary() ([]DictEntry, error) {
+// List and Dictionary share one binary layout — both serialize a Lua table:
+// u32 count, then a string key and a nested tree per entry. Lists carry
+// empty keys.
+func (d *Deserializer) readEntries() ([]DictEntry, error) {
 	count, err := d.ReadU32()
 	if err != nil {
 		return nil, err
@@ -217,6 +194,28 @@ func (d *Deserializer) ReadDictionary() ([]DictEntry, error) {
 		entries = append(entries, DictEntry{Key: key, Value: value})
 	}
 	return entries, nil
+}
+
+// ReadList reads a property tree list, discarding the empty per-item keys.
+//
+// See https://wiki.factorio.com/Property_tree#List
+func (d *Deserializer) ReadList() ([]PropertyTree, error) {
+	entries, err := d.readEntries()
+	if err != nil {
+		return nil, err
+	}
+	var items []PropertyTree
+	for _, entry := range entries {
+		items = append(items, entry.Value)
+	}
+	return items, nil
+}
+
+// ReadDictionary reads a property tree dictionary, preserving entry order.
+//
+// See https://wiki.factorio.com/Property_tree#Dictionary
+func (d *Deserializer) ReadDictionary() ([]DictEntry, error) {
+	return d.readEntries()
 }
 
 // ReadPropertyTree reads one property tree element.

--- a/internal/serdes/deserializer.go
+++ b/internal/serdes/deserializer.go
@@ -1,0 +1,281 @@
+package serdes
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"math"
+
+	"github.com/sakuro/factorix/internal/mod"
+)
+
+// Deserializer reads Factorio's binary format from a stream.
+type Deserializer struct {
+	r io.Reader
+}
+
+// NewDeserializer wraps r for reading.
+func NewDeserializer(r io.Reader) *Deserializer {
+	return &Deserializer{r: r}
+}
+
+// ReadBytes reads exactly n bytes, failing with io.ErrUnexpectedEOF (or
+// io.EOF when nothing was read) on a short stream.
+func (d *Deserializer) ReadBytes(n int) ([]byte, error) {
+	if n < 0 {
+		return nil, fmt.Errorf("%w: %d", ErrInvalidLength, n)
+	}
+	buf := make([]byte, n)
+	if _, err := io.ReadFull(d.r, buf); err != nil {
+		return nil, err
+	}
+	return buf, nil
+}
+
+// ReadU8 reads an unsigned 8-bit integer.
+func (d *Deserializer) ReadU8() (uint8, error) {
+	b, err := d.ReadBytes(1)
+	if err != nil {
+		return 0, err
+	}
+	return b[0], nil
+}
+
+// ReadU16 reads a little-endian unsigned 16-bit integer.
+func (d *Deserializer) ReadU16() (uint16, error) {
+	b, err := d.ReadBytes(2)
+	if err != nil {
+		return 0, err
+	}
+	return binary.LittleEndian.Uint16(b), nil
+}
+
+// ReadU32 reads a little-endian unsigned 32-bit integer.
+func (d *Deserializer) ReadU32() (uint32, error) {
+	b, err := d.ReadBytes(4)
+	if err != nil {
+		return 0, err
+	}
+	return binary.LittleEndian.Uint32(b), nil
+}
+
+// ReadOptimU16 reads a space-optimized 16-bit unsigned integer.
+//
+// See https://wiki.factorio.com/Data_types#Space_Optimized
+func (d *Deserializer) ReadOptimU16() (uint16, error) {
+	b, err := d.ReadU8()
+	if err != nil {
+		return 0, err
+	}
+	if b == 0xFF {
+		return d.ReadU16()
+	}
+	return uint16(b), nil
+}
+
+// ReadOptimU32 reads a space-optimized 32-bit unsigned integer.
+//
+// See https://wiki.factorio.com/Data_types#Space_Optimized
+func (d *Deserializer) ReadOptimU32() (uint32, error) {
+	b, err := d.ReadU8()
+	if err != nil {
+		return 0, err
+	}
+	if b == 0xFF {
+		return d.ReadU32()
+	}
+	return uint32(b), nil
+}
+
+// ReadBool reads a boolean value.
+func (d *Deserializer) ReadBool() (bool, error) {
+	b, err := d.ReadU8()
+	if err != nil {
+		return false, err
+	}
+	return b != 0, nil
+}
+
+// ReadStr reads a length-prefixed string.
+func (d *Deserializer) ReadStr() (string, error) {
+	length, err := d.ReadOptimU32()
+	if err != nil {
+		return "", err
+	}
+	b, err := d.ReadBytes(int(length))
+	if err != nil {
+		return "", err
+	}
+	return string(b), nil
+}
+
+// ReadStrProperty reads a string preceded by an "is empty" flag.
+//
+// See https://wiki.factorio.com/Property_tree#String
+func (d *Deserializer) ReadStrProperty() (string, error) {
+	empty, err := d.ReadBool()
+	if err != nil {
+		return "", err
+	}
+	if empty {
+		return "", nil
+	}
+	return d.ReadStr()
+}
+
+// ReadDouble reads a little-endian double-precision floating point number.
+func (d *Deserializer) ReadDouble() (float64, error) {
+	b, err := d.ReadBytes(8)
+	if err != nil {
+		return 0, err
+	}
+	return math.Float64frombits(binary.LittleEndian.Uint64(b)), nil
+}
+
+// ReadLong reads a little-endian signed 64-bit integer.
+func (d *Deserializer) ReadLong() (int64, error) {
+	v, err := d.ReadUnsignedLong()
+	return int64(v), err
+}
+
+// ReadUnsignedLong reads a little-endian unsigned 64-bit integer.
+func (d *Deserializer) ReadUnsignedLong() (uint64, error) {
+	b, err := d.ReadBytes(8)
+	if err != nil {
+		return 0, err
+	}
+	return binary.LittleEndian.Uint64(b), nil
+}
+
+// ReadGameVersion reads a GameVersion (4 x u16).
+func (d *Deserializer) ReadGameVersion() (mod.GameVersion, error) {
+	var parts [4]uint16
+	for i := range parts {
+		v, err := d.ReadU16()
+		if err != nil {
+			return mod.GameVersion{}, err
+		}
+		parts[i] = v
+	}
+	return mod.GameVersion{Major: parts[0], Minor: parts[1], Patch: parts[2], Build: parts[3]}, nil
+}
+
+// ReadMODVersion reads a MODVersion (3 x optim u16).
+func (d *Deserializer) ReadMODVersion() (mod.MODVersion, error) {
+	var parts [3]uint16
+	for i := range parts {
+		v, err := d.ReadOptimU16()
+		if err != nil {
+			return mod.MODVersion{}, err
+		}
+		parts[i] = v
+	}
+	return mod.NewMODVersion(parts[0], parts[1], parts[2])
+}
+
+// ReadList reads a property tree list. The binary structure is identical to
+// a dictionary; the per-item keys are empty and discarded.
+//
+// See https://wiki.factorio.com/Property_tree#List
+func (d *Deserializer) ReadList() ([]PropertyTree, error) {
+	count, err := d.ReadU32()
+	if err != nil {
+		return nil, err
+	}
+	var items []PropertyTree
+	for range count {
+		if _, err := d.ReadStrProperty(); err != nil {
+			return nil, err
+		}
+		item, err := d.ReadPropertyTree()
+		if err != nil {
+			return nil, err
+		}
+		items = append(items, item)
+	}
+	return items, nil
+}
+
+// ReadDictionary reads a property tree dictionary, preserving entry order.
+//
+// See https://wiki.factorio.com/Property_tree#Dictionary
+func (d *Deserializer) ReadDictionary() ([]DictEntry, error) {
+	count, err := d.ReadU32()
+	if err != nil {
+		return nil, err
+	}
+	var entries []DictEntry
+	for range count {
+		key, err := d.ReadStrProperty()
+		if err != nil {
+			return nil, err
+		}
+		value, err := d.ReadPropertyTree()
+		if err != nil {
+			return nil, err
+		}
+		entries = append(entries, DictEntry{Key: key, Value: value})
+	}
+	return entries, nil
+}
+
+// ReadPropertyTree reads one property tree element.
+func (d *Deserializer) ReadPropertyTree() (PropertyTree, error) {
+	typ, err := d.ReadU8()
+	if err != nil {
+		return PropertyTree{}, err
+	}
+	// The "any-type" flag is unused by Factorio; read and discard.
+	if _, err := d.ReadBool(); err != nil {
+		return PropertyTree{}, err
+	}
+
+	switch Kind(typ) {
+	case KindNone:
+		return None(), nil
+	case KindBool:
+		v, err := d.ReadBool()
+		if err != nil {
+			return PropertyTree{}, err
+		}
+		return Bool(v), nil
+	case KindNumber:
+		v, err := d.ReadDouble()
+		if err != nil {
+			return PropertyTree{}, err
+		}
+		return Number(v), nil
+	case KindString:
+		v, err := d.ReadStrProperty()
+		if err != nil {
+			return PropertyTree{}, err
+		}
+		return String(v), nil
+	case KindList:
+		items, err := d.ReadList()
+		if err != nil {
+			return PropertyTree{}, err
+		}
+		return List(items...), nil
+	case KindDict:
+		entries, err := d.ReadDictionary()
+		if err != nil {
+			return PropertyTree{}, err
+		}
+		return Dict(entries...), nil
+	case KindSignedInt:
+		v, err := d.ReadLong()
+		if err != nil {
+			return PropertyTree{}, err
+		}
+		return SignedInt(v), nil
+	case KindUnsignedInt:
+		v, err := d.ReadUnsignedLong()
+		if err != nil {
+			return PropertyTree{}, err
+		}
+		return UnsignedInt(v), nil
+	default:
+		return PropertyTree{}, &UnknownPropertyTypeError{Type: typ}
+	}
+}

--- a/internal/serdes/deserializer_test.go
+++ b/internal/serdes/deserializer_test.go
@@ -118,9 +118,11 @@ func TestReadStrProperty(t *testing.T) {
 }
 
 func TestReadDouble(t *testing.T) {
+	// Exact comparison is valid: the test value is exactly representable in
+	// binary64, and Read/WriteDouble transfer bit patterns without arithmetic.
 	v, err := newDeserializer("\x00\x00\x00\x00\x00\x00\xe0\x3f").ReadDouble()
 	require.NoError(t, err)
-	assert.InDelta(t, 0.5, v, 0)
+	assert.Equal(t, 0.5, v)
 }
 
 func TestReadLongs(t *testing.T) {

--- a/internal/serdes/deserializer_test.go
+++ b/internal/serdes/deserializer_test.go
@@ -1,0 +1,201 @@
+package serdes
+
+import (
+	"bytes"
+	"io"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sakuro/factorix/internal/mod"
+)
+
+func newDeserializer(data string) *Deserializer {
+	return NewDeserializer(strings.NewReader(data))
+}
+
+func TestReadBytes(t *testing.T) {
+	d := newDeserializer("\x00\x01\x02\x03\x04\x05\x06\x07")
+	b, err := d.ReadBytes(5)
+	require.NoError(t, err)
+	assert.Equal(t, []byte{0, 1, 2, 3, 4}, b)
+
+	b, err = d.ReadBytes(0)
+	require.NoError(t, err)
+	assert.Empty(t, b)
+
+	_, err = d.ReadBytes(-1)
+	require.ErrorIs(t, err, ErrInvalidLength)
+
+	_, err = d.ReadBytes(10)
+	require.ErrorIs(t, err, io.ErrUnexpectedEOF)
+}
+
+func TestReadUnsignedIntegers(t *testing.T) {
+	u8, err := newDeserializer("\xaa").ReadU8()
+	require.NoError(t, err)
+	assert.Equal(t, uint8(0xAA), u8)
+
+	u16, err := newDeserializer("\xaa\xbb").ReadU16()
+	require.NoError(t, err)
+	assert.Equal(t, uint16(0xBBAA), u16)
+
+	u32, err := newDeserializer("\xaa\xbb\xcc\xdd").ReadU32()
+	require.NoError(t, err)
+	assert.Equal(t, uint32(0xDDCCBBAA), u32)
+
+	_, err = newDeserializer("\xaa").ReadU16()
+	require.ErrorIs(t, err, io.ErrUnexpectedEOF)
+}
+
+func TestReadOptimU16(t *testing.T) {
+	v, err := newDeserializer("\xfe").ReadOptimU16()
+	require.NoError(t, err)
+	assert.Equal(t, uint16(0xFE), v)
+
+	v, err = newDeserializer("\xff\xaa\xbb").ReadOptimU16()
+	require.NoError(t, err)
+	assert.Equal(t, uint16(0xBBAA), v)
+
+	// 0xFF itself must be escaped with the sentinel.
+	v, err = newDeserializer("\xff\xff\x00").ReadOptimU16()
+	require.NoError(t, err)
+	assert.Equal(t, uint16(0xFF), v)
+
+	_, err = newDeserializer("\xff\xaa").ReadOptimU16()
+	require.ErrorIs(t, err, io.ErrUnexpectedEOF)
+}
+
+func TestReadOptimU32(t *testing.T) {
+	v, err := newDeserializer("\x99").ReadOptimU32()
+	require.NoError(t, err)
+	assert.Equal(t, uint32(0x99), v)
+
+	v, err = newDeserializer("\xff\xaa\xbb\xcc\xdd").ReadOptimU32()
+	require.NoError(t, err)
+	assert.Equal(t, uint32(0xDDCCBBAA), v)
+
+	_, err = newDeserializer("\xff\xaa\xbb\xcc").ReadOptimU32()
+	require.ErrorIs(t, err, io.ErrUnexpectedEOF)
+}
+
+func TestReadBool(t *testing.T) {
+	v, err := newDeserializer("\x00").ReadBool()
+	require.NoError(t, err)
+	assert.False(t, v)
+
+	v, err = newDeserializer("\x11").ReadBool()
+	require.NoError(t, err)
+	assert.True(t, v)
+}
+
+func TestReadStr(t *testing.T) {
+	v, err := newDeserializer("\x0chello, world").ReadStr()
+	require.NoError(t, err)
+	assert.Equal(t, "hello, world", v)
+
+	long := strings.Repeat("x", 300)
+	v, err = newDeserializer("\xff\x2c\x01\x00\x00" + long).ReadStr()
+	require.NoError(t, err)
+	assert.Equal(t, long, v)
+
+	multibyte := "こんにちは"
+	v, err = newDeserializer("\x0f" + multibyte).ReadStr()
+	require.NoError(t, err)
+	assert.Equal(t, multibyte, v)
+}
+
+func TestReadStrProperty(t *testing.T) {
+	v, err := newDeserializer("\x01").ReadStrProperty()
+	require.NoError(t, err)
+	assert.Empty(t, v)
+
+	v, err = newDeserializer("\x00\x03abc").ReadStrProperty()
+	require.NoError(t, err)
+	assert.Equal(t, "abc", v)
+}
+
+func TestReadDouble(t *testing.T) {
+	v, err := newDeserializer("\x00\x00\x00\x00\x00\x00\xe0\x3f").ReadDouble()
+	require.NoError(t, err)
+	assert.InDelta(t, 0.5, v, 0)
+}
+
+func TestReadLongs(t *testing.T) {
+	allFF := strings.Repeat("\xff", 8)
+
+	sv, err := newDeserializer(allFF).ReadLong()
+	require.NoError(t, err)
+	assert.Equal(t, int64(-1), sv)
+
+	uv, err := newDeserializer(allFF).ReadUnsignedLong()
+	require.NoError(t, err)
+	assert.Equal(t, uint64(0xFFFFFFFFFFFFFFFF), uv)
+}
+
+func TestReadGameVersion(t *testing.T) {
+	v, err := newDeserializer("\x01\x00\x02\x00\x03\x00\x04\x00").ReadGameVersion()
+	require.NoError(t, err)
+	assert.Equal(t, mod.GameVersion{Major: 1, Minor: 2, Patch: 3, Build: 4}, v)
+}
+
+func TestReadMODVersion(t *testing.T) {
+	v, err := newDeserializer("\x01\x02\x03").ReadMODVersion()
+	require.NoError(t, err)
+	assert.Equal(t, mod.MODVersion{Major: 1, Minor: 2, Patch: 3}, v)
+
+	// Components over 255 are representable in optim_u16 but rejected by the
+	// domain type.
+	_, err = newDeserializer("\xff\x2c\x01\x00\x00").ReadMODVersion()
+	var parseErr *mod.VersionParseError
+	require.ErrorAs(t, err, &parseErr)
+}
+
+func TestReadDictionary(t *testing.T) {
+	entries, err := newDeserializer("\x01\x00\x00\x00\x00\x05value\x02\x00\x00\x00\x00\x00\x00\x00\xe0\x3f").ReadDictionary()
+	require.NoError(t, err)
+	require.Len(t, entries, 1)
+	assert.Equal(t, "value", entries[0].Key)
+	assert.Equal(t, Number(0.5), entries[0].Value)
+}
+
+func TestReadPropertyTreeUnknownType(t *testing.T) {
+	_, err := newDeserializer("\x08\x00").ReadPropertyTree()
+	var unknownErr *UnknownPropertyTypeError
+	require.ErrorAs(t, err, &unknownErr)
+	assert.Equal(t, uint8(8), unknownErr.Type)
+}
+
+func TestReadPropertyTreeTruncated(t *testing.T) {
+	_, err := newDeserializer("\x01\x00\x00\x00\x00\x05value\x02\x00\x00\x00\x00\x00\x00\x00\xe0").ReadDictionary()
+	require.ErrorIs(t, err, io.ErrUnexpectedEOF)
+}
+
+func TestPropertyTreeRoundTrip(t *testing.T) {
+	tree := Dict(
+		DictEntry{Key: "none", Value: None()},
+		DictEntry{Key: "bool", Value: Bool(true)},
+		DictEntry{Key: "number", Value: Number(0.5)},
+		DictEntry{Key: "string", Value: String("hello")},
+		DictEntry{Key: "empty-string", Value: String("")},
+		DictEntry{Key: "list", Value: List(Number(1), String("two"), Bool(false))},
+		DictEntry{Key: "dict", Value: Dict(DictEntry{Key: "nested", Value: Number(2)})},
+		DictEntry{Key: "signed", Value: SignedInt(-42)},
+		DictEntry{Key: "unsigned", Value: UnsignedInt(42)},
+	)
+
+	var buf bytes.Buffer
+	require.NoError(t, NewSerializer(&buf).WritePropertyTree(tree))
+	first := buf.Bytes()
+
+	got, err := NewDeserializer(bytes.NewReader(first)).ReadPropertyTree()
+	require.NoError(t, err)
+	assert.Equal(t, tree, got)
+
+	// Serializing the reread tree must be byte-identical.
+	var buf2 bytes.Buffer
+	require.NoError(t, NewSerializer(&buf2).WritePropertyTree(got))
+	assert.Equal(t, first, buf2.Bytes())
+}

--- a/internal/serdes/errors.go
+++ b/internal/serdes/errors.go
@@ -1,0 +1,21 @@
+package serdes
+
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	ErrInvalidLength = errors.New("invalid length")
+	ErrInvalidUTF8   = errors.New("string is not valid UTF-8")
+)
+
+// UnknownPropertyTypeError reports a property tree type byte outside the
+// known range.
+type UnknownPropertyTypeError struct {
+	Type uint8
+}
+
+func (e *UnknownPropertyTypeError) Error() string {
+	return fmt.Sprintf("unknown property type: %d", e.Type)
+}

--- a/internal/serdes/property_tree.go
+++ b/internal/serdes/property_tree.go
@@ -1,0 +1,166 @@
+// Package serdes reads and writes Factorio's custom binary format used in
+// save files and mod-settings.dat.
+//
+// See https://wiki.factorio.com/Property_tree
+package serdes
+
+import "fmt"
+
+// Kind identifies the runtime type of a PropertyTree value. The numeric
+// values match the type bytes in the binary format.
+type Kind uint8
+
+const (
+	KindNone Kind = iota
+	KindBool
+	KindNumber
+	KindString
+	KindList
+	KindDict
+	KindSignedInt
+	KindUnsignedInt
+)
+
+func (k Kind) String() string {
+	switch k {
+	case KindNone:
+		return "none"
+	case KindBool:
+		return "bool"
+	case KindNumber:
+		return "number"
+	case KindString:
+		return "string"
+	case KindList:
+		return "list"
+	case KindDict:
+		return "dict"
+	case KindSignedInt:
+		return "signed-int"
+	case KindUnsignedInt:
+		return "unsigned-int"
+	default:
+		return fmt.Sprintf("Kind(%d)", uint8(k))
+	}
+}
+
+// PropertyTree is Factorio's recursive tagged union. Value holds
+// nil / bool / float64 / string / []PropertyTree / []DictEntry / int64 /
+// uint64 depending on Kind; use the kind-checked accessors instead of
+// asserting on Value directly.
+type PropertyTree struct {
+	Kind  Kind
+	Value any
+}
+
+// DictEntry is one key-value pair of a dictionary. Entries are a slice, not
+// a map, so that a load-and-save round trip preserves file order byte for
+// byte.
+type DictEntry struct {
+	Key   string
+	Value PropertyTree
+}
+
+// None returns a PropertyTree of the None type.
+func None() PropertyTree {
+	return PropertyTree{Kind: KindNone}
+}
+
+// Bool returns a PropertyTree wrapping a boolean.
+func Bool(v bool) PropertyTree {
+	return PropertyTree{Kind: KindBool, Value: v}
+}
+
+// Number returns a PropertyTree wrapping a double.
+func Number(v float64) PropertyTree {
+	return PropertyTree{Kind: KindNumber, Value: v}
+}
+
+// String returns a PropertyTree wrapping a string.
+func String(v string) PropertyTree {
+	return PropertyTree{Kind: KindString, Value: v}
+}
+
+// List returns a PropertyTree wrapping a list.
+func List(items ...PropertyTree) PropertyTree {
+	return PropertyTree{Kind: KindList, Value: items}
+}
+
+// Dict returns a PropertyTree wrapping a dictionary.
+func Dict(entries ...DictEntry) PropertyTree {
+	return PropertyTree{Kind: KindDict, Value: entries}
+}
+
+// SignedInt returns a PropertyTree wrapping a signed 64-bit integer.
+func SignedInt(v int64) PropertyTree {
+	return PropertyTree{Kind: KindSignedInt, Value: v}
+}
+
+// UnsignedInt returns a PropertyTree wrapping an unsigned 64-bit integer.
+func UnsignedInt(v uint64) PropertyTree {
+	return PropertyTree{Kind: KindUnsignedInt, Value: v}
+}
+
+// Bool returns the boolean value; ok is false when the kind differs.
+func (pt PropertyTree) Bool() (v, ok bool) {
+	if pt.Kind != KindBool {
+		return false, false
+	}
+	v, ok = pt.Value.(bool)
+	return v, ok
+}
+
+// Number returns the double value; ok is false when the kind differs.
+func (pt PropertyTree) Number() (float64, bool) {
+	if pt.Kind != KindNumber {
+		return 0, false
+	}
+	v, ok := pt.Value.(float64)
+	return v, ok
+}
+
+// Str returns the string value; ok is false when the kind differs.
+// (Not named String to avoid colliding with fmt.Stringer.)
+func (pt PropertyTree) Str() (string, bool) {
+	if pt.Kind != KindString {
+		return "", false
+	}
+	v, ok := pt.Value.(string)
+	return v, ok
+}
+
+// List returns the list items; ok is false when the kind differs.
+func (pt PropertyTree) List() ([]PropertyTree, bool) {
+	if pt.Kind != KindList {
+		return nil, false
+	}
+	v, ok := pt.Value.([]PropertyTree)
+	return v, ok
+}
+
+// Dict returns the dictionary entries; ok is false when the kind differs.
+func (pt PropertyTree) Dict() ([]DictEntry, bool) {
+	if pt.Kind != KindDict {
+		return nil, false
+	}
+	v, ok := pt.Value.([]DictEntry)
+	return v, ok
+}
+
+// SignedInt returns the signed integer value; ok is false when the kind differs.
+func (pt PropertyTree) SignedInt() (int64, bool) {
+	if pt.Kind != KindSignedInt {
+		return 0, false
+	}
+	v, ok := pt.Value.(int64)
+	return v, ok
+}
+
+// UnsignedInt returns the unsigned integer value; ok is false when the kind differs.
+func (pt PropertyTree) UnsignedInt() (uint64, bool) {
+	if pt.Kind != KindUnsignedInt {
+		return 0, false
+	}
+	v, ok := pt.Value.(uint64)
+	return v, ok
+}

--- a/internal/serdes/serializer.go
+++ b/internal/serdes/serializer.go
@@ -134,29 +134,10 @@ func (s *Serializer) WriteMODVersion(v mod.MODVersion) error {
 	return nil
 }
 
-// WriteList writes a property tree list. The binary structure is identical
-// to a dictionary; each item carries an empty key.
-//
-// See https://wiki.factorio.com/Property_tree#List
-func (s *Serializer) WriteList(items []PropertyTree) error {
-	if err := s.WriteU32(uint32(len(items))); err != nil {
-		return err
-	}
-	for _, item := range items {
-		if err := s.WriteStrProperty(""); err != nil {
-			return err
-		}
-		if err := s.WritePropertyTree(item); err != nil {
-			return err
-		}
-	}
-	return nil
-}
-
-// WriteDictionary writes a property tree dictionary in entry order.
-//
-// See https://wiki.factorio.com/Property_tree#Dictionary
-func (s *Serializer) WriteDictionary(entries []DictEntry) error {
+// List and Dictionary share one binary layout — both serialize a Lua table:
+// u32 count, then a string key and a nested tree per entry. Lists carry
+// empty keys.
+func (s *Serializer) writeEntries(entries []DictEntry) error {
 	if err := s.WriteU32(uint32(len(entries))); err != nil {
 		return err
 	}
@@ -169,6 +150,24 @@ func (s *Serializer) WriteDictionary(entries []DictEntry) error {
 		}
 	}
 	return nil
+}
+
+// WriteList writes a property tree list, giving each item an empty key.
+//
+// See https://wiki.factorio.com/Property_tree#List
+func (s *Serializer) WriteList(items []PropertyTree) error {
+	entries := make([]DictEntry, len(items))
+	for i, item := range items {
+		entries[i] = DictEntry{Value: item}
+	}
+	return s.writeEntries(entries)
+}
+
+// WriteDictionary writes a property tree dictionary in entry order.
+//
+// See https://wiki.factorio.com/Property_tree#Dictionary
+func (s *Serializer) WriteDictionary(entries []DictEntry) error {
+	return s.writeEntries(entries)
 }
 
 // WritePropertyTree writes one property tree element.

--- a/internal/serdes/serializer.go
+++ b/internal/serdes/serializer.go
@@ -1,0 +1,236 @@
+package serdes
+
+import (
+	"encoding/binary"
+	"fmt"
+	"io"
+	"math"
+	"unicode/utf8"
+
+	"github.com/sakuro/factorix/internal/mod"
+)
+
+// Serializer writes Factorio's binary format to a stream.
+type Serializer struct {
+	w io.Writer
+}
+
+// NewSerializer wraps w for writing.
+func NewSerializer(w io.Writer) *Serializer {
+	return &Serializer{w: w}
+}
+
+// WriteBytes writes raw bytes.
+func (s *Serializer) WriteBytes(p []byte) error {
+	_, err := s.w.Write(p)
+	return err
+}
+
+// WriteU8 writes an unsigned 8-bit integer.
+func (s *Serializer) WriteU8(v uint8) error {
+	return s.WriteBytes([]byte{v})
+}
+
+// WriteU16 writes a little-endian unsigned 16-bit integer.
+func (s *Serializer) WriteU16(v uint16) error {
+	return s.WriteBytes(binary.LittleEndian.AppendUint16(nil, v))
+}
+
+// WriteU32 writes a little-endian unsigned 32-bit integer.
+func (s *Serializer) WriteU32(v uint32) error {
+	return s.WriteBytes(binary.LittleEndian.AppendUint32(nil, v))
+}
+
+// WriteOptimU16 writes a space-optimized 16-bit unsigned integer.
+//
+// See https://wiki.factorio.com/Data_types#Space_Optimized
+func (s *Serializer) WriteOptimU16(v uint16) error {
+	if v < 0xFF {
+		return s.WriteU8(uint8(v))
+	}
+	if err := s.WriteU8(0xFF); err != nil {
+		return err
+	}
+	return s.WriteU16(v)
+}
+
+// WriteOptimU32 writes a space-optimized 32-bit unsigned integer.
+//
+// See https://wiki.factorio.com/Data_types#Space_Optimized
+func (s *Serializer) WriteOptimU32(v uint32) error {
+	if v < 0xFF {
+		return s.WriteU8(uint8(v))
+	}
+	if err := s.WriteU8(0xFF); err != nil {
+		return err
+	}
+	return s.WriteU32(v)
+}
+
+// WriteBool writes a boolean value.
+func (s *Serializer) WriteBool(v bool) error {
+	if v {
+		return s.WriteU8(0x01)
+	}
+	return s.WriteU8(0x00)
+}
+
+// WriteStr writes a length-prefixed string. The string must be valid UTF-8.
+func (s *Serializer) WriteStr(str string) error {
+	if !utf8.ValidString(str) {
+		return fmt.Errorf("%w: %q", ErrInvalidUTF8, str)
+	}
+	if err := s.WriteOptimU32(uint32(len(str))); err != nil {
+		return err
+	}
+	return s.WriteBytes([]byte(str))
+}
+
+// WriteStrProperty writes a string preceded by an "is empty" flag.
+//
+// See https://wiki.factorio.com/Property_tree#String
+func (s *Serializer) WriteStrProperty(str string) error {
+	if str == "" {
+		return s.WriteBool(true)
+	}
+	if err := s.WriteBool(false); err != nil {
+		return err
+	}
+	return s.WriteStr(str)
+}
+
+// WriteDouble writes a little-endian double-precision floating point number.
+func (s *Serializer) WriteDouble(v float64) error {
+	return s.WriteBytes(binary.LittleEndian.AppendUint64(nil, math.Float64bits(v)))
+}
+
+// WriteLong writes a little-endian signed 64-bit integer.
+func (s *Serializer) WriteLong(v int64) error {
+	return s.WriteUnsignedLong(uint64(v))
+}
+
+// WriteUnsignedLong writes a little-endian unsigned 64-bit integer.
+func (s *Serializer) WriteUnsignedLong(v uint64) error {
+	return s.WriteBytes(binary.LittleEndian.AppendUint64(nil, v))
+}
+
+// WriteGameVersion writes a GameVersion (4 x u16).
+func (s *Serializer) WriteGameVersion(v mod.GameVersion) error {
+	for _, u := range [...]uint16{v.Major, v.Minor, v.Patch, v.Build} {
+		if err := s.WriteU16(u); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// WriteMODVersion writes a MODVersion (3 x optim u16).
+func (s *Serializer) WriteMODVersion(v mod.MODVersion) error {
+	for _, u := range [...]uint16{v.Major, v.Minor, v.Patch} {
+		if err := s.WriteOptimU16(u); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// WriteList writes a property tree list. The binary structure is identical
+// to a dictionary; each item carries an empty key.
+//
+// See https://wiki.factorio.com/Property_tree#List
+func (s *Serializer) WriteList(items []PropertyTree) error {
+	if err := s.WriteU32(uint32(len(items))); err != nil {
+		return err
+	}
+	for _, item := range items {
+		if err := s.WriteStrProperty(""); err != nil {
+			return err
+		}
+		if err := s.WritePropertyTree(item); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// WriteDictionary writes a property tree dictionary in entry order.
+//
+// See https://wiki.factorio.com/Property_tree#Dictionary
+func (s *Serializer) WriteDictionary(entries []DictEntry) error {
+	if err := s.WriteU32(uint32(len(entries))); err != nil {
+		return err
+	}
+	for _, entry := range entries {
+		if err := s.WriteStrProperty(entry.Key); err != nil {
+			return err
+		}
+		if err := s.WritePropertyTree(entry.Value); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
+// WritePropertyTree writes one property tree element.
+func (s *Serializer) WritePropertyTree(pt PropertyTree) error {
+	if err := s.WriteU8(uint8(pt.Kind)); err != nil {
+		return err
+	}
+	// The "any-type" flag is unused by Factorio; always written as false.
+	if err := s.WriteBool(false); err != nil {
+		return err
+	}
+
+	switch pt.Kind {
+	case KindNone:
+		return nil
+	case KindBool:
+		v, ok := pt.Bool()
+		if !ok {
+			return valueMismatch(pt)
+		}
+		return s.WriteBool(v)
+	case KindNumber:
+		v, ok := pt.Number()
+		if !ok {
+			return valueMismatch(pt)
+		}
+		return s.WriteDouble(v)
+	case KindString:
+		v, ok := pt.Str()
+		if !ok {
+			return valueMismatch(pt)
+		}
+		return s.WriteStrProperty(v)
+	case KindList:
+		v, ok := pt.List()
+		if !ok {
+			return valueMismatch(pt)
+		}
+		return s.WriteList(v)
+	case KindDict:
+		v, ok := pt.Dict()
+		if !ok {
+			return valueMismatch(pt)
+		}
+		return s.WriteDictionary(v)
+	case KindSignedInt:
+		v, ok := pt.SignedInt()
+		if !ok {
+			return valueMismatch(pt)
+		}
+		return s.WriteLong(v)
+	case KindUnsignedInt:
+		v, ok := pt.UnsignedInt()
+		if !ok {
+			return valueMismatch(pt)
+		}
+		return s.WriteUnsignedLong(v)
+	default:
+		return &UnknownPropertyTypeError{Type: uint8(pt.Kind)}
+	}
+}
+
+func valueMismatch(pt PropertyTree) error {
+	return fmt.Errorf("property tree kind %v holds %T", pt.Kind, pt.Value)
+}

--- a/internal/serdes/serializer_test.go
+++ b/internal/serdes/serializer_test.go
@@ -1,0 +1,103 @@
+package serdes
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sakuro/factorix/internal/mod"
+)
+
+func serialize(t *testing.T, write func(*Serializer) error) []byte {
+	t.Helper()
+	var buf bytes.Buffer
+	require.NoError(t, write(NewSerializer(&buf)))
+	return buf.Bytes()
+}
+
+func TestWriteUnsignedIntegers(t *testing.T) {
+	assert.Equal(t, []byte{0xAA}, serialize(t, func(s *Serializer) error { return s.WriteU8(0xAA) }))
+	assert.Equal(t, []byte{0xAA, 0xBB}, serialize(t, func(s *Serializer) error { return s.WriteU16(0xBBAA) }))
+	assert.Equal(t, []byte{0xAA, 0xBB, 0xCC, 0xDD}, serialize(t, func(s *Serializer) error { return s.WriteU32(0xDDCCBBAA) }))
+}
+
+func TestWriteOptimU16(t *testing.T) {
+	assert.Equal(t, []byte{0xFE}, serialize(t, func(s *Serializer) error { return s.WriteOptimU16(0xFE) }))
+	// 0xFF itself must be escaped with the sentinel.
+	assert.Equal(t, []byte{0xFF, 0xFF, 0x00}, serialize(t, func(s *Serializer) error { return s.WriteOptimU16(0xFF) }))
+	assert.Equal(t, []byte{0xFF, 0xAA, 0xBB}, serialize(t, func(s *Serializer) error { return s.WriteOptimU16(0xBBAA) }))
+}
+
+func TestWriteOptimU32(t *testing.T) {
+	assert.Equal(t, []byte{0x99}, serialize(t, func(s *Serializer) error { return s.WriteOptimU32(0x99) }))
+	assert.Equal(t, []byte{0xFF, 0xAA, 0xBB, 0xCC, 0xDD}, serialize(t, func(s *Serializer) error { return s.WriteOptimU32(0xDDCCBBAA) }))
+}
+
+func TestWriteBool(t *testing.T) {
+	assert.Equal(t, []byte{0x01}, serialize(t, func(s *Serializer) error { return s.WriteBool(true) }))
+	assert.Equal(t, []byte{0x00}, serialize(t, func(s *Serializer) error { return s.WriteBool(false) }))
+}
+
+func TestWriteStr(t *testing.T) {
+	assert.Equal(t, []byte("\x0chello, world"), serialize(t, func(s *Serializer) error { return s.WriteStr("hello, world") }))
+
+	var buf bytes.Buffer
+	err := NewSerializer(&buf).WriteStr(string([]byte{0xFF, 0xFE}))
+	require.ErrorIs(t, err, ErrInvalidUTF8)
+}
+
+func TestWriteStrProperty(t *testing.T) {
+	assert.Equal(t, []byte{0x01}, serialize(t, func(s *Serializer) error { return s.WriteStrProperty("") }))
+	assert.Equal(t, []byte("\x00\x03abc"), serialize(t, func(s *Serializer) error { return s.WriteStrProperty("abc") }))
+}
+
+func TestWriteDouble(t *testing.T) {
+	assert.Equal(t, []byte{0x00, 0x00, 0x00, 0x00, 0x00, 0x00, 0xE0, 0x3F}, serialize(t, func(s *Serializer) error { return s.WriteDouble(0.5) }))
+}
+
+func TestWriteLongs(t *testing.T) {
+	allFF := bytes.Repeat([]byte{0xFF}, 8)
+	assert.Equal(t, allFF, serialize(t, func(s *Serializer) error { return s.WriteLong(-1) }))
+	assert.Equal(t, allFF, serialize(t, func(s *Serializer) error { return s.WriteUnsignedLong(0xFFFFFFFFFFFFFFFF) }))
+}
+
+func TestWriteGameVersion(t *testing.T) {
+	v := mod.GameVersion{Major: 1, Minor: 2, Patch: 3, Build: 4}
+	assert.Equal(t, []byte{0x01, 0x00, 0x02, 0x00, 0x03, 0x00, 0x04, 0x00}, serialize(t, func(s *Serializer) error { return s.WriteGameVersion(v) }))
+}
+
+func TestWriteMODVersion(t *testing.T) {
+	v := mod.MODVersion{Major: 1, Minor: 2, Patch: 255}
+	assert.Equal(t, []byte{0x01, 0x02, 0xFF, 0xFF, 0x00}, serialize(t, func(s *Serializer) error { return s.WriteMODVersion(v) }))
+}
+
+func TestWriteDictionary(t *testing.T) {
+	entries := []DictEntry{{Key: "value", Value: Number(0.5)}}
+	assert.Equal(t,
+		[]byte("\x01\x00\x00\x00\x00\x05value\x02\x00\x00\x00\x00\x00\x00\x00\xe0\x3f"),
+		serialize(t, func(s *Serializer) error { return s.WriteDictionary(entries) }),
+	)
+}
+
+func TestWriteList(t *testing.T) {
+	// Same structure as a dictionary: u32 count, then empty key + tree per item.
+	assert.Equal(t,
+		[]byte("\x01\x00\x00\x00\x01\x01\x00\x01"),
+		serialize(t, func(s *Serializer) error { return s.WriteList([]PropertyTree{Bool(true)}) }),
+	)
+}
+
+func TestWritePropertyTreeValueMismatch(t *testing.T) {
+	var buf bytes.Buffer
+	err := NewSerializer(&buf).WritePropertyTree(PropertyTree{Kind: KindBool, Value: "not a bool"})
+	require.Error(t, err)
+}
+
+func TestWritePropertyTreeUnknownKind(t *testing.T) {
+	var buf bytes.Buffer
+	err := NewSerializer(&buf).WritePropertyTree(PropertyTree{Kind: Kind(8)})
+	var unknownErr *UnknownPropertyTypeError
+	require.ErrorAs(t, err, &unknownErr)
+}


### PR DESCRIPTION
## Summary
Phase 2 of the Go migration roadmap: read/write support for Factorio's binary format (`internal/serdes`), used by save files and `mod-settings.dat` in later phases.

## Changes
- `Deserializer`/`Serializer` over `io.Reader`/`io.Writer`: u8/u16/u32 (little-endian), space-optimized u16/u32, bool, strings, double, long/unsigned long, `GameVersion` (4 x u16), `MODVersion` (3 x optim u16 via `NewMODVersion`, so >255 components from corrupt data are rejected)
- `PropertyTree` tagged union (`Kind` + `Value`) with constructors and kind-checked accessors; dictionaries are ordered `[]DictEntry` (not a map) so load-and-save round trips stay byte-identical
- List encoding follows the wiki — u32 count with an empty string key per item, identical to Dictionary — instead of porting the Ruby asymmetry (`write_list` emits optim_u32 without keys while `read_list` expects u32 with keys, and reading into a Hash collapses the empty keys)
- Tests port the Ruby spec byte fixtures and add a full-tree round-trip test (deserialize(serialize(tree)) == tree, and re-serialization is byte-identical)

## Test Plan
- `go build ./... && go vet ./... && go test ./...` pass locally
