### PR TITLE
:sparkles: Implement save file parsing and MOD settings (Phase 3)

### DIFF
--- a/doc/go-migration-roadmap.md
+++ b/doc/go-migration-roadmap.md
@@ -169,10 +169,11 @@ factorix/                  # repository root (Ruby lib/ and spec/ coexist until 
 │   ├── config/            # Config struct + TOML loading
 │   ├── dependency/        # Dependency parsing, graph, validation
 │   ├── httpx/             # HTTP client with retry/cache decorators
-│   ├── mod/               # Core domain: MOD, MODList, MODState, save file, etc.
+│   ├── mod/               # Core domain: MOD, MODList, MODState, etc.
 │   ├── platform/          # OS detection and path resolution
 │   ├── portal/            # High-level API facade
 │   ├── progress/          # Progress listener interfaces and implementations
+│   ├── save/              # Save file parsing (MOD list, startup settings)
 │   ├── serdes/            # Binary serializer/deserializer (Factorio format)
 │   ├── settings/          # MOD settings (mod-settings.dat)
 │   └── transfer/          # Downloader / Uploader
@@ -240,12 +241,13 @@ The Ruby implementation uses `pack`/`unpack`. In Go, use `encoding/binary` with 
 
 **Goal:** Parse `.zip` save files and `mod-settings.dat`.
 
-- [ ] `internal/mod/save_file.go`
+- [x] `internal/save/save_file.go` — not `internal/mod`: the parser needs
+      `internal/serdes`, which imports `internal/mod` for the version types
   - Open ZIP, locate `level.dat0` or `level-init.dat`
-  - Detect and strip zlib header (CMF byte 0x78)
-  - Parse save header → `GameVersion`, `[]MODState`
-  - Parse startup settings → `Settings`
-- [ ] `internal/settings/mod_settings.go`
+  - Detect zlib compression (CMF byte 0x78)
+  - Parse save header → `GameVersion`, `[]MODEntry`
+  - Parse startup settings → `settings.Section`
+- [x] `internal/settings/mod_settings.go`
   - Load / save `mod-settings.dat` (binary PropertyTree)
   - Sections: `startup`, `runtime-global`, `runtime-per-user`
   - JSON export/import (parity with Ruby `mod settings dump` / `restore`)

