### PR TITLE
:sparkles: Implement platform abstraction, config, and logging (Phase 5)

### DIFF
--- a/doc/go-migration-roadmap.md
+++ b/doc/go-migration-roadmap.md
@@ -169,6 +169,7 @@ factorix/                  # repository root (Ruby lib/ and spec/ coexist until 
 │   ├── config/            # Config struct + TOML loading
 │   ├── dependency/        # Dependency parsing, graph, validation
 │   ├── httpx/             # HTTP client with retry/cache decorators
+│   ├── logging/           # slog setup (file handler, level parsing)
 │   ├── mod/               # Core domain: MOD, MODList, MODState, etc.
 │   ├── platform/          # OS detection and path resolution
 │   ├── portal/            # High-level API facade
@@ -290,21 +291,20 @@ parity, once the actual game behavior can be observed.
 
 **Goal:** Resolve Factorio and Factorix paths correctly on each supported OS; load configuration.
 
-- [ ] `internal/platform/platform.go` — `Platform` interface
-  ```go
-  type Platform interface {
-      GameDataDir() (string, error)
-      GameUserDataDir() (string, error)
-      ModDir() (string, error)
-      // ...
-  }
-  ```
-- [ ] `internal/platform/linux.go`, `macos.go`, `windows.go`, `wsl.go`
-  - WSL detection via `/proc/version`
-- [ ] `internal/platform/detect.go` — `Detect() (Platform, error)` using `runtime.GOOS`
-- [ ] Config-based path overrides (Ruby `Runtime::UserConfigurable` equivalent)
-- [ ] `internal/config/config.go` — config struct, TOML loading, env var overrides
-- [ ] `slog` setup writing to the platform log path, honoring `log_level`
+- [x] `internal/platform/platform.go` — `Platform` interface (game paths + platform
+      base-directory defaults) and a `Runtime` wrapper deriving every path the
+      application needs (mod dir, mod-list.json, lock file, Factorix cache/config/log)
+- [x] `internal/platform/linux.go`, `macos.go`, `windows.go`, `wsl.go`
+  - WSL detection via `/proc/version`; WSL fetches Windows env vars via one
+    PowerShell batch and converts paths to `/mnt/<drive>`
+- [x] `internal/platform/detect.go` — `Detect() (Platform, error)` using `runtime.GOOS`
+- [x] Config-based path overrides (Ruby `Runtime::UserConfigurable` equivalent) —
+      `platform.Overrides`, wired from `[runtime]` in config.toml
+- [x] `internal/config/config.go` — config struct, TOML loading (BurntSushi/toml),
+      unknown-key rejection; legacy `redis`/`s3` keys are accepted and ignored so
+      Ruby-era files still load, but only `backend = "file_system"` is allowed
+- [x] `slog` setup (`internal/logging`) writing to the platform log path,
+      honoring `log_level` (including `fatal` as LevelError+4)
 
 ---
 

--- a/go.mod
+++ b/go.mod
@@ -3,6 +3,7 @@ module github.com/sakuro/factorix
 go 1.23
 
 require (
+	github.com/BurntSushi/toml v1.6.0
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
 )

--- a/go.sum
+++ b/go.sum
@@ -1,3 +1,5 @@
+github.com/BurntSushi/toml v1.6.0 h1:dRaEfpa2VI55EwlIW72hMRHdWouJeRF7TPYhI+AUQjk=
+github.com/BurntSushi/toml v1.6.0/go.mod h1:ukJfTF/6rtPPRCnwkur4qwRxa8vTRFBF0uk2lLoLwho=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=
 github.com/davecgh/go-spew v1.1.1 h1:vj9j/u1bqnvCEfJOwUhtlOARqs3+rkHYY13jYWTU97c=
 github.com/davecgh/go-spew v1.1.1/go.mod h1:J7Y8YcW2NihsgmVo/mv3lAwl/skON4iLHjSsI+c5H38=

