### PR TITLE
:sparkles: Implement dependency system (Phase 4)

### DIFF
--- a/doc/go-migration-roadmap.md
+++ b/doc/go-migration-roadmap.md
@@ -263,9 +263,14 @@ The Ruby implementation uses Parslet (PEG). In Go, hand-roll a recursive descent
 Dependency string grammar (Factorio format; note MOD names may contain spaces):
 ```
 dep    = [prefix " "] name [" " op " " version]
-prefix = "!" | "?" | "(?)" | "~"
+prefix = "!" | "?" | "(?)" | "~" | "+"
 op     = "=" | ">" | ">=" | "<" | "<="
 ```
+
+The `+` prefix (optional but recommended; enabled by default) becomes
+meaningful in Factorio 2.1. Parsing is already supported; the command-level
+behavior is tracked in issues #90–#95 and starts after the port reaches
+parity, once the actual game behavior can be observed.
 
 - [x] `internal/dependency/parser.go` — parse dependency strings into `Entry` structs
       (a well-formed but out-of-range version requirement is dropped, not an error —

--- a/doc/go-migration-roadmap.md
+++ b/doc/go-migration-roadmap.md
@@ -267,13 +267,17 @@ prefix = "!" | "?" | "(?)" | "~"
 op     = "=" | ">" | ">=" | "<" | "<="
 ```
 
-- [ ] `internal/dependency/parser.go` — parse dependency strings into `Entry` structs
-- [ ] `internal/dependency/entry.go` — `Entry` (kind, name, operator, version)
-- [ ] `internal/dependency/graph.go` — adjacency-list DAG
+- [x] `internal/dependency/parser.go` — parse dependency strings into `Entry` structs
+      (a well-formed but out-of-range version requirement is dropped, not an error —
+      MODs with such versions exist on the Portal)
+- [x] `internal/dependency/entry.go` — `Entry` (type, MOD, version requirement)
+- [x] `internal/dependency/graph.go` — adjacency-list DAG
   - `AddNode`, `AddEdge`, `TopologicalSort` (Kahn's algorithm)
   - `StronglyConnectedComponents` for cycle detection
-- [ ] `internal/dependency/validator.go` — validate installed MODs against requirements
-- [ ] `internal/dependency/resolver.go` — determine install/uninstall order
+  - `builder.go` builds the graph from installed MODs + mod-list.json
+- [x] `internal/dependency/validator.go` — validate installed MODs against requirements
+- Install/uninstall ordering has no Ruby `Resolver` counterpart; it is implemented
+  with the `mod install` / `mod uninstall` commands in Phase 10
 
 ---
 

--- a/internal/dependency/builder.go
+++ b/internal/dependency/builder.go
@@ -1,0 +1,92 @@
+package dependency
+
+import (
+	"github.com/sakuro/factorix/internal/mod"
+)
+
+// BuildGraph constructs the dependency graph of the installed MODs:
+// one node per MOD (enabled state from mod-list.json) and one edge per
+// dependency declared in the active version's info.json.
+func BuildGraph(installedMODs []mod.InstalledMOD, modList *mod.MODList) (*Graph, error) {
+	graph := NewGraph()
+
+	var uniqueMODs []mod.MOD
+	seen := map[mod.MOD]bool{}
+	for _, im := range installedMODs {
+		if !seen[im.MOD] {
+			seen[im.MOD] = true
+			uniqueMODs = append(uniqueMODs, im.MOD)
+		}
+	}
+
+	activeVersions := make(map[mod.MOD]mod.MODVersion, len(uniqueMODs))
+	for _, m := range uniqueMODs {
+		version := selectVersion(m, installedMODs, modList)
+		activeVersions[m] = version
+		if err := graph.AddNode(Node{
+			MOD:       m,
+			Version:   version,
+			Enabled:   modEnabled(m, modList),
+			Installed: true,
+		}); err != nil {
+			return nil, err
+		}
+	}
+
+	// Only the active version of each MOD contributes edges.
+	for _, im := range installedMODs {
+		if activeVersions[im.MOD] != im.Version {
+			continue
+		}
+		for _, depString := range im.Info.Dependencies {
+			entry, err := Parse(depString)
+			if err != nil {
+				return nil, err
+			}
+			// The base MOD is always available and cannot be disabled, so
+			// edges to it carry no information. Expansion MODs can be
+			// disabled and must be validated like any other dependency.
+			if entry.MOD.IsBase() {
+				continue
+			}
+			if err := graph.AddEdge(Edge{
+				From:        im.MOD,
+				To:          entry.MOD,
+				Type:        entry.Type,
+				Requirement: entry.Requirement,
+			}); err != nil {
+				return nil, err
+			}
+		}
+	}
+
+	return graph, nil
+}
+
+// selectVersion picks the version the game would load: the version pinned in
+// mod-list.json when that exact version is installed, otherwise the newest
+// installed version.
+func selectVersion(m mod.MOD, installedMODs []mod.InstalledMOD, modList *mod.MODList) mod.MODVersion {
+	if modList.Contains(m) {
+		if pinned, err := modList.Version(m); err == nil && pinned != nil {
+			for _, im := range installedMODs {
+				if im.MOD == m && im.Version == *pinned {
+					return *pinned
+				}
+			}
+		}
+	}
+
+	var newest mod.MODVersion
+	for _, im := range installedMODs {
+		if im.MOD == m && newest.Less(im.Version) {
+			newest = im.Version
+		}
+	}
+	return newest
+}
+
+func modEnabled(m mod.MOD, modList *mod.MODList) bool {
+	enabled, err := modList.Enabled(m)
+	return err == nil && enabled
+}

--- a/internal/dependency/builder_test.go
+++ b/internal/dependency/builder_test.go
@@ -1,0 +1,96 @@
+package dependency
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sakuro/factorix/internal/mod"
+)
+
+func installedMOD(name, version string, deps ...string) mod.InstalledMOD {
+	v, err := mod.ParseMODVersion(version)
+	if err != nil {
+		panic(err)
+	}
+	return mod.InstalledMOD{
+		MOD:     mod.MOD{Name: name},
+		Version: v,
+		Form:    mod.FormZIP,
+		Info: mod.InfoJSON{
+			Name:         name,
+			Version:      v,
+			Title:        name,
+			Author:       "test",
+			Dependencies: deps,
+		},
+	}
+}
+
+func TestBuildGraph(t *testing.T) {
+	installed := []mod.InstalledMOD{
+		installedMOD("base", "2.0.0"),
+		installedMOD("lib", "1.0.0", "base"),
+		installedMOD("app", "1.0.0", "base", "lib >= 1.0.0", "? extra"),
+	}
+	list := mod.NewMODList()
+	require.NoError(t, list.Add(mod.MOD{Name: "base"}, mod.MODState{Enabled: true}))
+	require.NoError(t, list.Add(mod.MOD{Name: "lib"}, mod.MODState{Enabled: true}))
+	require.NoError(t, list.Add(mod.MOD{Name: "app"}, mod.MODState{Enabled: false}))
+
+	graph, err := BuildGraph(installed, list)
+	require.NoError(t, err)
+
+	assert.Equal(t, 3, graph.Len())
+
+	app, ok := graph.Node(mod.MOD{Name: "app"})
+	require.True(t, ok)
+	assert.False(t, app.Enabled)
+	assert.True(t, app.Installed)
+
+	// Edges to the base MOD are skipped; optional edges are kept.
+	appEdges := graph.EdgesFrom(mod.MOD{Name: "app"})
+	require.Len(t, appEdges, 2)
+	assert.Equal(t, mod.MOD{Name: "lib"}, appEdges[0].To)
+	assert.Equal(t, TypeRequired, appEdges[0].Type)
+	assert.Equal(t, mod.MOD{Name: "extra"}, appEdges[1].To)
+	assert.Equal(t, TypeOptional, appEdges[1].Type)
+
+	assert.Empty(t, graph.EdgesFrom(mod.MOD{Name: "lib"}))
+}
+
+func TestBuildGraphVersionSelection(t *testing.T) {
+	installed := []mod.InstalledMOD{
+		installedMOD("multi", "1.0.0"),
+		installedMOD("multi", "2.0.0"),
+		installedMOD("pinned", "1.0.0"),
+		installedMOD("pinned", "2.0.0"),
+	}
+	pinnedVersion := mod.MODVersion{Major: 1}
+	list := mod.NewMODList()
+	require.NoError(t, list.Add(mod.MOD{Name: "multi"}, mod.MODState{Enabled: true}))
+	require.NoError(t, list.Add(mod.MOD{Name: "pinned"}, mod.MODState{Enabled: true, Version: &pinnedVersion}))
+
+	graph, err := BuildGraph(installed, list)
+	require.NoError(t, err)
+
+	// Without a pin the newest installed version wins.
+	multi, ok := graph.Node(mod.MOD{Name: "multi"})
+	require.True(t, ok)
+	assert.Equal(t, mod.MODVersion{Major: 2}, multi.Version)
+
+	// A pinned version wins when that exact version is installed.
+	pinned, ok := graph.Node(mod.MOD{Name: "pinned"})
+	require.True(t, ok)
+	assert.Equal(t, mod.MODVersion{Major: 1}, pinned.Version)
+}
+
+func TestBuildGraphInvalidDependency(t *testing.T) {
+	installed := []mod.InstalledMOD{installedMOD("broken", "1.0.0", ">= 1.0")}
+	list := mod.NewMODList()
+
+	_, err := BuildGraph(installed, list)
+	var parseErr *ParseError
+	require.ErrorAs(t, err, &parseErr)
+}

--- a/internal/dependency/entry.go
+++ b/internal/dependency/entry.go
@@ -1,0 +1,147 @@
+// Package dependency parses MOD dependency strings and builds, sorts, and
+// validates the dependency graph.
+package dependency
+
+import (
+	"fmt"
+
+	"github.com/sakuro/factorix/internal/mod"
+)
+
+// Type is the kind of a dependency relation.
+type Type uint8
+
+const (
+	TypeRequired Type = iota
+	TypeOptional
+	TypeHiddenOptional
+	TypeIncompatible
+	TypeLoadNeutral
+	TypeRecommended
+)
+
+func (t Type) String() string {
+	switch t {
+	case TypeRequired:
+		return "required"
+	case TypeOptional:
+		return "optional"
+	case TypeHiddenOptional:
+		return "hidden"
+	case TypeIncompatible:
+		return "incompatible"
+	case TypeLoadNeutral:
+		return "load-neutral"
+	case TypeRecommended:
+		return "recommended"
+	default:
+		return fmt.Sprintf("Type(%d)", uint8(t))
+	}
+}
+
+// prefix returns the dependency-string prefix for the type, including the
+// separating space when non-empty.
+func (t Type) prefix() string {
+	switch t {
+	case TypeOptional:
+		return "? "
+	case TypeHiddenOptional:
+		return "(?) "
+	case TypeIncompatible:
+		return "! "
+	case TypeLoadNeutral:
+		return "~ "
+	case TypeRecommended:
+		return "+ "
+	default:
+		return ""
+	}
+}
+
+// Operator is a version comparison operator.
+type Operator uint8
+
+const (
+	OpEqual Operator = iota
+	OpGreater
+	OpGreaterEqual
+	OpLess
+	OpLessEqual
+)
+
+func (o Operator) String() string {
+	switch o {
+	case OpEqual:
+		return "="
+	case OpGreater:
+		return ">"
+	case OpGreaterEqual:
+		return ">="
+	case OpLess:
+		return "<"
+	case OpLessEqual:
+		return "<="
+	default:
+		return fmt.Sprintf("Operator(%d)", uint8(o))
+	}
+}
+
+// VersionRequirement is a version constraint such as ">= 1.2.0".
+type VersionRequirement struct {
+	Operator Operator
+	Version  mod.MODVersion
+}
+
+// SatisfiedBy reports whether the given version satisfies the requirement.
+func (r VersionRequirement) SatisfiedBy(v mod.MODVersion) bool {
+	c := v.Compare(r.Version)
+	switch r.Operator {
+	case OpEqual:
+		return c == 0
+	case OpGreater:
+		return c > 0
+	case OpGreaterEqual:
+		return c >= 0
+	case OpLess:
+		return c < 0
+	case OpLessEqual:
+		return c <= 0
+	default:
+		return false
+	}
+}
+
+func (r VersionRequirement) String() string {
+	return fmt.Sprintf("%s %s", r.Operator, r.Version)
+}
+
+// Entry is a single parsed dependency of a MOD.
+type Entry struct {
+	MOD         mod.MOD
+	Type        Type
+	Requirement *VersionRequirement // nil when no version constraint
+}
+
+// IsOptional reports whether the dependency is optional, including the
+// hidden-optional form.
+func (e Entry) IsOptional() bool {
+	return e.Type == TypeOptional || e.Type == TypeHiddenOptional
+}
+
+// SatisfiedBy reports whether the given version satisfies the entry's
+// version requirement; entries without a requirement are always satisfied.
+func (e Entry) SatisfiedBy(v mod.MODVersion) bool {
+	if e.Requirement == nil {
+		return true
+	}
+	return e.Requirement.SatisfiedBy(v)
+}
+
+// String renders the entry in dependency-string form, e.g. "? some-mod >= 1.2.0".
+func (e Entry) String() string {
+	s := e.Type.prefix() + e.MOD.Name
+	if e.Requirement != nil {
+		s += " " + e.Requirement.String()
+	}
+	return s
+}

--- a/internal/dependency/errors.go
+++ b/internal/dependency/errors.go
@@ -1,0 +1,22 @@
+package dependency
+
+import (
+	"errors"
+	"fmt"
+)
+
+var (
+	ErrNodeExists         = errors.New("node already exists")
+	ErrNodeMissing        = errors.New("node does not exist")
+	ErrCircularDependency = errors.New("circular dependency detected")
+)
+
+// ParseError reports a malformed dependency string.
+type ParseError struct {
+	Input  string
+	Reason string
+}
+
+func (e *ParseError) Error() string {
+	return fmt.Sprintf("invalid dependency %q: %s", e.Input, e.Reason)
+}

--- a/internal/dependency/graph.go
+++ b/internal/dependency/graph.go
@@ -1,0 +1,282 @@
+package dependency
+
+import (
+	"fmt"
+
+	"github.com/sakuro/factorix/internal/mod"
+)
+
+// Operation is a planned action on a graph node.
+type Operation uint8
+
+const (
+	OpNone Operation = iota
+	OpInstall
+	OpEnable
+	OpDisable
+	OpUninstall
+)
+
+func (o Operation) String() string {
+	switch o {
+	case OpNone:
+		return "none"
+	case OpInstall:
+		return "install"
+	case OpEnable:
+		return "enable"
+	case OpDisable:
+		return "disable"
+	case OpUninstall:
+		return "uninstall"
+	default:
+		return fmt.Sprintf("Operation(%d)", uint8(o))
+	}
+}
+
+// Node is a MOD in the dependency graph with its state.
+type Node struct {
+	MOD       mod.MOD
+	Version   mod.MODVersion
+	Enabled   bool
+	Installed bool
+	Operation Operation
+}
+
+// Edge is a dependency relation from one MOD to another.
+type Edge struct {
+	From        mod.MOD
+	To          mod.MOD
+	Type        Type
+	Requirement *VersionRequirement
+}
+
+// SatisfiedBy reports whether the given version satisfies the edge's
+// version requirement; edges without a requirement are always satisfied.
+func (e Edge) SatisfiedBy(v mod.MODVersion) bool {
+	if e.Requirement == nil {
+		return true
+	}
+	return e.Requirement.SatisfiedBy(v)
+}
+
+// Graph is a directed graph of MOD dependencies. Nodes keep their insertion
+// order so sorting and cycle reporting are deterministic.
+type Graph struct {
+	order []mod.MOD
+	nodes map[mod.MOD]Node
+	edges map[mod.MOD][]Edge
+}
+
+// NewGraph returns an empty graph.
+func NewGraph() *Graph {
+	return &Graph{nodes: map[mod.MOD]Node{}, edges: map[mod.MOD][]Edge{}}
+}
+
+// AddNode adds a node; adding a MOD twice is an error.
+func (g *Graph) AddNode(n Node) error {
+	if _, ok := g.nodes[n.MOD]; ok {
+		return fmt.Errorf("%w: %s", ErrNodeExists, n.MOD)
+	}
+	g.order = append(g.order, n.MOD)
+	g.nodes[n.MOD] = n
+	return nil
+}
+
+// SetNodeOperation sets the planned operation of an existing node; missing
+// nodes are ignored.
+func (g *Graph) SetNodeOperation(m mod.MOD, op Operation) {
+	node, ok := g.nodes[m]
+	if !ok {
+		return
+	}
+	node.Operation = op
+	g.nodes[m] = node
+}
+
+// AddEdge adds an edge; the origin node must exist.
+func (g *Graph) AddEdge(e Edge) error {
+	if _, ok := g.nodes[e.From]; !ok {
+		return fmt.Errorf("%w: %s", ErrNodeMissing, e.From)
+	}
+	g.edges[e.From] = append(g.edges[e.From], e)
+	return nil
+}
+
+// Node returns the node for the MOD; ok is false when absent.
+func (g *Graph) Node(m mod.MOD) (Node, bool) {
+	n, ok := g.nodes[m]
+	return n, ok
+}
+
+// Contains reports whether the graph has a node for the MOD.
+func (g *Graph) Contains(m mod.MOD) bool {
+	_, ok := g.nodes[m]
+	return ok
+}
+
+// Len returns the number of nodes.
+func (g *Graph) Len() int {
+	return len(g.order)
+}
+
+// Nodes returns all nodes in insertion order.
+func (g *Graph) Nodes() []Node {
+	nodes := make([]Node, 0, len(g.order))
+	for _, m := range g.order {
+		nodes = append(nodes, g.nodes[m])
+	}
+	return nodes
+}
+
+// EdgesFrom returns the edges originating from the MOD.
+func (g *Graph) EdgesFrom(m mod.MOD) []Edge {
+	return g.edges[m]
+}
+
+// EdgesTo returns the edges pointing at the MOD.
+func (g *Graph) EdgesTo(m mod.MOD) []Edge {
+	var result []Edge
+	for _, from := range g.order {
+		for _, e := range g.edges[from] {
+			if e.To == m {
+				result = append(result, e)
+			}
+		}
+	}
+	return result
+}
+
+// FindEnabledDependents returns the enabled MODs that have a required
+// dependency on the given MOD.
+func (g *Graph) FindEnabledDependents(m mod.MOD) []mod.MOD {
+	var dependents []mod.MOD
+	for _, from := range g.order {
+		node := g.nodes[from]
+		if !node.Enabled {
+			continue
+		}
+		for _, e := range g.edges[from] {
+			if e.Type == TypeRequired && e.To == m {
+				dependents = append(dependents, from)
+				break
+			}
+		}
+	}
+	return dependents
+}
+
+// requiredDeps returns the MODs the given MOD requires, restricted to MODs
+// present in the graph. Only required edges participate in ordering and
+// cycle detection: optional cycles are allowed in Factorio.
+func (g *Graph) requiredDeps(m mod.MOD) []mod.MOD {
+	var deps []mod.MOD
+	for _, e := range g.edges[m] {
+		if e.Type != TypeRequired {
+			continue
+		}
+		if _, ok := g.nodes[e.To]; ok {
+			deps = append(deps, e.To)
+		}
+	}
+	return deps
+}
+
+// TopologicalSort returns the MODs with every dependency ordered before its
+// dependents (Kahn's algorithm). It fails with ErrCircularDependency when
+// the graph has a required-dependency cycle.
+func (g *Graph) TopologicalSort() ([]mod.MOD, error) {
+	// pending counts each node's unemitted required dependencies;
+	// dependents is the reverse adjacency used to decrement them.
+	pending := make(map[mod.MOD]int, len(g.order))
+	dependents := make(map[mod.MOD][]mod.MOD, len(g.order))
+	for _, m := range g.order {
+		deps := g.requiredDeps(m)
+		pending[m] = len(deps)
+		for _, dep := range deps {
+			dependents[dep] = append(dependents[dep], m)
+		}
+	}
+
+	var queue []mod.MOD
+	for _, m := range g.order {
+		if pending[m] == 0 {
+			queue = append(queue, m)
+		}
+	}
+
+	sorted := make([]mod.MOD, 0, len(g.order))
+	for len(queue) > 0 {
+		m := queue[0]
+		queue = queue[1:]
+		sorted = append(sorted, m)
+		for _, dependent := range dependents[m] {
+			pending[dependent]--
+			if pending[dependent] == 0 {
+				queue = append(queue, dependent)
+			}
+		}
+	}
+
+	if len(sorted) < len(g.order) {
+		return nil, ErrCircularDependency
+	}
+	return sorted, nil
+}
+
+// IsCyclic reports whether the graph has a required-dependency cycle.
+func (g *Graph) IsCyclic() bool {
+	_, err := g.TopologicalSort()
+	return err != nil
+}
+
+// StronglyConnectedComponents returns the strongly connected components of
+// the required-dependency graph (Tarjan's algorithm). Cycles are the
+// components with more than one member.
+func (g *Graph) StronglyConnectedComponents() [][]mod.MOD {
+	index := 0
+	indices := map[mod.MOD]int{}
+	lowlinks := map[mod.MOD]int{}
+	onStack := map[mod.MOD]bool{}
+	var stack []mod.MOD
+	var components [][]mod.MOD
+
+	var strongConnect func(m mod.MOD)
+	strongConnect = func(m mod.MOD) {
+		indices[m] = index
+		lowlinks[m] = index
+		index++
+		stack = append(stack, m)
+		onStack[m] = true
+
+		for _, dep := range g.requiredDeps(m) {
+			if _, visited := indices[dep]; !visited {
+				strongConnect(dep)
+				lowlinks[m] = min(lowlinks[m], lowlinks[dep])
+			} else if onStack[dep] {
+				lowlinks[m] = min(lowlinks[m], indices[dep])
+			}
+		}
+
+		if lowlinks[m] == indices[m] {
+			var component []mod.MOD
+			for {
+				top := stack[len(stack)-1]
+				stack = stack[:len(stack)-1]
+				onStack[top] = false
+				component = append(component, top)
+				if top == m {
+					break
+				}
+			}
+			components = append(components, component)
+		}
+	}
+
+	for _, m := range g.order {
+		if _, visited := indices[m]; !visited {
+			strongConnect(m)
+		}
+	}
+	return components
+}

--- a/internal/dependency/graph_test.go
+++ b/internal/dependency/graph_test.go
@@ -1,0 +1,110 @@
+package dependency
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sakuro/factorix/internal/mod"
+)
+
+func testMOD(name string) mod.MOD {
+	return mod.MOD{Name: name}
+}
+
+func addNodes(t *testing.T, g *Graph, names ...string) {
+	t.Helper()
+	for _, name := range names {
+		require.NoError(t, g.AddNode(Node{MOD: testMOD(name), Version: mod.MODVersion{Major: 1}, Enabled: true, Installed: true}))
+	}
+}
+
+func requireEdge(t *testing.T, g *Graph, from, to string, typ Type) {
+	t.Helper()
+	require.NoError(t, g.AddEdge(Edge{From: testMOD(from), To: testMOD(to), Type: typ}))
+}
+
+func TestGraphAddNode(t *testing.T) {
+	g := NewGraph()
+	addNodes(t, g, "a")
+	assert.True(t, g.Contains(testMOD("a")))
+	assert.Equal(t, 1, g.Len())
+
+	err := g.AddNode(Node{MOD: testMOD("a")})
+	require.ErrorIs(t, err, ErrNodeExists)
+}
+
+func TestGraphAddEdgeMissingNode(t *testing.T) {
+	g := NewGraph()
+	err := g.AddEdge(Edge{From: testMOD("ghost"), To: testMOD("a")})
+	require.ErrorIs(t, err, ErrNodeMissing)
+}
+
+func TestGraphSetNodeOperation(t *testing.T) {
+	g := NewGraph()
+	addNodes(t, g, "a")
+	g.SetNodeOperation(testMOD("a"), OpEnable)
+	node, ok := g.Node(testMOD("a"))
+	require.True(t, ok)
+	assert.Equal(t, OpEnable, node.Operation)
+
+	g.SetNodeOperation(testMOD("missing"), OpEnable) // no-op
+}
+
+func TestGraphTopologicalSort(t *testing.T) {
+	g := NewGraph()
+	addNodes(t, g, "app", "lib", "core")
+	requireEdge(t, g, "app", "lib", TypeRequired)
+	requireEdge(t, g, "lib", "core", TypeRequired)
+
+	sorted, err := g.TopologicalSort()
+	require.NoError(t, err)
+	assert.Equal(t, []mod.MOD{testMOD("core"), testMOD("lib"), testMOD("app")}, sorted)
+}
+
+func TestGraphTopologicalSortIgnoresNonRequiredEdges(t *testing.T) {
+	g := NewGraph()
+	addNodes(t, g, "a", "b")
+	// An optional cycle is allowed in Factorio and must not fail the sort.
+	requireEdge(t, g, "a", "b", TypeOptional)
+	requireEdge(t, g, "b", "a", TypeOptional)
+
+	_, err := g.TopologicalSort()
+	require.NoError(t, err)
+	assert.False(t, g.IsCyclic())
+}
+
+func TestGraphCycle(t *testing.T) {
+	g := NewGraph()
+	addNodes(t, g, "a", "b", "c")
+	requireEdge(t, g, "a", "b", TypeRequired)
+	requireEdge(t, g, "b", "a", TypeRequired)
+
+	_, err := g.TopologicalSort()
+	require.ErrorIs(t, err, ErrCircularDependency)
+	assert.True(t, g.IsCyclic())
+
+	var cycles [][]mod.MOD
+	for _, component := range g.StronglyConnectedComponents() {
+		if len(component) > 1 {
+			cycles = append(cycles, component)
+		}
+	}
+	require.Len(t, cycles, 1)
+	assert.ElementsMatch(t, []mod.MOD{testMOD("a"), testMOD("b")}, cycles[0])
+}
+
+func TestGraphEdgesToAndDependents(t *testing.T) {
+	g := NewGraph()
+	addNodes(t, g, "a", "b", "c")
+	require.NoError(t, g.AddNode(Node{MOD: testMOD("d"), Version: mod.MODVersion{Major: 1}, Enabled: false, Installed: true}))
+	requireEdge(t, g, "a", "c", TypeRequired)
+	requireEdge(t, g, "b", "c", TypeOptional)
+	requireEdge(t, g, "d", "c", TypeRequired)
+
+	assert.Len(t, g.EdgesTo(testMOD("c")), 3)
+
+	// Only enabled MODs with a *required* edge count as dependents.
+	assert.Equal(t, []mod.MOD{testMOD("a")}, g.FindEnabledDependents(testMOD("c")))
+}

--- a/internal/dependency/parser.go
+++ b/internal/dependency/parser.go
@@ -2,10 +2,13 @@ package dependency
 
 import (
 	"strings"
-	"unicode"
 
 	"github.com/sakuro/factorix/internal/mod"
 )
+
+// MOD names and the grammar are ASCII; matching Unicode whitespace would be
+// broader than the Ruby grammar's \s.
+const asciiSpaces = " \t\r\n\f\v"
 
 // Prefixes are matched longest first so "(?)" is not read as "(" + "?".
 var prefixes = []struct {
@@ -40,7 +43,7 @@ var operators = []struct {
 // MOD names may contain spaces, so the scanner treats a space run as part of
 // the name only when another name character follows it.
 func Parse(s string) (Entry, error) {
-	rest := strings.TrimSpace(s)
+	rest := trimSpaces(s)
 	if rest == "" {
 		return Entry{}, &ParseError{Input: s, Reason: "empty dependency string"}
 	}
@@ -49,7 +52,7 @@ func Parse(s string) (Entry, error) {
 	for _, p := range prefixes {
 		if strings.HasPrefix(rest, p.token) {
 			typ = p.typ
-			rest = strings.TrimSpace(rest[len(p.token):])
+			rest = trimSpaces(rest[len(p.token):])
 			break
 		}
 	}
@@ -91,7 +94,11 @@ func isNameChar(c byte) bool {
 }
 
 func isSpaceChar(c byte) bool {
-	return unicode.IsSpace(rune(c))
+	return strings.IndexByte(asciiSpaces, c) >= 0
+}
+
+func trimSpaces(s string) string {
+	return strings.Trim(s, asciiSpaces)
 }
 
 // scanName returns the MOD name and the remaining input after it.
@@ -115,9 +122,9 @@ func scanName(s, input string) (name, rest string, err error) {
 				i = j
 				continue
 			}
-			return s[:end], strings.TrimSpace(s[end:]), nil
+			return s[:end], trimSpaces(s[end:]), nil
 		default:
-			return s[:end], strings.TrimSpace(s[end:]), nil
+			return s[:end], trimSpaces(s[end:]), nil
 		}
 	}
 	return s[:end], "", nil
@@ -126,7 +133,7 @@ func scanName(s, input string) (name, rest string, err error) {
 func scanOperator(s string) (Operator, string, bool) {
 	for _, o := range operators {
 		if strings.HasPrefix(s, o.token) {
-			return o.op, strings.TrimSpace(s[len(o.token):]), true
+			return o.op, trimSpaces(s[len(o.token):]), true
 		}
 	}
 	return 0, s, false

--- a/internal/dependency/parser.go
+++ b/internal/dependency/parser.go
@@ -1,0 +1,152 @@
+package dependency
+
+import (
+	"strings"
+	"unicode"
+
+	"github.com/sakuro/factorix/internal/mod"
+)
+
+// Prefixes are matched longest first so "(?)" is not read as "(" + "?".
+var prefixes = []struct {
+	token string
+	typ   Type
+}{
+	{"(?)", TypeHiddenOptional},
+	{"!", TypeIncompatible},
+	{"?", TypeOptional},
+	{"~", TypeLoadNeutral},
+	{"+", TypeRecommended},
+}
+
+// Operators are matched longest first so ">=" is not read as ">" + "=".
+var operators = []struct {
+	token string
+	op    Operator
+}{
+	{">=", OpGreaterEqual},
+	{"<=", OpLessEqual},
+	{">", OpGreater},
+	{"<", OpLess},
+	{"=", OpEqual},
+}
+
+// Parse parses a dependency string from info.json:
+//
+//	dep    = [prefix] name [op version]
+//	prefix = "!" | "?" | "(?)" | "~" | "+"
+//	op     = "=" | ">" | ">=" | "<" | "<="
+//
+// MOD names may contain spaces, so the scanner treats a space run as part of
+// the name only when another name character follows it.
+func Parse(s string) (Entry, error) {
+	rest := strings.TrimSpace(s)
+	if rest == "" {
+		return Entry{}, &ParseError{Input: s, Reason: "empty dependency string"}
+	}
+
+	typ := TypeRequired
+	for _, p := range prefixes {
+		if strings.HasPrefix(rest, p.token) {
+			typ = p.typ
+			rest = strings.TrimSpace(rest[len(p.token):])
+			break
+		}
+	}
+
+	name, rest, err := scanName(rest, s)
+	if err != nil {
+		return Entry{}, err
+	}
+	entry := Entry{MOD: mod.MOD{Name: name}, Type: typ}
+	if rest == "" {
+		return entry, nil
+	}
+
+	op, rest, ok := scanOperator(rest)
+	if !ok {
+		return Entry{}, &ParseError{Input: s, Reason: "expected a version operator after the MOD name"}
+	}
+	if rest == "" {
+		return Entry{}, &ParseError{Input: s, Reason: "empty version"}
+	}
+	if !isVersionFormat(rest) {
+		return Entry{}, &ParseError{Input: s, Reason: "invalid version format"}
+	}
+
+	version, err := mod.ParseMODVersion(rest)
+	if err != nil {
+		// The format is valid, so the error is an out-of-range component.
+		// MODs with such versions exist on the Portal; drop the requirement
+		// instead of failing, matching the Ruby implementation.
+		return entry, nil
+	}
+	entry.Requirement = &VersionRequirement{Operator: op, Version: version}
+	return entry, nil
+}
+
+func isNameChar(c byte) bool {
+	return c == '_' || c == '-' ||
+		('a' <= c && c <= 'z') || ('A' <= c && c <= 'Z') || ('0' <= c && c <= '9')
+}
+
+func isSpaceChar(c byte) bool {
+	return unicode.IsSpace(rune(c))
+}
+
+// scanName returns the MOD name and the remaining input after it.
+func scanName(s, input string) (name, rest string, err error) {
+	if s == "" || !isNameChar(s[0]) {
+		return "", "", &ParseError{Input: input, Reason: "empty MOD name"}
+	}
+
+	end := 0 // exclusive end of the name
+	for i := 0; i < len(s); {
+		switch {
+		case isNameChar(s[i]):
+			i++
+			end = i
+		case isSpaceChar(s[i]):
+			j := i
+			for j < len(s) && isSpaceChar(s[j]) {
+				j++
+			}
+			if j < len(s) && isNameChar(s[j]) {
+				i = j
+				continue
+			}
+			return s[:end], strings.TrimSpace(s[end:]), nil
+		default:
+			return s[:end], strings.TrimSpace(s[end:]), nil
+		}
+	}
+	return s[:end], "", nil
+}
+
+func scanOperator(s string) (Operator, string, bool) {
+	for _, o := range operators {
+		if strings.HasPrefix(s, o.token) {
+			return o.op, strings.TrimSpace(s[len(o.token):]), true
+		}
+	}
+	return 0, s, false
+}
+
+// isVersionFormat reports whether s is "X.Y" or "X.Y.Z" with decimal parts.
+func isVersionFormat(s string) bool {
+	parts := strings.Split(s, ".")
+	if len(parts) != 2 && len(parts) != 3 {
+		return false
+	}
+	for _, part := range parts {
+		if part == "" {
+			return false
+		}
+		for i := 0; i < len(part); i++ {
+			if part[i] < '0' || part[i] > '9' {
+				return false
+			}
+		}
+	}
+	return true
+}

--- a/internal/dependency/parser_test.go
+++ b/internal/dependency/parser_test.go
@@ -1,0 +1,112 @@
+package dependency
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sakuro/factorix/internal/mod"
+)
+
+func TestParse(t *testing.T) {
+	v120 := VersionRequirement{Operator: OpGreaterEqual, Version: mod.MODVersion{Major: 1, Minor: 2}}
+	tests := []struct {
+		input string
+		want  Entry
+	}{
+		{"base", Entry{MOD: mod.MOD{Name: "base"}, Type: TypeRequired}},
+		{"? some-mod >= 1.2.0", Entry{MOD: mod.MOD{Name: "some-mod"}, Type: TypeOptional, Requirement: &v120}},
+		{"?compact", Entry{MOD: mod.MOD{Name: "compact"}, Type: TypeOptional}},
+		{"(?) hidden-mod", Entry{MOD: mod.MOD{Name: "hidden-mod"}, Type: TypeHiddenOptional}},
+		{"! bad-mod", Entry{MOD: mod.MOD{Name: "bad-mod"}, Type: TypeIncompatible}},
+		{"~ neutral-mod", Entry{MOD: mod.MOD{Name: "neutral-mod"}, Type: TypeLoadNeutral}},
+		{"+ recommended-mod", Entry{MOD: mod.MOD{Name: "recommended-mod"}, Type: TypeRecommended}},
+		{"  base  ", Entry{MOD: mod.MOD{Name: "base"}, Type: TypeRequired}},
+		{
+			"Mod With Spaces >= 1.2",
+			Entry{MOD: mod.MOD{Name: "Mod With Spaces"}, Type: TypeRequired, Requirement: &v120},
+		},
+		{
+			"some-mod = 2.0",
+			Entry{
+				MOD: mod.MOD{Name: "some-mod"}, Type: TypeRequired,
+				Requirement: &VersionRequirement{Operator: OpEqual, Version: mod.MODVersion{Major: 2}},
+			},
+		},
+		{
+			"some-mod<1.0.5",
+			Entry{
+				MOD: mod.MOD{Name: "some-mod"}, Type: TypeRequired,
+				Requirement: &VersionRequirement{Operator: OpLess, Version: mod.MODVersion{Major: 1, Patch: 5}},
+			},
+		},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := Parse(tt.input)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+}
+
+func TestParseDropsOutOfRangeRequirement(t *testing.T) {
+	// MODs with version components over 255 exist on the Portal; the
+	// requirement is dropped rather than failing the whole dependency.
+	got, err := Parse("weird-mod >= 2019.11.20")
+	require.NoError(t, err)
+	assert.Equal(t, Entry{MOD: mod.MOD{Name: "weird-mod"}, Type: TypeRequired}, got)
+}
+
+func TestParseInvalid(t *testing.T) {
+	inputs := []string{
+		"",
+		"   ",
+		">= 1.0",         // empty MOD name
+		"? >= 1.0",       // empty MOD name after prefix
+		"some-mod >=",    // empty version
+		"some-mod > x",   // invalid version format
+		"some-mod > 1",   // version needs at least two parts
+		"some-mod 1.2.3", // version without operator
+	}
+	for _, input := range inputs {
+		t.Run(input, func(t *testing.T) {
+			_, err := Parse(input)
+			var parseErr *ParseError
+			require.ErrorAs(t, err, &parseErr, "input %q", input)
+		})
+	}
+}
+
+func TestEntryString(t *testing.T) {
+	for _, s := range []string{"base", "? some-mod >= 1.2.0", "(?) hidden-mod", "! bad-mod", "~ neutral-mod", "+ recommended-mod"} {
+		entry, err := Parse(s)
+		require.NoError(t, err)
+		assert.Equal(t, s, entry.String())
+	}
+}
+
+func TestVersionRequirementSatisfiedBy(t *testing.T) {
+	v100 := mod.MODVersion{Major: 1}
+	v110 := mod.MODVersion{Major: 1, Minor: 1}
+	v090 := mod.MODVersion{Minor: 9}
+
+	tests := []struct {
+		op       Operator
+		version  mod.MODVersion
+		expected map[mod.MODVersion]bool
+	}{
+		{OpEqual, v100, map[mod.MODVersion]bool{v100: true, v110: false, v090: false}},
+		{OpGreater, v100, map[mod.MODVersion]bool{v100: false, v110: true, v090: false}},
+		{OpGreaterEqual, v100, map[mod.MODVersion]bool{v100: true, v110: true, v090: false}},
+		{OpLess, v100, map[mod.MODVersion]bool{v100: false, v110: false, v090: true}},
+		{OpLessEqual, v100, map[mod.MODVersion]bool{v100: true, v110: false, v090: true}},
+	}
+	for _, tt := range tests {
+		r := VersionRequirement{Operator: tt.op, Version: tt.version}
+		for v, want := range tt.expected {
+			assert.Equal(t, want, r.SatisfiedBy(v), "%s against %s", r, v)
+		}
+	}
+}

--- a/internal/dependency/validation_result.go
+++ b/internal/dependency/validation_result.go
@@ -1,0 +1,56 @@
+package dependency
+
+import "github.com/sakuro/factorix/internal/mod"
+
+// ErrorType classifies validation errors.
+type ErrorType uint8
+
+const (
+	ErrorMissingDependency ErrorType = iota
+	ErrorDisabledDependency
+	ErrorVersionMismatch
+	ErrorConflict
+	ErrorCircularDependency
+)
+
+// WarningType classifies validation warnings.
+type WarningType uint8
+
+const (
+	WarningMODInListNotInstalled WarningType = iota
+	WarningMODInstalledNotInList
+)
+
+// ValidationError is an error found during dependency validation.
+type ValidationError struct {
+	Type       ErrorType
+	Message    string
+	MOD        mod.MOD
+	Dependency mod.MOD
+}
+
+// ValidationWarning is a warning found during dependency validation.
+type ValidationWarning struct {
+	Type    WarningType
+	Message string
+	MOD     mod.MOD
+}
+
+// Suggestion is a hint for resolving a validation error.
+type Suggestion struct {
+	Message string
+	MOD     mod.MOD
+	Version mod.MODVersion
+}
+
+// ValidationResult holds everything found during a validation pass.
+type ValidationResult struct {
+	Errors      []ValidationError
+	Warnings    []ValidationWarning
+	Suggestions []Suggestion
+}
+
+// Valid reports whether the validation found no errors.
+func (r *ValidationResult) Valid() bool {
+	return len(r.Errors) == 0
+}

--- a/internal/dependency/validator.go
+++ b/internal/dependency/validator.go
@@ -1,0 +1,156 @@
+package dependency
+
+import (
+	"fmt"
+	"strings"
+
+	"github.com/sakuro/factorix/internal/mod"
+)
+
+// Validator checks a dependency graph for missing or disabled dependencies,
+// unsatisfied version requirements, conflicts, cycles, and inconsistencies
+// between the graph and mod-list.json.
+type Validator struct {
+	Graph         *Graph
+	MODList       *mod.MODList
+	InstalledMODs []mod.InstalledMOD
+}
+
+// Validate runs all checks and collects the findings.
+func (v *Validator) Validate() *ValidationResult {
+	result := &ValidationResult{}
+	v.validateCircularDependencies(result)
+	v.validateDependencies(result)
+	v.validateConflicts(result)
+	v.validateMODList(result)
+	return result
+}
+
+func (v *Validator) validateCircularDependencies(result *ValidationResult) {
+	if !v.Graph.IsCyclic() {
+		return
+	}
+	for _, component := range v.Graph.StronglyConnectedComponents() {
+		if len(component) <= 1 {
+			continue
+		}
+		names := make([]string, len(component))
+		for i, m := range component {
+			names[i] = m.Name
+		}
+		result.Errors = append(result.Errors, ValidationError{
+			Type:    ErrorCircularDependency,
+			Message: "Circular dependency detected: " + strings.Join(names, " -> "),
+		})
+	}
+}
+
+func (v *Validator) validateDependencies(result *ValidationResult) {
+	for _, node := range v.Graph.Nodes() {
+		if !node.Enabled {
+			continue
+		}
+		for _, edge := range v.Graph.EdgesFrom(node.MOD) {
+			if edge.Type != TypeRequired {
+				continue
+			}
+			v.validateRequiredDependency(node, edge, result)
+		}
+	}
+}
+
+func (v *Validator) validateRequiredDependency(node Node, edge Edge, result *ValidationResult) {
+	depNode, ok := v.Graph.Node(edge.To)
+	if !ok {
+		result.Errors = append(result.Errors, ValidationError{
+			Type:       ErrorMissingDependency,
+			Message:    fmt.Sprintf("MOD '%s@%s' requires '%s' which is not installed", node.MOD, node.Version, edge.To),
+			MOD:        node.MOD,
+			Dependency: edge.To,
+		})
+		return
+	}
+	if !depNode.Enabled {
+		result.Errors = append(result.Errors, ValidationError{
+			Type:       ErrorDisabledDependency,
+			Message:    fmt.Sprintf("MOD '%s@%s' requires '%s' which is not enabled", node.MOD, node.Version, edge.To),
+			MOD:        node.MOD,
+			Dependency: edge.To,
+		})
+		return
+	}
+	if edge.SatisfiedBy(depNode.Version) {
+		return
+	}
+	result.Errors = append(result.Errors, ValidationError{
+		Type: ErrorVersionMismatch,
+		Message: fmt.Sprintf("MOD '%s@%s' requires '%s' version %s, but version %s is installed",
+			node.MOD, node.Version, edge.To, edge.Requirement, depNode.Version),
+		MOD:        node.MOD,
+		Dependency: edge.To,
+	})
+	v.suggestAlternativeVersions(edge, result)
+}
+
+func (v *Validator) validateConflicts(result *ValidationResult) {
+	for _, node := range v.Graph.Nodes() {
+		if !node.Enabled {
+			continue
+		}
+		for _, edge := range v.Graph.EdgesFrom(node.MOD) {
+			if edge.Type != TypeIncompatible {
+				continue
+			}
+			conflictNode, ok := v.Graph.Node(edge.To)
+			if !ok || !conflictNode.Enabled {
+				continue
+			}
+			result.Errors = append(result.Errors, ValidationError{
+				Type: ErrorConflict,
+				Message: fmt.Sprintf("MOD '%s@%s' conflicts with '%s@%s' but both are enabled",
+					node.MOD, node.Version, edge.To, conflictNode.Version),
+				MOD:        node.MOD,
+				Dependency: edge.To,
+			})
+		}
+	}
+}
+
+func (v *Validator) validateMODList(result *ValidationResult) {
+	for m := range v.MODList.MODs() {
+		if v.Graph.Contains(m) {
+			continue
+		}
+		result.Warnings = append(result.Warnings, ValidationWarning{
+			Type:    WarningMODInListNotInstalled,
+			Message: fmt.Sprintf("MOD '%s' in mod-list.json is not installed", m),
+			MOD:     m,
+		})
+	}
+	for _, node := range v.Graph.Nodes() {
+		if v.MODList.Contains(node.MOD) {
+			continue
+		}
+		result.Warnings = append(result.Warnings, ValidationWarning{
+			Type:    WarningMODInstalledNotInList,
+			Message: fmt.Sprintf("MOD '%s' is installed but not in mod-list.json", node.MOD),
+			MOD:     node.MOD,
+		})
+	}
+}
+
+// suggestAlternativeVersions points out installed versions that would
+// satisfy the failed requirement.
+func (v *Validator) suggestAlternativeVersions(edge Edge, result *ValidationResult) {
+	for _, im := range v.InstalledMODs {
+		if im.MOD != edge.To || !edge.SatisfiedBy(im.Version) {
+			continue
+		}
+		result.Suggestions = append(result.Suggestions, Suggestion{
+			Message: fmt.Sprintf("MOD '%s' version %s is installed and would satisfy this requirement",
+				edge.To, im.Version),
+			MOD:     edge.To,
+			Version: im.Version,
+		})
+	}
+}

--- a/internal/dependency/validator_test.go
+++ b/internal/dependency/validator_test.go
@@ -1,0 +1,103 @@
+package dependency
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sakuro/factorix/internal/mod"
+)
+
+func errorTypes(result *ValidationResult) []ErrorType {
+	types := make([]ErrorType, len(result.Errors))
+	for i, e := range result.Errors {
+		types[i] = e.Type
+	}
+	return types
+}
+
+func TestValidatorValid(t *testing.T) {
+	g := NewGraph()
+	addNodes(t, g, "app", "lib")
+	requireEdge(t, g, "app", "lib", TypeRequired)
+
+	list := mod.NewMODList()
+	require.NoError(t, list.Add(testMOD("app"), mod.MODState{Enabled: true}))
+	require.NoError(t, list.Add(testMOD("lib"), mod.MODState{Enabled: true}))
+
+	result := (&Validator{Graph: g, MODList: list}).Validate()
+	assert.True(t, result.Valid())
+	assert.Empty(t, result.Warnings)
+}
+
+func TestValidatorMissingDependency(t *testing.T) {
+	g := NewGraph()
+	addNodes(t, g, "app")
+	requireEdge(t, g, "app", "ghost", TypeRequired)
+
+	result := (&Validator{Graph: g, MODList: mod.NewMODList()}).Validate()
+	assert.Contains(t, errorTypes(result), ErrorMissingDependency)
+}
+
+func TestValidatorDisabledDependency(t *testing.T) {
+	g := NewGraph()
+	addNodes(t, g, "app")
+	require.NoError(t, g.AddNode(Node{MOD: testMOD("lib"), Version: mod.MODVersion{Major: 1}, Enabled: false, Installed: true}))
+	requireEdge(t, g, "app", "lib", TypeRequired)
+
+	result := (&Validator{Graph: g, MODList: mod.NewMODList()}).Validate()
+	assert.Contains(t, errorTypes(result), ErrorDisabledDependency)
+}
+
+func TestValidatorVersionMismatchWithSuggestion(t *testing.T) {
+	g := NewGraph()
+	addNodes(t, g, "app", "lib") // lib is at version 1
+	require.NoError(t, g.AddEdge(Edge{
+		From: testMOD("app"), To: testMOD("lib"), Type: TypeRequired,
+		Requirement: &VersionRequirement{Operator: OpGreaterEqual, Version: mod.MODVersion{Major: 2}},
+	}))
+
+	installed := []mod.InstalledMOD{installedMOD("lib", "2.0.0")}
+	result := (&Validator{Graph: g, MODList: mod.NewMODList(), InstalledMODs: installed}).Validate()
+
+	assert.Contains(t, errorTypes(result), ErrorVersionMismatch)
+	require.Len(t, result.Suggestions, 1)
+	assert.Equal(t, testMOD("lib"), result.Suggestions[0].MOD)
+	assert.Equal(t, mod.MODVersion{Major: 2}, result.Suggestions[0].Version)
+}
+
+func TestValidatorConflict(t *testing.T) {
+	g := NewGraph()
+	addNodes(t, g, "app", "rival")
+	requireEdge(t, g, "app", "rival", TypeIncompatible)
+
+	result := (&Validator{Graph: g, MODList: mod.NewMODList()}).Validate()
+	assert.Contains(t, errorTypes(result), ErrorConflict)
+}
+
+func TestValidatorCircularDependency(t *testing.T) {
+	g := NewGraph()
+	addNodes(t, g, "a", "b")
+	requireEdge(t, g, "a", "b", TypeRequired)
+	requireEdge(t, g, "b", "a", TypeRequired)
+
+	result := (&Validator{Graph: g, MODList: mod.NewMODList()}).Validate()
+	assert.Contains(t, errorTypes(result), ErrorCircularDependency)
+}
+
+func TestValidatorMODListWarnings(t *testing.T) {
+	g := NewGraph()
+	addNodes(t, g, "installed-only")
+
+	list := mod.NewMODList()
+	require.NoError(t, list.Add(testMOD("listed-only"), mod.MODState{Enabled: true}))
+
+	result := (&Validator{Graph: g, MODList: list}).Validate()
+	assert.True(t, result.Valid())
+	require.Len(t, result.Warnings, 2)
+	assert.Equal(t, WarningMODInListNotInstalled, result.Warnings[0].Type)
+	assert.Equal(t, testMOD("listed-only"), result.Warnings[0].MOD)
+	assert.Equal(t, WarningMODInstalledNotInList, result.Warnings[1].Type)
+	assert.Equal(t, testMOD("installed-only"), result.Warnings[1].MOD)
+}


### PR DESCRIPTION
## Summary
Phase 4 of the Go migration roadmap: dependency string parsing, the dependency graph with topological sort and cycle detection, the graph builder, and the validator.

## Changes
- `Parse` is a hand-rolled scanner for the dependency grammar (`[prefix] name [op version]`); MOD names may contain spaces, so a space run belongs to the name only when another name character follows it. All six types are supported, including `+` (recommended), which the roadmap grammar omitted
- A well-formed version requirement with components over 255 is dropped rather than failing (matching Ruby, which logs and skips) — MODs with such versions exist on the Portal
- `Graph` keeps nodes in insertion order for deterministic output; `TopologicalSort` (Kahn) and `StronglyConnectedComponents` (Tarjan) follow only required edges — optional cycles are allowed in Factorio
- `BuildGraph` ports `Graph::Builder` (pinned version wins when installed, else newest; only the active version contributes edges; edges to base are skipped) and parses `InfoJSON.Dependencies` strings, which Phase 1 left raw
- `Validator` ports the five error checks (missing/disabled dependency, version mismatch with alternative-version suggestions, conflict, cycle) and the two mod-list consistency warnings
- Install/uninstall ordering (`resolver.go` in the roadmap) has no Ruby counterpart; it arrives with the Phase 10 commands (roadmap updated)

## Test Plan
- `go build ./... && go vet ./... && go test ./...` pass locally