--- a/internal/save/save_file.go
+++ b/internal/save/save_file.go
@@ -1,0 +1,244 @@
+// Package save extracts MOD information and startup settings from Factorio
+// save files (.zip archives containing level.dat0 or level-init.dat).
+//
+// This lives outside internal/mod because it needs internal/serdes, which
+// itself imports internal/mod for the version types.
+package save
+
+import (
+	"archive/zip"
+	"bufio"
+	"compress/zlib"
+	"io"
+	"strings"
+
+	"github.com/sakuro/factorix/internal/mod"
+	"github.com/sakuro/factorix/internal/serdes"
+	"github.com/sakuro/factorix/internal/settings"
+)
+
+// Level file names to search for, in priority order.
+var levelFileNames = []string{"level.dat0", "level-init.dat"}
+
+// File is the information extracted from a save file.
+type File struct {
+	Version         mod.GameVersion
+	MODs            []MODEntry // in save-file order; every recorded MOD is enabled
+	StartupSettings *settings.Section
+}
+
+// MODEntry is one MOD recorded in the save header.
+type MODEntry struct {
+	Name    string
+	Version mod.MODVersion
+}
+
+// Load extracts MOD information and startup settings from a save file.
+func Load(path string) (*File, error) {
+	zr, err := zip.OpenReader(path)
+	if err != nil {
+		return nil, &mod.FileFormatError{Path: path, Msg: "invalid zip file: " + err.Error()}
+	}
+	defer zr.Close()
+
+	for _, fileName := range levelFileNames {
+		entry := findLevelEntry(&zr.Reader, fileName)
+		if entry == nil {
+			continue
+		}
+		rc, err := entry.Open()
+		if err != nil {
+			return nil, &mod.FileFormatError{Path: path, Msg: err.Error()}
+		}
+		defer rc.Close()
+
+		r, err := decompressIfNeeded(rc)
+		if err != nil {
+			return nil, &mod.FileFormatError{Path: path, Msg: err.Error()}
+		}
+		return parse(r)
+	}
+	return nil, &mod.FileFormatError{Path: path, Msg: "level.dat0 or level-init.dat not found"}
+}
+
+// The level file sits in the single top-level directory named after the save.
+func findLevelEntry(zr *zip.Reader, fileName string) *zip.File {
+	for _, f := range zr.File {
+		parts := strings.Split(f.Name, "/")
+		if len(parts) == 2 && parts[1] == fileName {
+			return f
+		}
+	}
+	return nil
+}
+
+// decompressIfNeeded wraps r with a zlib reader when the content is
+// compressed. CMF byte 0x78 marks zlib (DEFLATE with a 32K window).
+func decompressIfNeeded(r io.Reader) (io.Reader, error) {
+	br := bufio.NewReader(r)
+	head, err := br.Peek(1)
+	if err != nil {
+		if err == io.EOF {
+			return br, nil
+		}
+		return nil, err
+	}
+	if head[0] == 0x78 {
+		return zlib.NewReader(br)
+	}
+	return br, nil
+}
+
+// headerReader reads consecutive header fields with a sticky error, so the
+// field sequence below stays readable.
+type headerReader struct {
+	d   *serdes.Deserializer
+	err error
+}
+
+func (h *headerReader) u8() uint8 {
+	var v uint8
+	if h.err == nil {
+		v, h.err = h.d.ReadU8()
+	}
+	return v
+}
+
+func (h *headerReader) u16() uint16 {
+	var v uint16
+	if h.err == nil {
+		v, h.err = h.d.ReadU16()
+	}
+	return v
+}
+
+func (h *headerReader) u32() uint32 {
+	var v uint32
+	if h.err == nil {
+		v, h.err = h.d.ReadU32()
+	}
+	return v
+}
+
+func (h *headerReader) optimU32() uint32 {
+	var v uint32
+	if h.err == nil {
+		v, h.err = h.d.ReadOptimU32()
+	}
+	return v
+}
+
+func (h *headerReader) boolean() bool {
+	var v bool
+	if h.err == nil {
+		v, h.err = h.d.ReadBool()
+	}
+	return v
+}
+
+func (h *headerReader) str() string {
+	var v string
+	if h.err == nil {
+		v, h.err = h.d.ReadStr()
+	}
+	return v
+}
+
+func (h *headerReader) gameVersion() mod.GameVersion {
+	var v mod.GameVersion
+	if h.err == nil {
+		v, h.err = h.d.ReadGameVersion()
+	}
+	return v
+}
+
+func (h *headerReader) modVersion() mod.MODVersion {
+	var v mod.MODVersion
+	if h.err == nil {
+		v, h.err = h.d.ReadMODVersion()
+	}
+	return v
+}
+
+func parse(r io.Reader) (*File, error) {
+	d := serdes.NewDeserializer(r)
+	h := &headerReader{d: d}
+
+	version := h.gameVersion()
+
+	h.u8()         // unknown byte after the version
+	h.str()        // campaign
+	h.str()        // level_name
+	h.str()        // base_mod
+	h.u8()         // difficulty
+	h.boolean()    // finished
+	h.boolean()    // player_won
+	h.str()        // next_level
+	h.boolean()    // can_continue
+	h.boolean()    // finished_but_continuing
+	h.boolean()    // saving_replay
+	h.boolean()    // allow_non_admin_debug_options
+	h.modVersion() // loaded_from (MODVersion, not GameVersion)
+	h.u16()        // loaded_from_build
+	h.u8()         // allowed_commands
+	h.boolean()    // unknown
+	h.u32()        // unknown
+	h.boolean()    // unknown
+
+	modsCount := h.optimU32()
+	var mods []MODEntry
+	for range modsCount {
+		name := h.str()
+		modVersion := h.modVersion()
+		h.u32() // CRC
+		if h.err != nil {
+			return nil, h.err
+		}
+		mods = append(mods, MODEntry{Name: name, Version: modVersion})
+	}
+
+	// Unknown 4 bytes between the MOD list and the startup settings.
+	h.u32()
+	if h.err != nil {
+		return nil, h.err
+	}
+
+	startup, err := parseStartupSettings(d)
+	if err != nil {
+		return nil, err
+	}
+
+	return &File{Version: version, MODs: mods, StartupSettings: startup}, nil
+}
+
+func parseStartupSettings(d *serdes.Deserializer) (*settings.Section, error) {
+	tree, err := d.ReadPropertyTree()
+	if err != nil {
+		return nil, err
+	}
+
+	section, err := settings.NewSection("startup")
+	if err != nil {
+		return nil, err
+	}
+
+	// Non-dictionary elements are skipped, as in the Ruby implementation:
+	// each setting is expected to be a {"value": X} dictionary.
+	entries, ok := tree.Dict()
+	if !ok {
+		return section, nil
+	}
+	for _, entry := range entries {
+		wrapper, ok := entry.Value.Dict()
+		if !ok {
+			continue
+		}
+		for _, wrapperEntry := range wrapper {
+			if wrapperEntry.Key == "value" {
+				section.Set(entry.Key, wrapperEntry.Value)
+				break
+			}
+		}
+	}
+	return section, nil
+}