--- a/internal/config/config.go
+++ b/internal/config/config.go
@@ -1,0 +1,153 @@
+// Package config loads the Factorix configuration from config.toml.
+// The file format is shared with the Ruby implementation, so existing
+// configuration files carry over unchanged.
+package config
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"slices"
+
+	"github.com/BurntSushi/toml"
+)
+
+var ErrInvalidConfig = errors.New("invalid configuration")
+
+// Config is the application configuration.
+type Config struct {
+	LogLevel string  `toml:"log_level"`
+	Runtime  Runtime `toml:"runtime"`
+	RCON     RCON    `toml:"rcon"`
+	HTTP     HTTP    `toml:"http"`
+	Cache    Cache   `toml:"cache"`
+}
+
+// Runtime holds path overrides; an empty value means platform auto-detection.
+type Runtime struct {
+	ExecutablePath string `toml:"executable_path"`
+	UserDir        string `toml:"user_dir"`
+	DataDir        string `toml:"data_dir"`
+}
+
+// RCON holds RCON connection settings.
+type RCON struct {
+	Host     string `toml:"host"`
+	Port     int    `toml:"port"`
+	Password string `toml:"password"`
+}
+
+// HTTP holds HTTP timeout settings in seconds.
+type HTTP struct {
+	ConnectTimeout int `toml:"connect_timeout"`
+	ReadTimeout    int `toml:"read_timeout"`
+	WriteTimeout   int `toml:"write_timeout"`
+}
+
+// Cache holds the per-cache-type settings.
+type Cache struct {
+	Download CacheType `toml:"download"`
+	API      CacheType `toml:"api"`
+	InfoJSON CacheType `toml:"info_json"`
+}
+
+// CacheType configures one cache instance.
+type CacheType struct {
+	Backend    string            `toml:"backend"`
+	TTL        *int64            `toml:"ttl"` // seconds; nil = unlimited
+	FileSystem FileSystemBackend `toml:"file_system"`
+	// Redis and S3 are accepted so Ruby-era configuration files still load,
+	// but the backends are out of scope for the Go version and the values
+	// are ignored.
+	Redis RedisBackend `toml:"redis"`
+	S3    S3Backend    `toml:"s3"`
+}
+
+// FileSystemBackend configures the filesystem cache backend.
+type FileSystemBackend struct {
+	MaxFileSize          *int64 `toml:"max_file_size"`         // bytes; nil = unlimited
+	CompressionThreshold *int64 `toml:"compression_threshold"` // bytes; nil = never compress
+}
+
+// RedisBackend is accepted for Ruby-file compatibility only.
+type RedisBackend struct {
+	URL         string `toml:"url"`
+	LockTimeout int64  `toml:"lock_timeout"`
+}
+
+// S3Backend is accepted for Ruby-file compatibility only.
+type S3Backend struct {
+	Bucket      string `toml:"bucket"`
+	Region      string `toml:"region"`
+	LockTimeout int64  `toml:"lock_timeout"`
+}
+
+var validLogLevels = []string{"debug", "info", "warn", "error", "fatal"}
+
+func int64Ptr(v int64) *int64 {
+	return &v
+}
+
+// Default returns the default configuration, matching the Ruby DEFAULTS.
+func Default() Config {
+	return Config{
+		LogLevel: "info",
+		RCON:     RCON{Host: "localhost", Port: 27015},
+		HTTP:     HTTP{ConnectTimeout: 5, ReadTimeout: 30, WriteTimeout: 30},
+		Cache: Cache{
+			// MOD files are immutable: no TTL, no size limit.
+			Download: CacheType{Backend: "file_system"},
+			// API responses may change.
+			API: CacheType{
+				Backend: "file_system",
+				TTL:     int64Ptr(3600),
+				FileSystem: FileSystemBackend{
+					MaxFileSize:          int64Ptr(10 * 1024 * 1024),
+					CompressionThreshold: int64Ptr(0),
+				},
+			},
+			// info.json is immutable within a MOD ZIP.
+			InfoJSON: CacheType{
+				Backend:    "file_system",
+				FileSystem: FileSystemBackend{CompressionThreshold: int64Ptr(0)},
+			},
+		},
+	}
+}
+
+// LoadFile reads a config.toml, applying its values over the defaults.
+func LoadFile(path string) (Config, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		return Config{}, err
+	}
+
+	cfg := Default()
+	meta, err := toml.Decode(string(data), &cfg)
+	if err != nil {
+		return Config{}, fmt.Errorf("%w: invalid TOML in %s: %s", ErrInvalidConfig, path, err)
+	}
+	if undecoded := meta.Undecoded(); len(undecoded) > 0 {
+		return Config{}, fmt.Errorf("%w: unknown configuration key: %s", ErrInvalidConfig, undecoded[0])
+	}
+	if err := cfg.validate(); err != nil {
+		return Config{}, err
+	}
+	return cfg, nil
+}
+
+func (c Config) validate() error {
+	if !slices.Contains(validLogLevels, c.LogLevel) {
+		return fmt.Errorf("%w: invalid log_level: %q", ErrInvalidConfig, c.LogLevel)
+	}
+	for name, ct := range map[string]CacheType{
+		"download":  c.Cache.Download,
+		"api":       c.Cache.API,
+		"info_json": c.Cache.InfoJSON,
+	} {
+		if ct.Backend != "file_system" {
+			return fmt.Errorf("%w: cache.%s.backend %q is not supported (only file_system)", ErrInvalidConfig, name, ct.Backend)
+		}
+	}
+	return nil
+}