--- a/internal/save/save_file_test.go
+++ b/internal/save/save_file_test.go
@@ -1,0 +1,62 @@
+package save
+
+import (
+	"archive/zip"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sakuro/factorix/internal/mod"
+)
+
+func TestLoad(t *testing.T) {
+	f, err := Load(filepath.Join("..", "..", "spec", "fixtures", "test-save.zip"))
+	require.NoError(t, err)
+
+	assert.Equal(t, "2.0.72", f.Version.String())
+
+	require.NotEmpty(t, f.MODs)
+	var base *MODEntry
+	for i := range f.MODs {
+		if f.MODs[i].Name == "base" {
+			base = &f.MODs[i]
+			break
+		}
+	}
+	require.NotNil(t, base, "save must record the base MOD")
+	assert.Equal(t, "2.0.72", base.Version.String())
+
+	require.NotNil(t, f.StartupSettings)
+	assert.Equal(t, "startup", f.StartupSettings.Name())
+	assert.Positive(t, f.StartupSettings.Len())
+}
+
+func TestLoadNotAZip(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "not-a-save.zip")
+	require.NoError(t, os.WriteFile(path, []byte("plain text"), 0o644))
+
+	_, err := Load(path)
+	var ffe *mod.FileFormatError
+	require.ErrorAs(t, err, &ffe)
+}
+
+func TestLoadNoLevelFile(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "no-level.zip")
+	f, err := os.Create(path)
+	require.NoError(t, err)
+	zw := zip.NewWriter(f)
+	w, err := zw.Create("some-save/other.dat")
+	require.NoError(t, err)
+	_, err = w.Write([]byte("irrelevant"))
+	require.NoError(t, err)
+	require.NoError(t, zw.Close())
+	require.NoError(t, f.Close())
+
+	_, err = Load(path)
+	var ffe *mod.FileFormatError
+	require.ErrorAs(t, err, &ffe)
+	assert.Contains(t, ffe.Msg, "not found")
+}

--- a/internal/settings/errors.go
+++ b/internal/settings/errors.go
@@ -1,0 +1,10 @@
+package settings
+
+import "errors"
+
+var (
+	ErrInvalidSectionName = errors.New("invalid MOD section name")
+	ErrSectionNotFound    = errors.New("MOD section not found")
+	ErrExtraData          = errors.New("extra data found at the end of MOD settings file")
+	ErrMalformedSettings  = errors.New("malformed MOD settings")
+)

--- a/internal/settings/json.go
+++ b/internal/settings/json.go
@@ -1,0 +1,294 @@
+package settings
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"math"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/sakuro/factorix/internal/mod"
+	"github.com/sakuro/factorix/internal/serdes"
+)
+
+// DumpJSON renders the settings as pretty-printed JSON:
+// {"game_version": "X.Y.Z", "<section>": {"<key>": <value>, ...}, ...}.
+// Empty sections are omitted, matching the Ruby implementation.
+func (ms *MODSettings) DumpJSON() ([]byte, error) {
+	var buf bytes.Buffer
+	buf.WriteString("{\n")
+	fmt.Fprintf(&buf, "  %s: %s", jsonString("game_version"), jsonString(ms.GameVersion.String()))
+
+	for section := range ms.Sections() {
+		if section.Len() == 0 {
+			continue
+		}
+		fmt.Fprintf(&buf, ",\n  %s: ", jsonString(section.Name()))
+		entries := make([]serdes.DictEntry, 0, section.Len())
+		for key, value := range section.All() {
+			entries = append(entries, serdes.DictEntry{Key: key, Value: value})
+		}
+		if err := appendJSONValue(&buf, serdes.Dict(entries...), "  "); err != nil {
+			return nil, err
+		}
+	}
+
+	buf.WriteString("\n}")
+	return buf.Bytes(), nil
+}
+
+func appendJSONValue(buf *bytes.Buffer, value serdes.PropertyTree, indent string) error {
+	switch value.Kind {
+	case serdes.KindNone:
+		buf.WriteString("null")
+	case serdes.KindBool:
+		v, _ := value.Bool()
+		buf.WriteString(strconv.FormatBool(v))
+	case serdes.KindNumber:
+		v, _ := value.Number()
+		s, err := formatDouble(v)
+		if err != nil {
+			return err
+		}
+		buf.WriteString(s)
+	case serdes.KindString:
+		v, _ := value.Str()
+		buf.WriteString(jsonString(v))
+	case serdes.KindSignedInt:
+		v, _ := value.SignedInt()
+		buf.WriteString(strconv.FormatInt(v, 10))
+	case serdes.KindUnsignedInt:
+		v, _ := value.UnsignedInt()
+		buf.WriteString(strconv.FormatUint(v, 10))
+	case serdes.KindList:
+		items, _ := value.List()
+		if len(items) == 0 {
+			buf.WriteString("[]")
+			return nil
+		}
+		buf.WriteString("[\n")
+		inner := indent + "  "
+		for i, item := range items {
+			if i > 0 {
+				buf.WriteString(",\n")
+			}
+			buf.WriteString(inner)
+			if err := appendJSONValue(buf, item, inner); err != nil {
+				return err
+			}
+		}
+		buf.WriteString("\n" + indent + "]")
+	case serdes.KindDict:
+		entries, _ := value.Dict()
+		if len(entries) == 0 {
+			buf.WriteString("{}")
+			return nil
+		}
+		buf.WriteString("{\n")
+		inner := indent + "  "
+		for i, entry := range entries {
+			if i > 0 {
+				buf.WriteString(",\n")
+			}
+			buf.WriteString(inner + jsonString(entry.Key) + ": ")
+			if err := appendJSONValue(buf, entry.Value, inner); err != nil {
+				return err
+			}
+		}
+		buf.WriteString("\n" + indent + "}")
+	default:
+		return &serdes.UnknownPropertyTypeError{Type: uint8(value.Kind)}
+	}
+	return nil
+}
+
+// A JSON number must keep the decimal point (e.g. "100.0", not "100") so
+// that RestoreJSON maps it back to Number rather than SignedInt.
+func formatDouble(v float64) (string, error) {
+	if math.IsNaN(v) || math.IsInf(v, 0) {
+		return "", fmt.Errorf("%w: %v is not representable in JSON", ErrMalformedSettings, v)
+	}
+	s := strconv.FormatFloat(v, 'g', -1, 64)
+	if !strings.ContainsAny(s, ".eE") {
+		s += ".0"
+	}
+	return s, nil
+}
+
+func jsonString(s string) string {
+	b, err := json.Marshal(s)
+	if err != nil {
+		// json.Marshal of a string cannot fail; invalid UTF-8 is replaced.
+		return `""`
+	}
+	return string(b)
+}
+
+// RestoreJSON parses JSON produced by DumpJSON back into MODSettings.
+// Sections are rebuilt in canonical order; keys keep their JSON order.
+// JSON cannot distinguish signed from unsigned, so every integer becomes
+// SignedInt, matching Factorio's int-setting type and the Ruby implementation.
+func RestoreJSON(data []byte) (*MODSettings, error) {
+	dec := json.NewDecoder(bytes.NewReader(data))
+	dec.UseNumber()
+
+	if err := expectDelim(dec, '{'); err != nil {
+		return nil, err
+	}
+
+	var version *mod.GameVersion
+	parsed := map[string]*Section{}
+
+	for dec.More() {
+		tok, err := dec.Token()
+		if err != nil {
+			return nil, err
+		}
+		key, ok := tok.(string)
+		if !ok {
+			return nil, fmt.Errorf("%w: unexpected token %v", ErrMalformedSettings, tok)
+		}
+
+		switch {
+		case key == "game_version":
+			value, err := parseJSONValue(dec)
+			if err != nil {
+				return nil, err
+			}
+			s, ok := value.Str()
+			if !ok {
+				return nil, fmt.Errorf("%w: game_version is not a string", ErrMalformedSettings)
+			}
+			v, err := mod.ParseGameVersion(s)
+			if err != nil {
+				return nil, err
+			}
+			version = &v
+		case slices.Contains(ValidSections, key):
+			value, err := parseJSONValue(dec)
+			if err != nil {
+				return nil, err
+			}
+			entries, ok := value.Dict()
+			if !ok {
+				return nil, fmt.Errorf("%w: section %q is not an object", ErrMalformedSettings, key)
+			}
+			section, _ := NewSection(key)
+			for _, entry := range entries {
+				section.Set(entry.Key, entry.Value)
+			}
+			parsed[key] = section
+		default:
+			// Unknown top-level keys are ignored, as in the Ruby implementation.
+			if _, err := parseJSONValue(dec); err != nil {
+				return nil, err
+			}
+		}
+	}
+	if err := expectDelim(dec, '}'); err != nil {
+		return nil, err
+	}
+
+	if version == nil {
+		return nil, fmt.Errorf("%w: game_version is missing", ErrMalformedSettings)
+	}
+
+	ms := New(*version)
+	for name, section := range parsed {
+		ms.sections[name] = section
+	}
+	return ms, nil
+}
+
+// parseJSONValue reads one JSON value as a PropertyTree via the token
+// stream, preserving object key order (a decoded map would lose it).
+func parseJSONValue(dec *json.Decoder) (serdes.PropertyTree, error) {
+	tok, err := dec.Token()
+	if err != nil {
+		return serdes.PropertyTree{}, err
+	}
+	return jsonTokenToTree(dec, tok)
+}
+
+func jsonTokenToTree(dec *json.Decoder, tok json.Token) (serdes.PropertyTree, error) {
+	switch t := tok.(type) {
+	case nil:
+		return serdes.None(), nil
+	case bool:
+		return serdes.Bool(t), nil
+	case string:
+		return serdes.String(t), nil
+	case json.Number:
+		if strings.ContainsAny(t.String(), ".eE") {
+			v, err := t.Float64()
+			if err != nil {
+				return serdes.PropertyTree{}, err
+			}
+			return serdes.Number(v), nil
+		}
+		v, err := t.Int64()
+		if err != nil {
+			return serdes.PropertyTree{}, err
+		}
+		return serdes.SignedInt(v), nil
+	case json.Delim:
+		switch t {
+		case '{':
+			var entries []serdes.DictEntry
+			for dec.More() {
+				keyTok, err := dec.Token()
+				if err != nil {
+					return serdes.PropertyTree{}, err
+				}
+				key, ok := keyTok.(string)
+				if !ok {
+					return serdes.PropertyTree{}, fmt.Errorf("%w: unexpected token %v", ErrMalformedSettings, keyTok)
+				}
+				value, err := parseJSONValue(dec)
+				if err != nil {
+					return serdes.PropertyTree{}, err
+				}
+				entries = append(entries, serdes.DictEntry{Key: key, Value: value})
+			}
+			if err := expectDelim(dec, '}'); err != nil {
+				return serdes.PropertyTree{}, err
+			}
+			return serdes.Dict(entries...), nil
+		case '[':
+			var items []serdes.PropertyTree
+			for dec.More() {
+				item, err := parseJSONValue(dec)
+				if err != nil {
+					return serdes.PropertyTree{}, err
+				}
+				items = append(items, item)
+			}
+			if err := expectDelim(dec, ']'); err != nil {
+				return serdes.PropertyTree{}, err
+			}
+			return serdes.List(items...), nil
+		default:
+			return serdes.PropertyTree{}, fmt.Errorf("%w: unexpected delimiter %v", ErrMalformedSettings, t)
+		}
+	default:
+		return serdes.PropertyTree{}, fmt.Errorf("%w: unexpected token %v", ErrMalformedSettings, tok)
+	}
+}
+
+func expectDelim(dec *json.Decoder, want json.Delim) error {
+	tok, err := dec.Token()
+	if err != nil {
+		if errors.Is(err, io.EOF) {
+			return fmt.Errorf("%w: unexpected end of JSON", ErrMalformedSettings)
+		}
+		return err
+	}
+	if d, ok := tok.(json.Delim); !ok || d != want {
+		return fmt.Errorf("%w: expected %q, got %v", ErrMalformedSettings, want, tok)
+	}
+	return nil
+}