--- a/internal/config/config_test.go
+++ b/internal/config/config_test.go
@@ -1,0 +1,113 @@
+package config
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func writeConfig(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "config.toml")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+	return path
+}
+
+func TestDefault(t *testing.T) {
+	cfg := Default()
+	assert.Equal(t, "info", cfg.LogLevel)
+	assert.Equal(t, "localhost", cfg.RCON.Host)
+	assert.Equal(t, 27015, cfg.RCON.Port)
+	assert.Equal(t, 5, cfg.HTTP.ConnectTimeout)
+
+	assert.Nil(t, cfg.Cache.Download.TTL)
+	require.NotNil(t, cfg.Cache.API.TTL)
+	assert.Equal(t, int64(3600), *cfg.Cache.API.TTL)
+	require.NotNil(t, cfg.Cache.API.FileSystem.MaxFileSize)
+	assert.Equal(t, int64(10*1024*1024), *cfg.Cache.API.FileSystem.MaxFileSize)
+	assert.Nil(t, cfg.Cache.InfoJSON.FileSystem.MaxFileSize)
+	require.NotNil(t, cfg.Cache.InfoJSON.FileSystem.CompressionThreshold)
+
+	require.NoError(t, cfg.validate())
+}
+
+func TestLoadFile(t *testing.T) {
+	path := writeConfig(t, `
+log_level = "debug"
+
+[runtime]
+executable_path = "/opt/factorio/bin/x64/factorio"
+
+[rcon]
+port = 34197
+
+[cache.api]
+ttl = 60
+`)
+	cfg, err := LoadFile(path)
+	require.NoError(t, err)
+
+	assert.Equal(t, "debug", cfg.LogLevel)
+	assert.Equal(t, "/opt/factorio/bin/x64/factorio", cfg.Runtime.ExecutablePath)
+	assert.Empty(t, cfg.Runtime.UserDir)
+
+	// Unspecified values keep their defaults.
+	assert.Equal(t, "localhost", cfg.RCON.Host)
+	assert.Equal(t, 34197, cfg.RCON.Port)
+	require.NotNil(t, cfg.Cache.API.TTL)
+	assert.Equal(t, int64(60), *cfg.Cache.API.TTL)
+	require.NotNil(t, cfg.Cache.API.FileSystem.MaxFileSize)
+}
+
+func TestLoadFileToleratesRubyLegacyKeys(t *testing.T) {
+	// Redis/S3 sections from Ruby-era configuration files load but are ignored.
+	path := writeConfig(t, `
+[cache.download.redis]
+url = "redis://localhost"
+lock_timeout = 30
+
+[cache.download.s3]
+bucket = "my-bucket"
+region = "us-east-1"
+`)
+	_, err := LoadFile(path)
+	require.NoError(t, err)
+}
+
+func TestLoadFileUnknownKey(t *testing.T) {
+	path := writeConfig(t, `unknown_key = 1`)
+	_, err := LoadFile(path)
+	require.ErrorIs(t, err, ErrInvalidConfig)
+	assert.Contains(t, err.Error(), "unknown_key")
+}
+
+func TestLoadFileInvalidTOML(t *testing.T) {
+	path := writeConfig(t, `log_level = `)
+	_, err := LoadFile(path)
+	require.ErrorIs(t, err, ErrInvalidConfig)
+}
+
+func TestLoadFileInvalidLogLevel(t *testing.T) {
+	path := writeConfig(t, `log_level = "verbose"`)
+	_, err := LoadFile(path)
+	require.ErrorIs(t, err, ErrInvalidConfig)
+	assert.Contains(t, err.Error(), "log_level")
+}
+
+func TestLoadFileUnsupportedBackend(t *testing.T) {
+	path := writeConfig(t, `
+[cache.api]
+backend = "redis"
+`)
+	_, err := LoadFile(path)
+	require.ErrorIs(t, err, ErrInvalidConfig)
+	assert.Contains(t, err.Error(), "backend")
+}
+
+func TestLoadFileMissing(t *testing.T) {
+	_, err := LoadFile(filepath.Join(t.TempDir(), "missing.toml"))
+	require.ErrorIs(t, err, os.ErrNotExist)
+}

--- a/internal/logging/logging.go
+++ b/internal/logging/logging.go
@@ -1,0 +1,48 @@
+// Package logging sets up the application logger (log/slog) writing to the
+// platform log path.
+package logging
+
+import (
+	"fmt"
+	"io"
+	"log/slog"
+	"os"
+	"path/filepath"
+)
+
+// LevelFatal extends the slog levels with the "fatal" setting accepted by
+// the Ruby implementation.
+const LevelFatal = slog.LevelError + 4
+
+// ParseLevel maps a log_level configuration value to a slog level.
+func ParseLevel(s string) (slog.Level, error) {
+	switch s {
+	case "debug":
+		return slog.LevelDebug, nil
+	case "info":
+		return slog.LevelInfo, nil
+	case "warn":
+		return slog.LevelWarn, nil
+	case "error":
+		return slog.LevelError, nil
+	case "fatal":
+		return LevelFatal, nil
+	default:
+		return 0, fmt.Errorf("invalid log level: %q", s)
+	}
+}
+
+// NewFileLogger opens (creating directories as needed) the log file in
+// append mode and returns a logger writing to it. The caller closes the
+// returned Closer on shutdown.
+func NewFileLogger(path string, level slog.Level) (*slog.Logger, io.Closer, error) {
+	if err := os.MkdirAll(filepath.Dir(path), 0o755); err != nil {
+		return nil, nil, err
+	}
+	f, err := os.OpenFile(path, os.O_CREATE|os.O_WRONLY|os.O_APPEND, 0o644)
+	if err != nil {
+		return nil, nil, err
+	}
+	logger := slog.New(slog.NewTextHandler(f, &slog.HandlerOptions{Level: level}))
+	return logger, f, nil
+}

--- a/internal/logging/logging_test.go
+++ b/internal/logging/logging_test.go
@@ -1,0 +1,47 @@
+package logging
+
+import (
+	"log/slog"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestParseLevel(t *testing.T) {
+	tests := map[string]slog.Level{
+		"debug": slog.LevelDebug,
+		"info":  slog.LevelInfo,
+		"warn":  slog.LevelWarn,
+		"error": slog.LevelError,
+		"fatal": LevelFatal,
+	}
+	for input, want := range tests {
+		got, err := ParseLevel(input)
+		require.NoError(t, err)
+		assert.Equal(t, want, got)
+	}
+
+	_, err := ParseLevel("verbose")
+	require.Error(t, err)
+}
+
+func TestNewFileLogger(t *testing.T) {
+	path := filepath.Join(t.TempDir(), "state", "factorix", "factorix.log")
+
+	logger, closer, err := NewFileLogger(path, slog.LevelInfo)
+	require.NoError(t, err)
+	defer closer.Close()
+
+	logger.Info("hello", "key", "value")
+	logger.Debug("filtered out")
+	require.NoError(t, closer.Close())
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "hello")
+	assert.Contains(t, string(data), "key=value")
+	assert.NotContains(t, string(data), "filtered out")
+}