--- a/internal/settings/json_test.go
+++ b/internal/settings/json_test.go
@@ -1,0 +1,84 @@
+package settings
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sakuro/factorix/internal/serdes"
+)
+
+func TestDumpJSON(t *testing.T) {
+	data, err := sampleSettings(t).DumpJSON()
+	require.NoError(t, err)
+
+	assert.JSONEq(t, `{
+		"game_version": "2.0.72",
+		"startup": {
+			"bool-setting": true,
+			"number-setting": 0.5,
+			"string-setting": "hello",
+			"int-setting": -42
+		},
+		"runtime-global": {
+			"color-setting": {"r": 1.0, "g": 0.5}
+		}
+	}`, string(data))
+
+	// An integral double must keep its decimal point so RestoreJSON maps it
+	// back to Number, not SignedInt.
+	assert.Contains(t, string(data), `"r": 1.0`)
+}
+
+func TestJSONRoundTrip(t *testing.T) {
+	ms := sampleSettings(t)
+
+	data, err := ms.DumpJSON()
+	require.NoError(t, err)
+
+	restored, err := RestoreJSON(data)
+	require.NoError(t, err)
+
+	assert.Equal(t, ms.GameVersion, restored.GameVersion)
+	for section := range ms.Sections() {
+		restoredSection, err := restored.Section(section.Name())
+		require.NoError(t, err)
+		require.Equal(t, section.Len(), restoredSection.Len(), section.Name())
+		for key, value := range section.All() {
+			got, ok := restoredSection.Get(key)
+			require.True(t, ok, key)
+			assert.Equal(t, value, got, key)
+		}
+	}
+}
+
+func TestRestoreJSONIntegersBecomeSignedInt(t *testing.T) {
+	ms, err := RestoreJSON([]byte(`{
+		"game_version": "2.0.72",
+		"startup": {"count": 7, "ratio": 7.0}
+	}`))
+	require.NoError(t, err)
+
+	startup, err := ms.Section("startup")
+	require.NoError(t, err)
+
+	count, ok := startup.Get("count")
+	require.True(t, ok)
+	assert.Equal(t, serdes.SignedInt(7), count)
+
+	ratio, ok := startup.Get("ratio")
+	require.True(t, ok)
+	assert.Equal(t, serdes.Number(7.0), ratio)
+}
+
+func TestRestoreJSONMissingGameVersion(t *testing.T) {
+	_, err := RestoreJSON([]byte(`{"startup": {}}`))
+	require.ErrorIs(t, err, ErrMalformedSettings)
+}
+
+func TestRestoreJSONIgnoresUnknownKeys(t *testing.T) {
+	ms, err := RestoreJSON([]byte(`{"game_version": "2.0.72", "comment": ["ignored"]}`))
+	require.NoError(t, err)
+	assert.Equal(t, "2.0.72", ms.GameVersion.String())
+}

--- a/internal/settings/mod_settings.go
+++ b/internal/settings/mod_settings.go
@@ -1,0 +1,178 @@
+package settings
+
+import (
+	"fmt"
+	"io"
+	"iter"
+	"os"
+	"slices"
+
+	"github.com/sakuro/factorix/internal/mod"
+	"github.com/sakuro/factorix/internal/serdes"
+)
+
+// MODSettings is the content of mod-settings.dat: a game version and the
+// three settings sections.
+type MODSettings struct {
+	GameVersion mod.GameVersion
+	order       []string
+	sections    map[string]*Section
+}
+
+// New returns MODSettings with all three sections empty, in canonical order.
+func New(version mod.GameVersion) *MODSettings {
+	ms := &MODSettings{GameVersion: version, sections: map[string]*Section{}}
+	for _, name := range ValidSections {
+		section, _ := NewSection(name)
+		ms.order = append(ms.order, name)
+		ms.sections[name] = section
+	}
+	return ms
+}
+
+// Load reads mod-settings.dat content from r.
+func Load(r io.Reader) (*MODSettings, error) {
+	d := serdes.NewDeserializer(r)
+
+	version, err := d.ReadGameVersion()
+	if err != nil {
+		return nil, err
+	}
+	// One boolean of unknown purpose follows the version; always false.
+	if _, err := d.ReadBool(); err != nil {
+		return nil, err
+	}
+
+	tree, err := d.ReadPropertyTree()
+	if err != nil {
+		return nil, err
+	}
+	sections, ok := tree.Dict()
+	if !ok {
+		return nil, fmt.Errorf("%w: top-level element is not a dictionary", ErrMalformedSettings)
+	}
+
+	ms := &MODSettings{GameVersion: version, sections: map[string]*Section{}}
+	for _, sectionEntry := range sections {
+		section, err := NewSection(sectionEntry.Key)
+		if err != nil {
+			return nil, err
+		}
+		settingEntries, ok := sectionEntry.Value.Dict()
+		if !ok {
+			return nil, fmt.Errorf("%w: section %q is not a dictionary", ErrMalformedSettings, sectionEntry.Key)
+		}
+		for _, settingEntry := range settingEntries {
+			value, err := unwrapValue(settingEntry)
+			if err != nil {
+				return nil, err
+			}
+			section.Set(settingEntry.Key, value)
+		}
+		ms.order = append(ms.order, section.Name())
+		ms.sections[section.Name()] = section
+	}
+
+	// Sections absent from the file still exist, empty, in canonical order.
+	for _, name := range ValidSections {
+		if _, ok := ms.sections[name]; !ok {
+			section, _ := NewSection(name)
+			ms.order = append(ms.order, name)
+			ms.sections[name] = section
+		}
+	}
+
+	var trailing [1]byte
+	if n, _ := io.ReadFull(r, trailing[:]); n > 0 {
+		return nil, ErrExtraData
+	}
+
+	return ms, nil
+}
+
+// LoadFile reads a mod-settings.dat file.
+func LoadFile(path string) (*MODSettings, error) {
+	f, err := os.Open(path)
+	if err != nil {
+		return nil, err
+	}
+	defer f.Close()
+	return Load(f)
+}
+
+// Each setting is stored as a one-entry dictionary {"value": X}.
+func unwrapValue(settingEntry serdes.DictEntry) (serdes.PropertyTree, error) {
+	wrapper, ok := settingEntry.Value.Dict()
+	if !ok {
+		return serdes.PropertyTree{}, fmt.Errorf("%w: setting %q is not a dictionary", ErrMalformedSettings, settingEntry.Key)
+	}
+	for _, entry := range wrapper {
+		if entry.Key == "value" {
+			return entry.Value, nil
+		}
+	}
+	return serdes.PropertyTree{}, fmt.Errorf("%w: setting %q has no value entry", ErrMalformedSettings, settingEntry.Key)
+}
+
+// Save writes mod-settings.dat content to w. Empty sections are omitted,
+// matching the Ruby implementation.
+func (ms *MODSettings) Save(w io.Writer) error {
+	s := serdes.NewSerializer(w)
+
+	if err := s.WriteGameVersion(ms.GameVersion); err != nil {
+		return err
+	}
+	if err := s.WriteBool(false); err != nil {
+		return err
+	}
+
+	var sections []serdes.DictEntry
+	for _, name := range ms.order {
+		section := ms.sections[name]
+		if section.Len() == 0 {
+			continue
+		}
+		var settingEntries []serdes.DictEntry
+		for key, value := range section.All() {
+			settingEntries = append(settingEntries, serdes.DictEntry{
+				Key:   key,
+				Value: serdes.Dict(serdes.DictEntry{Key: "value", Value: value}),
+			})
+		}
+		sections = append(sections, serdes.DictEntry{Key: name, Value: serdes.Dict(settingEntries...)})
+	}
+	return s.WritePropertyTree(serdes.Dict(sections...))
+}
+
+// SaveFile writes a mod-settings.dat file.
+func (ms *MODSettings) SaveFile(path string) error {
+	f, err := os.Create(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+	return ms.Save(f)
+}
+
+// Section returns the named section.
+func (ms *MODSettings) Section(name string) (*Section, error) {
+	if !slices.Contains(ValidSections, name) {
+		return nil, fmt.Errorf("%w: %s", ErrInvalidSectionName, name)
+	}
+	section, ok := ms.sections[name]
+	if !ok {
+		return nil, fmt.Errorf("%w: %s", ErrSectionNotFound, name)
+	}
+	return section, nil
+}
+
+// Sections iterates over the sections in order.
+func (ms *MODSettings) Sections() iter.Seq[*Section] {
+	return func(yield func(*Section) bool) {
+		for _, name := range ms.order {
+			if !yield(ms.sections[name]) {
+				return
+			}
+		}
+	}
+}

--- a/internal/settings/mod_settings_test.go
+++ b/internal/settings/mod_settings_test.go
@@ -1,0 +1,94 @@
+package settings
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sakuro/factorix/internal/mod"
+	"github.com/sakuro/factorix/internal/serdes"
+)
+
+func sampleSettings(t *testing.T) *MODSettings {
+	t.Helper()
+	ms := New(mod.GameVersion{Major: 2, Minor: 0, Patch: 72})
+
+	startup, err := ms.Section("startup")
+	require.NoError(t, err)
+	startup.Set("bool-setting", serdes.Bool(true))
+	startup.Set("number-setting", serdes.Number(0.5))
+	startup.Set("string-setting", serdes.String("hello"))
+	startup.Set("int-setting", serdes.SignedInt(-42))
+
+	global, err := ms.Section("runtime-global")
+	require.NoError(t, err)
+	global.Set("color-setting", serdes.Dict(
+		serdes.DictEntry{Key: "r", Value: serdes.Number(1)},
+		serdes.DictEntry{Key: "g", Value: serdes.Number(0.5)},
+	))
+
+	return ms
+}
+
+func TestMODSettingsRoundTrip(t *testing.T) {
+	ms := sampleSettings(t)
+
+	var buf bytes.Buffer
+	require.NoError(t, ms.Save(&buf))
+	first := buf.Bytes()
+
+	loaded, err := Load(bytes.NewReader(first))
+	require.NoError(t, err)
+	assert.Equal(t, ms.GameVersion, loaded.GameVersion)
+
+	startup, err := loaded.Section("startup")
+	require.NoError(t, err)
+	assert.Equal(t, 4, startup.Len())
+	v, ok := startup.Get("number-setting")
+	require.True(t, ok)
+	assert.Equal(t, serdes.Number(0.5), v)
+
+	// The empty runtime-per-user section still exists after loading.
+	perUser, err := loaded.Section("runtime-per-user")
+	require.NoError(t, err)
+	assert.Equal(t, 0, perUser.Len())
+
+	var buf2 bytes.Buffer
+	require.NoError(t, loaded.Save(&buf2))
+	assert.Equal(t, first, buf2.Bytes())
+}
+
+func TestLoadExtraData(t *testing.T) {
+	var buf bytes.Buffer
+	require.NoError(t, sampleSettings(t).Save(&buf))
+	buf.WriteByte(0x00)
+
+	_, err := Load(bytes.NewReader(buf.Bytes()))
+	require.ErrorIs(t, err, ErrExtraData)
+}
+
+func TestLoadInvalidSectionName(t *testing.T) {
+	var buf bytes.Buffer
+	s := serdes.NewSerializer(&buf)
+	require.NoError(t, s.WriteGameVersion(mod.GameVersion{Major: 2}))
+	require.NoError(t, s.WriteBool(false))
+	require.NoError(t, s.WritePropertyTree(serdes.Dict(
+		serdes.DictEntry{Key: "bogus-section", Value: serdes.Dict()},
+	)))
+
+	_, err := Load(bytes.NewReader(buf.Bytes()))
+	require.ErrorIs(t, err, ErrInvalidSectionName)
+}
+
+func TestNewSectionInvalidName(t *testing.T) {
+	_, err := NewSection("bogus")
+	require.ErrorIs(t, err, ErrInvalidSectionName)
+}
+
+func TestMODSettingsSectionInvalidName(t *testing.T) {
+	ms := New(mod.GameVersion{Major: 2})
+	_, err := ms.Section("bogus")
+	require.ErrorIs(t, err, ErrInvalidSectionName)
+}