--- a/internal/platform/detect.go
+++ b/internal/platform/detect.go
@@ -1,0 +1,37 @@
+package platform
+
+import (
+	"os"
+	"runtime"
+	"strings"
+)
+
+// procVersionPath is a variable so tests can point it at a fixture.
+var procVersionPath = "/proc/version"
+
+// Detect returns the Platform for the current OS.
+func Detect() (Platform, error) {
+	switch runtime.GOOS {
+	case "darwin":
+		return MacOS{}, nil
+	case "windows":
+		return Windows{}, nil
+	case "linux":
+		if isWSL() {
+			return &WSL{}, nil
+		}
+		return Linux{}, nil
+	default:
+		return nil, &UnsupportedPlatformError{GOOS: runtime.GOOS}
+	}
+}
+
+// runtime.GOOS reports "linux" on WSL; the kernel version string is the
+// documented way to tell them apart.
+func isWSL() bool {
+	data, err := os.ReadFile(procVersionPath)
+	if err != nil {
+		return false
+	}
+	return strings.Contains(strings.ToLower(string(data)), "microsoft")
+}

--- a/internal/platform/linux.go
+++ b/internal/platform/linux.go
@@ -1,0 +1,43 @@
+package platform
+
+import "path/filepath"
+
+// Linux assumes a Steam installation; other installations (standalone,
+// Flatpak, Snap) are covered by the [runtime] overrides in config.toml.
+type Linux struct{}
+
+func (Linux) GameExecutablePath() (string, error) {
+	return homePath(".steam", "steam", "steamapps", "common", "Factorio", "bin", "x64", "factorio")
+}
+
+func (Linux) GameUserDir() (string, error) {
+	return homePath(".factorio")
+}
+
+func (Linux) GameDataDir() (string, error) {
+	return homePath(".steam", "steam", "steamapps", "common", "Factorio", "data")
+}
+
+func (Linux) DefaultCacheHomeDir() (string, error) {
+	return homePath(".cache")
+}
+
+func (Linux) DefaultConfigHomeDir() (string, error) {
+	return homePath(".config")
+}
+
+func (Linux) DefaultDataHomeDir() (string, error) {
+	return homePath(".local", "share")
+}
+
+func (Linux) DefaultStateHomeDir() (string, error) {
+	return homePath(".local", "state")
+}
+
+func (l Linux) DefaultFactorixLogPath() (string, error) {
+	stateHome, err := l.DefaultStateHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(stateHome, "factorix", "factorix.log"), nil
+}