--- a/internal/settings/section.go
+++ b/internal/settings/section.go
@@ -1,0 +1,64 @@
+// Package settings handles MOD settings stored in mod-settings.dat.
+package settings
+
+import (
+	"fmt"
+	"iter"
+	"slices"
+
+	"github.com/sakuro/factorix/internal/serdes"
+)
+
+// ValidSections lists the three section names of mod-settings.dat.
+var ValidSections = []string{"startup", "runtime-global", "runtime-per-user"}
+
+// Section is one named group of settings. Keys keep their insertion order so
+// a load-and-save round trip preserves file order.
+type Section struct {
+	name   string
+	keys   []string
+	values map[string]serdes.PropertyTree
+}
+
+// NewSection creates an empty section with one of the ValidSections names.
+func NewSection(name string) (*Section, error) {
+	if !slices.Contains(ValidSections, name) {
+		return nil, fmt.Errorf("%w: %s", ErrInvalidSectionName, name)
+	}
+	return &Section{name: name, values: map[string]serdes.PropertyTree{}}, nil
+}
+
+// Name returns the section name.
+func (s *Section) Name() string {
+	return s.name
+}
+
+// Len returns the number of settings in the section.
+func (s *Section) Len() int {
+	return len(s.keys)
+}
+
+// Get returns the value for key; ok is false when the key is absent.
+func (s *Section) Get(key string) (serdes.PropertyTree, bool) {
+	v, ok := s.values[key]
+	return v, ok
+}
+
+// Set stores the value for key, appending new keys in insertion order.
+func (s *Section) Set(key string, value serdes.PropertyTree) {
+	if _, ok := s.values[key]; !ok {
+		s.keys = append(s.keys, key)
+	}
+	s.values[key] = value
+}
+
+// All iterates over key/value pairs in insertion order.
+func (s *Section) All() iter.Seq2[string, serdes.PropertyTree] {
+	return func(yield func(string, serdes.PropertyTree) bool) {
+		for _, key := range s.keys {
+			if !yield(key, s.values[key]) {
+				return
+			}
+		}
+	}
+}