--- a/internal/platform/macos.go
+++ b/internal/platform/macos.go
@@ -1,0 +1,47 @@
+package platform
+
+import "path/filepath"
+
+// MacOS assumes a Steam installation; other installations (GOG, itch.io,
+// standalone) are covered by the [runtime] overrides in config.toml.
+type MacOS struct{}
+
+func (MacOS) GameExecutablePath() (string, error) {
+	return homePath("Library", "Application Support", "Steam", "steamapps", "common", "Factorio",
+		"factorio.app", "Contents", "MacOS", "factorio")
+}
+
+func (MacOS) GameUserDir() (string, error) {
+	return homePath("Library", "Application Support", "factorio")
+}
+
+func (MacOS) GameDataDir() (string, error) {
+	return homePath("Library", "Application Support", "Steam", "steamapps", "common", "Factorio",
+		"factorio.app", "Contents", "data")
+}
+
+func (MacOS) DefaultCacheHomeDir() (string, error) {
+	return homePath("Library", "Caches")
+}
+
+func (MacOS) DefaultConfigHomeDir() (string, error) {
+	return homePath("Library", "Application Support")
+}
+
+func (MacOS) DefaultDataHomeDir() (string, error) {
+	return homePath("Library", "Application Support")
+}
+
+func (MacOS) DefaultStateHomeDir() (string, error) {
+	return homePath(".local", "state")
+}
+
+// Logs follow the macOS convention (~/Library/Logs), not the XDG state
+// directory.
+func (MacOS) DefaultFactorixLogPath() (string, error) {
+	dir, err := homePath("Library", "Logs")
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "factorix", "factorix.log"), nil
+}

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -1,0 +1,226 @@
+// Package platform resolves Factorio and Factorix paths for each supported
+// OS (Linux, macOS, Windows, WSL). Named platform rather than the stdlib
+// name runtime, which it must import.
+package platform
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// UnsupportedPlatformError reports an OS the tool does not support.
+type UnsupportedPlatformError struct {
+	GOOS string
+}
+
+func (e *UnsupportedPlatformError) Error() string {
+	return "platform is not supported: " + e.GOOS
+}
+
+var ErrMissingEnv = errors.New("required environment variable is not set")
+
+// Platform provides the platform-specific base paths. The Default* methods
+// return the fallbacks used when the corresponding XDG_* environment
+// variable is not set.
+type Platform interface {
+	GameExecutablePath() (string, error)
+	GameUserDir() (string, error)
+	GameDataDir() (string, error)
+	DefaultCacheHomeDir() (string, error)
+	DefaultConfigHomeDir() (string, error)
+	DefaultDataHomeDir() (string, error)
+	DefaultStateHomeDir() (string, error)
+	DefaultFactorixLogPath() (string, error)
+}
+
+// Overrides are user-configured paths that take precedence over platform
+// auto-detection (the [runtime] section of config.toml).
+type Overrides struct {
+	ExecutablePath string
+	UserDir        string
+	DataDir        string
+}
+
+// Runtime combines a Platform with user overrides and derives every path
+// the application needs.
+type Runtime struct {
+	platform  Platform
+	overrides Overrides
+}
+
+// NewRuntime wraps a platform with user overrides.
+func NewRuntime(p Platform, o Overrides) *Runtime {
+	return &Runtime{platform: p, overrides: o}
+}
+
+// ExecutablePath returns the Factorio executable path.
+func (r *Runtime) ExecutablePath() (string, error) {
+	if r.overrides.ExecutablePath != "" {
+		return r.overrides.ExecutablePath, nil
+	}
+	return r.platform.GameExecutablePath()
+}
+
+// UserDir returns the Factorio user directory (mods, saves, config).
+func (r *Runtime) UserDir() (string, error) {
+	if r.overrides.UserDir != "" {
+		return r.overrides.UserDir, nil
+	}
+	return r.platform.GameUserDir()
+}
+
+// DataDir returns the Factorio data directory (base game data and bundled
+// expansion MODs).
+func (r *Runtime) DataDir() (string, error) {
+	if r.overrides.DataDir != "" {
+		return r.overrides.DataDir, nil
+	}
+	return r.platform.GameDataDir()
+}
+
+func (r *Runtime) underUserDir(elems ...string) (string, error) {
+	userDir, err := r.UserDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(append([]string{userDir}, elems...)...), nil
+}
+
+// MODDir returns the directory holding installed MODs and MOD configuration.
+func (r *Runtime) MODDir() (string, error) {
+	return r.underUserDir("mods")
+}
+
+// SaveDir returns the save game directory.
+func (r *Runtime) SaveDir() (string, error) {
+	return r.underUserDir("saves")
+}
+
+// ScriptOutputDir returns the directory for Lua script output.
+func (r *Runtime) ScriptOutputDir() (string, error) {
+	return r.underUserDir("script-output")
+}
+
+// MODListPath returns the path of mod-list.json.
+func (r *Runtime) MODListPath() (string, error) {
+	return r.underUserDir("mods", "mod-list.json")
+}
+
+// MODSettingsPath returns the path of mod-settings.dat.
+func (r *Runtime) MODSettingsPath() (string, error) {
+	return r.underUserDir("mods", "mod-settings.dat")
+}
+
+// PlayerDataPath returns the path of player-data.json.
+func (r *Runtime) PlayerDataPath() (string, error) {
+	return r.underUserDir("player-data.json")
+}
+
+// CurrentLogPath returns the path of the current Factorio log.
+func (r *Runtime) CurrentLogPath() (string, error) {
+	return r.underUserDir("factorio-current.log")
+}
+
+// PreviousLogPath returns the path of the previous Factorio log.
+func (r *Runtime) PreviousLogPath() (string, error) {
+	return r.underUserDir("factorio-previous.log")
+}
+
+// LockPath returns the path of the lock file Factorio creates while running.
+func (r *Runtime) LockPath() (string, error) {
+	return r.underUserDir(".lock")
+}
+
+// IsRunning reports whether Factorio is running. The game daemonizes on
+// launch, so the lock file is the only reliable signal.
+func (r *Runtime) IsRunning() (bool, error) {
+	lockPath, err := r.LockPath()
+	if err != nil {
+		return false, err
+	}
+	_, err = os.Stat(lockPath)
+	if err == nil {
+		return true, nil
+	}
+	if errors.Is(err, os.ErrNotExist) {
+		return false, nil
+	}
+	return false, err
+}
+
+// xdgDir returns the environment variable's value when set (even if empty,
+// matching the Ruby ENV.fetch behavior), otherwise the platform default.
+func xdgDir(envVar string, defaultFn func() (string, error)) (string, error) {
+	if value, ok := os.LookupEnv(envVar); ok {
+		return value, nil
+	}
+	return defaultFn()
+}
+
+// XDGCacheHomeDir returns XDG_CACHE_HOME or the platform equivalent.
+func (r *Runtime) XDGCacheHomeDir() (string, error) {
+	return xdgDir("XDG_CACHE_HOME", r.platform.DefaultCacheHomeDir)
+}
+
+// XDGConfigHomeDir returns XDG_CONFIG_HOME or the platform equivalent.
+func (r *Runtime) XDGConfigHomeDir() (string, error) {
+	return xdgDir("XDG_CONFIG_HOME", r.platform.DefaultConfigHomeDir)
+}
+
+// XDGDataHomeDir returns XDG_DATA_HOME or the platform equivalent.
+func (r *Runtime) XDGDataHomeDir() (string, error) {
+	return xdgDir("XDG_DATA_HOME", r.platform.DefaultDataHomeDir)
+}
+
+// XDGStateHomeDir returns XDG_STATE_HOME or the platform equivalent.
+func (r *Runtime) XDGStateHomeDir() (string, error) {
+	return xdgDir("XDG_STATE_HOME", r.platform.DefaultStateHomeDir)
+}
+
+// FactorixCacheDir returns the Factorix cache directory.
+func (r *Runtime) FactorixCacheDir() (string, error) {
+	dir, err := r.XDGCacheHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "factorix"), nil
+}
+
+// FactorixConfigPath returns the Factorix configuration file path.
+func (r *Runtime) FactorixConfigPath() (string, error) {
+	dir, err := r.XDGConfigHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(dir, "factorix", "config.toml"), nil
+}
+
+// FactorixLogPath returns the Factorix log file path. An explicitly set
+// XDG_STATE_HOME takes precedence over the platform convention so sandboxed
+// environments (tests) can redirect the log file.
+func (r *Runtime) FactorixLogPath() (string, error) {
+	if stateHome, ok := os.LookupEnv("XDG_STATE_HOME"); ok {
+		return filepath.Join(stateHome, "factorix", "factorix.log"), nil
+	}
+	return r.platform.DefaultFactorixLogPath()
+}
+
+// homeDir returns the user's home directory.
+func homeDir() (string, error) {
+	home, err := os.UserHomeDir()
+	if err != nil {
+		return "", fmt.Errorf("cannot determine home directory: %w", err)
+	}
+	return home, nil
+}
+
+// homePath joins elems under the home directory.
+func homePath(elems ...string) (string, error) {
+	home, err := homeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(append([]string{home}, elems...)...), nil
+}