### PR DESCRIPTION
## Summary
Phase 3 of the Go migration roadmap: parse save files and read/write `mod-settings.dat`, including the JSON dump/restore conversion.

## Changes
- `internal/settings`: `MODSettings` with the three ordered sections (`startup`, `runtime-global`, `runtime-per-user`), binary load/save over serdes with the `{"value": X}` wrapping, extra-data detection, and empty sections omitted on write (Ruby parity)
- JSON dump/restore in `internal/settings/json.go`: token-stream parsing preserves key order (a decoded Go map would not), integers restore as `SignedInt` (JSON cannot distinguish signedness), and integral doubles are dumped with a trailing `.0` so they restore as `Number` — Go's default float marshaling would emit `100` and silently change the type
- `internal/save`: extract `GameVersion`, the MOD list, and startup settings from save ZIPs (`level.dat0` / `level-init.dat`, zlib detection via CMF byte 0x78); header field skipping mirrors the Ruby parser, wrapped in a sticky-error reader to keep the sequence readable
- Save parsing lives in `internal/save`, not `internal/mod` as the roadmap originally said: it needs `internal/serdes`, which imports `internal/mod` for the version types (roadmap updated)

## Test Plan
- `go build ./... && go vet ./... && go test ./...` pass locally
- `internal/save` tests parse the real `spec/fixtures/test-save.zip` (version 2.0.72, base MOD present, startup settings non-empty)
- Settings tests cover byte-identical binary round trips and JSON dump/restore round trips