--- a/internal/platform/platform_test.go
+++ b/internal/platform/platform_test.go
@@ -1,0 +1,222 @@
+package platform
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// setHome points the home directory at a temp dir for the test.
+// os.UserHomeDir reads $HOME on Unix; these tests do not run on Windows CI.
+func setHome(t *testing.T) string {
+	t.Helper()
+	home := t.TempDir()
+	t.Setenv("HOME", home)
+	return home
+}
+
+func clearXDG(t *testing.T) {
+	t.Helper()
+	for _, v := range []string{"XDG_CACHE_HOME", "XDG_CONFIG_HOME", "XDG_DATA_HOME", "XDG_STATE_HOME"} {
+		t.Setenv(v, "") // ensure restoration...
+		os.Unsetenv(v)
+	}
+}
+
+func TestLinuxPaths(t *testing.T) {
+	home := setHome(t)
+	p := Linux{}
+
+	exe, err := p.GameExecutablePath()
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(home, ".steam/steam/steamapps/common/Factorio/bin/x64/factorio"), exe)
+
+	userDir, err := p.GameUserDir()
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(home, ".factorio"), userDir)
+
+	dataDir, err := p.GameDataDir()
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(home, ".steam/steam/steamapps/common/Factorio/data"), dataDir)
+}
+
+func TestMacOSPaths(t *testing.T) {
+	home := setHome(t)
+	p := MacOS{}
+
+	userDir, err := p.GameUserDir()
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(home, "Library/Application Support/factorio"), userDir)
+
+	logPath, err := p.DefaultFactorixLogPath()
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(home, "Library/Logs/factorix/factorix.log"), logPath)
+}
+
+func TestWindowsPaths(t *testing.T) {
+	t.Setenv("ProgramFiles(x86)", `C:\Program Files (x86)`)
+	t.Setenv("APPDATA", `C:\Users\test\AppData\Roaming`)
+	t.Setenv("LOCALAPPDATA", `C:\Users\test\AppData\Local`)
+	p := Windows{}
+
+	exe, err := p.GameExecutablePath()
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(`C:\Program Files (x86)`, "Steam", "steamapps", "common", "Factorio", "bin", "x64", "factorio.exe"), exe)
+
+	userDir, err := p.GameUserDir()
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(`C:\Users\test\AppData\Roaming`, "Factorio"), userDir)
+}
+
+func TestWindowsPathsMissingEnv(t *testing.T) {
+	t.Setenv("APPDATA", "")
+	_, err := Windows{}.GameUserDir()
+	require.ErrorIs(t, err, ErrMissingEnv)
+}
+
+func TestConvertWindowsToWSL(t *testing.T) {
+	tests := map[string]string{
+		`C:\Program Files (x86)`:        "/mnt/c/Program Files (x86)",
+		`C:\Users\test\AppData\Roaming`: "/mnt/c/Users/test/AppData/Roaming",
+		`D:/Games/Factorio`:             "/mnt/d/Games/Factorio",
+		`C:\`:                           "/mnt/c",
+	}
+	for input, want := range tests {
+		got, err := convertWindowsToWSL(input)
+		require.NoError(t, err)
+		assert.Equal(t, want, got, input)
+	}
+
+	_, err := convertWindowsToWSL("not a windows path")
+	require.Error(t, err)
+}
+
+func TestRuntimeDerivedPaths(t *testing.T) {
+	home := setHome(t)
+	r := NewRuntime(Linux{}, Overrides{})
+
+	modDir, err := r.MODDir()
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(home, ".factorio/mods"), modDir)
+
+	modListPath, err := r.MODListPath()
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(home, ".factorio/mods/mod-list.json"), modListPath)
+
+	settingsPath, err := r.MODSettingsPath()
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(home, ".factorio/mods/mod-settings.dat"), settingsPath)
+
+	saveDir, err := r.SaveDir()
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(home, ".factorio/saves"), saveDir)
+
+	playerData, err := r.PlayerDataPath()
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(home, ".factorio/player-data.json"), playerData)
+}
+
+func TestRuntimeOverrides(t *testing.T) {
+	setHome(t)
+	r := NewRuntime(Linux{}, Overrides{
+		ExecutablePath: "/opt/factorio/bin/x64/factorio",
+		UserDir:        "/srv/factorio",
+	})
+
+	exe, err := r.ExecutablePath()
+	require.NoError(t, err)
+	assert.Equal(t, "/opt/factorio/bin/x64/factorio", exe)
+
+	modDir, err := r.MODDir()
+	require.NoError(t, err)
+	assert.Equal(t, "/srv/factorio/mods", modDir)
+
+	// DataDir has no override and falls back to auto-detection.
+	dataDir, err := r.DataDir()
+	require.NoError(t, err)
+	assert.Contains(t, dataDir, ".steam")
+}
+
+func TestRuntimeXDGDirs(t *testing.T) {
+	home := setHome(t)
+	clearXDG(t)
+	r := NewRuntime(Linux{}, Overrides{})
+
+	cacheDir, err := r.FactorixCacheDir()
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(home, ".cache/factorix"), cacheDir)
+
+	configPath, err := r.FactorixConfigPath()
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(home, ".config/factorix/config.toml"), configPath)
+
+	logPath, err := r.FactorixLogPath()
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(home, ".local/state/factorix/factorix.log"), logPath)
+
+	t.Setenv("XDG_CACHE_HOME", "/custom/cache")
+	t.Setenv("XDG_STATE_HOME", "/custom/state")
+
+	cacheDir, err = r.FactorixCacheDir()
+	require.NoError(t, err)
+	assert.Equal(t, "/custom/cache/factorix", cacheDir)
+
+	logPath, err = r.FactorixLogPath()
+	require.NoError(t, err)
+	assert.Equal(t, "/custom/state/factorix/factorix.log", logPath)
+}
+
+func TestMacOSLogPathHonorsXDGStateHome(t *testing.T) {
+	home := setHome(t)
+	clearXDG(t)
+	r := NewRuntime(MacOS{}, Overrides{})
+
+	logPath, err := r.FactorixLogPath()
+	require.NoError(t, err)
+	assert.Equal(t, filepath.Join(home, "Library/Logs/factorix/factorix.log"), logPath)
+
+	t.Setenv("XDG_STATE_HOME", "/sandbox/state")
+	logPath, err = r.FactorixLogPath()
+	require.NoError(t, err)
+	assert.Equal(t, "/sandbox/state/factorix/factorix.log", logPath)
+}
+
+func TestRuntimeIsRunning(t *testing.T) {
+	userDir := t.TempDir()
+	r := NewRuntime(Linux{}, Overrides{UserDir: userDir})
+
+	running, err := r.IsRunning()
+	require.NoError(t, err)
+	assert.False(t, running)
+
+	require.NoError(t, os.WriteFile(filepath.Join(userDir, ".lock"), nil, 0o644))
+	running, err = r.IsRunning()
+	require.NoError(t, err)
+	assert.True(t, running)
+}
+
+func TestIsWSL(t *testing.T) {
+	dir := t.TempDir()
+	fake := filepath.Join(dir, "version")
+
+	orig := procVersionPath
+	defer func() { procVersionPath = orig }()
+	procVersionPath = fake
+
+	assert.False(t, isWSL()) // file absent
+
+	require.NoError(t, os.WriteFile(fake, []byte("Linux version 6.6.0 (Microsoft@Microsoft.com)"), 0o644))
+	assert.True(t, isWSL())
+
+	require.NoError(t, os.WriteFile(fake, []byte("Linux version 6.6.0 (gcc ...)"), 0o644))
+	assert.False(t, isWSL())
+}
+
+func TestDetect(t *testing.T) {
+	p, err := Detect()
+	require.NoError(t, err)
+	assert.NotNil(t, p)
+}

--- a/internal/platform/windows.go
+++ b/internal/platform/windows.go
@@ -1,0 +1,85 @@
+package platform
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+)
+
+// Windows locates Factorio via the standard environment variables and
+// assumes a Steam installation; other installations are covered by the
+// [runtime] overrides in config.toml.
+type Windows struct{}
+
+func windowsEnv(name string) (string, error) {
+	value := os.Getenv(name)
+	if value == "" {
+		return "", fmt.Errorf("%w: %s", ErrMissingEnv, name)
+	}
+	return value, nil
+}
+
+func (Windows) programFilesX86() (string, error) {
+	return windowsEnv("ProgramFiles(x86)")
+}
+
+func (Windows) appData() (string, error) {
+	return windowsEnv("APPDATA")
+}
+
+func (Windows) localAppData() (string, error) {
+	return windowsEnv("LOCALAPPDATA")
+}
+
+// steamFactorioPath joins elems under Steam's Factorio directory.
+func steamFactorioPath(root string, elems ...string) string {
+	return filepath.Join(append([]string{root, "Steam", "steamapps", "common", "Factorio"}, elems...)...)
+}
+
+func (w Windows) GameExecutablePath() (string, error) {
+	root, err := w.programFilesX86()
+	if err != nil {
+		return "", err
+	}
+	return steamFactorioPath(root, "bin", "x64", "factorio.exe"), nil
+}
+
+func (w Windows) GameUserDir() (string, error) {
+	appData, err := w.appData()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(appData, "Factorio"), nil
+}
+
+func (w Windows) GameDataDir() (string, error) {
+	root, err := w.programFilesX86()
+	if err != nil {
+		return "", err
+	}
+	return steamFactorioPath(root, "data"), nil
+}
+
+func (w Windows) DefaultCacheHomeDir() (string, error) {
+	return w.localAppData()
+}
+
+func (w Windows) DefaultConfigHomeDir() (string, error) {
+	return w.appData()
+}
+
+func (w Windows) DefaultDataHomeDir() (string, error) {
+	return w.localAppData()
+}
+
+func (Windows) DefaultStateHomeDir() (string, error) {
+	return homePath(".local", "state")
+}
+
+func (w Windows) DefaultFactorixLogPath() (string, error) {
+	stateHome, err := w.DefaultStateHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(stateHome, "factorix", "factorix.log"), nil
+}

--- a/internal/platform/wsl.go
+++ b/internal/platform/wsl.go
@@ -1,0 +1,142 @@
+package platform
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"sync"
+)
+
+// WSL locates Factorio through the Windows side of the system: it fetches
+// the Windows environment variables via powershell.exe in one batch and
+// converts the paths to their /mnt/<drive> equivalents. Factorix-side
+// directories (cache, config, state) live in the Linux home.
+type WSL struct {
+	once sync.Once
+	envs map[string]string
+	err  error
+}
+
+// The Windows environment variables fetched in one PowerShell invocation.
+const wslPowerShellScript = `[pscustomobject]@{
+  "ProgramFiles(x86)" = ${Env:ProgramFiles(x86)};
+  "APPDATA"           = ${Env:APPDATA};
+  "LOCALAPPDATA"      = ${Env:LOCALAPPDATA}
+} | ConvertTo-Json -Compress`
+
+var wslPowerShellFallbackPaths = []string{
+	"/mnt/c/Windows/System32/WindowsPowerShell/v1.0/powershell.exe",
+	"/mnt/c/Windows/system32/WindowsPowerShell/v1.0/powershell.exe",
+}
+
+func (w *WSL) windowsPath(name string) (string, error) {
+	w.once.Do(func() {
+		w.envs, w.err = fetchWindowsEnvs()
+	})
+	if w.err != nil {
+		return "", w.err
+	}
+	value, ok := w.envs[name]
+	if !ok || value == "" {
+		return "", fmt.Errorf("%w: %s", ErrMissingEnv, name)
+	}
+	return convertWindowsToWSL(value)
+}
+
+func fetchWindowsEnvs() (map[string]string, error) {
+	ps, err := findPowerShell()
+	if err != nil {
+		return nil, err
+	}
+	out, err := exec.Command(ps, "-NoProfile", "-NonInteractive", "-ExecutionPolicy", "Bypass", "-Command", wslPowerShellScript).Output()
+	if err != nil {
+		return nil, fmt.Errorf("PowerShell execution failed: %w", err)
+	}
+	var envs map[string]string
+	if err := json.Unmarshal(out, &envs); err != nil {
+		return nil, fmt.Errorf("cannot parse PowerShell output: %w", err)
+	}
+	return envs, nil
+}
+
+func findPowerShell() (string, error) {
+	if path, err := exec.LookPath("powershell.exe"); err == nil {
+		return path, nil
+	}
+	for _, path := range wslPowerShellFallbackPaths {
+		if _, err := os.Stat(path); err == nil {
+			return path, nil
+		}
+	}
+	return "", fmt.Errorf("powershell.exe not found in PATH or default locations")
+}
+
+var windowsPathRE = regexp.MustCompile(`\A([A-Za-z]):[\\/]?(.*)\z`)
+
+// convertWindowsToWSL maps "C:\Users\x" to "/mnt/c/Users/x".
+func convertWindowsToWSL(windowsPath string) (string, error) {
+	m := windowsPathRE.FindStringSubmatch(windowsPath)
+	if m == nil {
+		return "", fmt.Errorf("invalid Windows path: %q", windowsPath)
+	}
+	drive := strings.ToLower(m[1])
+	rest := strings.ReplaceAll(m[2], `\`, "/")
+	result := "/mnt/" + drive + "/" + rest
+	// Collapse duplicate slashes and drop a trailing one.
+	for strings.Contains(result, "//") {
+		result = strings.ReplaceAll(result, "//", "/")
+	}
+	return strings.TrimSuffix(result, "/"), nil
+}
+
+func (w *WSL) GameExecutablePath() (string, error) {
+	root, err := w.windowsPath("ProgramFiles(x86)")
+	if err != nil {
+		return "", err
+	}
+	return steamFactorioPath(root, "bin", "x64", "factorio.exe"), nil
+}
+
+func (w *WSL) GameUserDir() (string, error) {
+	appData, err := w.windowsPath("APPDATA")
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(appData, "Factorio"), nil
+}
+
+func (w *WSL) GameDataDir() (string, error) {
+	root, err := w.windowsPath("ProgramFiles(x86)")
+	if err != nil {
+		return "", err
+	}
+	return steamFactorioPath(root, "data"), nil
+}
+
+func (w *WSL) DefaultCacheHomeDir() (string, error) {
+	return w.windowsPath("LOCALAPPDATA")
+}
+
+func (w *WSL) DefaultConfigHomeDir() (string, error) {
+	return w.windowsPath("APPDATA")
+}
+
+func (w *WSL) DefaultDataHomeDir() (string, error) {
+	return w.windowsPath("LOCALAPPDATA")
+}
+
+func (*WSL) DefaultStateHomeDir() (string, error) {
+	return homePath(".local", "state")
+}
+
+func (w *WSL) DefaultFactorixLogPath() (string, error) {
+	stateHome, err := w.DefaultStateHomeDir()
+	if err != nil {
+		return "", err
+	}
+	return filepath.Join(stateHome, "factorix", "factorix.log"), nil
+}


### PR DESCRIPTION
## Summary
Phase 5 of the Go migration roadmap: platform-specific path resolution, configuration loading, and slog setup.

## Changes
- `internal/platform`: a `Platform` interface per OS (Linux/macOS/Windows/WSL, detected via `runtime.GOOS` + `/proc/version`) plus a `Runtime` wrapper that derives every application path (MOD dir, mod-list.json, lock file, Factorix cache/config/log) and applies the `[runtime]` config overrides — the Go equivalent of Ruby's `Runtime::UserConfigurable`
- XDG env vars are honored with platform defaults as fallback; macOS logs to `~/Library/Logs` unless `XDG_STATE_HOME` is set, matching Ruby
- WSL fetches `ProgramFiles(x86)`/`APPDATA`/`LOCALAPPDATA` via one PowerShell batch (sync.Once) and converts `C:\...` to `/mnt/c/...`
- `internal/config`: TOML loading (BurntSushi/toml) over Ruby-identical defaults, with unknown-key rejection via `meta.Undecoded()`. Ruby-era `redis`/`s3` keys still load (ignored) so existing files carry over, but only `backend = "file_system"` is accepted — Redis/S3 are out of scope
- `internal/logging`: file-backed slog handler and `log_level` parsing; `fatal` maps to `LevelError+4` since slog has no fatal level

## Test Plan
- `go build ./... && go vet ./... && go test ./...` pass locally
- Platform tests pin the expected paths per OS via `$HOME`/env fixtures; WSL path conversion and `/proc/version` detection are unit-tested
