### PR TITLE
:sparkles: Implement MOD Portal and game download APIs (Phase 7)

### DIFF
--- a/doc/go-migration-roadmap.md
+++ b/doc/go-migration-roadmap.md
@@ -341,14 +341,24 @@ parity, once the actual game behavior can be observed.
 
 All API response types are plain structs with JSON tags.
 
-- [ ] `internal/api/types.go` — `MODInfo`, `Release`, `Image`, `Category`, `Tag`, `License`
-- [ ] `internal/api/portal.go` — `MODPortalAPI`: list, search, show
-- [ ] `internal/api/download.go` — `MODDownloadAPI`: build authenticated download URL, stream to cache
-- [ ] `internal/api/game_download.go` — `GameDownloadAPI`: game binary download (`download` command)
-- [ ] `internal/api/management.go` — `MODManagementAPI`: upload, edit, image management
+- [x] `internal/api/types.go` — `MODInfo`, `Release`, `Image`, `License`; a release
+      with an out-of-range version is dropped after decoding instead of failing the
+      MOD. Category/Tag are plain strings — the Ruby display catalogs (names,
+      descriptions) move to the `mod show`/upload commands in Phase 10
+- [x] `internal/api/portal.go` — `MODPortalAPI`: list, show (short/full), cache
+      invalidation; JSON decodes directly into the typed structs, so the Ruby
+      `Portal` facade's Hash-to-object conversion role disappears (its upload
+      orchestration moves to Phase 10)
+- [x] `internal/api/download.go` — `MODDownloadAPI`: build authenticated download
+      URL (streaming to cache is the Phase 8 downloader's job)
+- [x] `internal/api/game_download.go` — `GameDownloadAPI`: latest releases, filename
+      resolution via redirect, authenticated download URL
+- [x] `internal/api/management.go` — `MODManagementAPI`: upload, edit, image management
   - cache-invalidation callback to `MODPortalAPI` (replaces dry-events subscription)
-- [ ] `internal/api/credential.go`
-  - `ServiceCredential` — username/token from env vars or `player-data.json`
+  - uploads go through an `Uploader` interface implemented by `internal/transfer` in Phase 8
+- [x] `internal/api/credential.go`
+  - `ServiceCredential` — username/token from env vars or `player-data.json`;
+    lazily resolved so the environment is only consulted when actually needed
   - `APICredential` — `FACTORIO_API_KEY` (required by the management API)
 
 ---

--- a/internal/api/credential.go
+++ b/internal/api/credential.go
@@ -1,0 +1,92 @@
+package api
+
+import (
+	"encoding/json"
+	"fmt"
+	"os"
+)
+
+const (
+	envUsername = "FACTORIO_USERNAME"
+	envToken    = "FACTORIO_TOKEN"
+	envAPIKey   = "FACTORIO_API_KEY"
+)
+
+// ServiceCredential is the username/token pair used by the download
+// endpoints. Fields are unexported so the values do not leak through
+// formatting; String renders masked.
+type ServiceCredential struct {
+	username string
+	token    string
+}
+
+// Username returns the service username.
+func (c ServiceCredential) Username() string {
+	return c.username
+}
+
+// Token returns the service token.
+func (c ServiceCredential) Token() string {
+	return c.token
+}
+
+func (ServiceCredential) String() string {
+	return `ServiceCredential{username: "*****", token: "*****"}`
+}
+
+// LoadServiceCredential loads the username/token pair from the environment
+// (FACTORIO_USERNAME / FACTORIO_TOKEN), falling back to player-data.json at
+// the given path when neither is set. Setting only one variable is an error.
+func LoadServiceCredential(playerDataPath string) (ServiceCredential, error) {
+	username := os.Getenv(envUsername)
+	token := os.Getenv(envToken)
+
+	switch {
+	case username != "" && token != "":
+		return ServiceCredential{username: username, token: token}, nil
+	case username != "" || token != "":
+		return ServiceCredential{}, fmt.Errorf("%w: both %s and %s must be set (or neither)", ErrCredential, envUsername, envToken)
+	}
+
+	data, err := os.ReadFile(playerDataPath)
+	if err != nil {
+		return ServiceCredential{}, fmt.Errorf("%w: cannot read player-data.json: %s", ErrCredential, err)
+	}
+	var playerData struct {
+		ServiceUsername string `json:"service-username"`
+		ServiceToken    string `json:"service-token"`
+	}
+	if err := json.Unmarshal(data, &playerData); err != nil {
+		return ServiceCredential{}, fmt.Errorf("%w: invalid player-data.json: %s", ErrCredential, err)
+	}
+	if playerData.ServiceUsername == "" {
+		return ServiceCredential{}, fmt.Errorf("%w: service-username is missing in player-data.json", ErrCredential)
+	}
+	if playerData.ServiceToken == "" {
+		return ServiceCredential{}, fmt.Errorf("%w: service-token is missing in player-data.json", ErrCredential)
+	}
+	return ServiceCredential{username: playerData.ServiceUsername, token: playerData.ServiceToken}, nil
+}
+
+// APICredential is the API key required by the management API.
+type APICredential struct {
+	apiKey string
+}
+
+// APIKey returns the API key.
+func (c APICredential) APIKey() string {
+	return c.apiKey
+}
+
+func (APICredential) String() string {
+	return `APICredential{api_key: "*****"}`
+}
+
+// LoadAPICredential loads the API key from FACTORIO_API_KEY.
+func LoadAPICredential() (APICredential, error) {
+	apiKey := os.Getenv(envAPIKey)
+	if apiKey == "" {
+		return APICredential{}, fmt.Errorf("%w: %s environment variable is not set", ErrCredential, envAPIKey)
+	}
+	return APICredential{apiKey: apiKey}, nil
+}

--- a/internal/api/credential_test.go
+++ b/internal/api/credential_test.go
@@ -1,0 +1,95 @@
+package api
+
+import (
+	"fmt"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func clearCredentialEnv(t *testing.T) {
+	t.Helper()
+	for _, v := range []string{envUsername, envToken, envAPIKey} {
+		t.Setenv(v, "")
+		os.Unsetenv(v)
+	}
+}
+
+func playerDataFile(t *testing.T, content string) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "player-data.json")
+	require.NoError(t, os.WriteFile(path, []byte(content), 0o644))
+	return path
+}
+
+func TestLoadServiceCredentialFromEnv(t *testing.T) {
+	clearCredentialEnv(t)
+	t.Setenv(envUsername, "alice")
+	t.Setenv(envToken, "secret")
+
+	credential, err := LoadServiceCredential("/nonexistent")
+	require.NoError(t, err)
+	assert.Equal(t, "alice", credential.Username())
+	assert.Equal(t, "secret", credential.Token())
+}
+
+func TestLoadServiceCredentialPartialEnv(t *testing.T) {
+	clearCredentialEnv(t)
+	t.Setenv(envUsername, "alice")
+
+	_, err := LoadServiceCredential("/nonexistent")
+	require.ErrorIs(t, err, ErrCredential)
+}
+
+func TestLoadServiceCredentialFromPlayerData(t *testing.T) {
+	clearCredentialEnv(t)
+	path := playerDataFile(t, `{"service-username": "bob", "service-token": "tok"}`)
+
+	credential, err := LoadServiceCredential(path)
+	require.NoError(t, err)
+	assert.Equal(t, "bob", credential.Username())
+	assert.Equal(t, "tok", credential.Token())
+}
+
+func TestLoadServiceCredentialPlayerDataMissingFields(t *testing.T) {
+	clearCredentialEnv(t)
+	path := playerDataFile(t, `{"service-username": "bob"}`)
+
+	_, err := LoadServiceCredential(path)
+	require.ErrorIs(t, err, ErrCredential)
+	assert.Contains(t, err.Error(), "service-token")
+}
+
+func TestLoadServiceCredentialNoSources(t *testing.T) {
+	clearCredentialEnv(t)
+	_, err := LoadServiceCredential(filepath.Join(t.TempDir(), "absent.json"))
+	require.ErrorIs(t, err, ErrCredential)
+}
+
+func TestServiceCredentialMasking(t *testing.T) {
+	clearCredentialEnv(t)
+	t.Setenv(envUsername, "alice")
+	t.Setenv(envToken, "secret")
+	credential, err := LoadServiceCredential("/nonexistent")
+	require.NoError(t, err)
+
+	rendered := fmt.Sprintf("%v / %s", credential, credential)
+	assert.NotContains(t, rendered, "alice")
+	assert.NotContains(t, rendered, "secret")
+}
+
+func TestLoadAPICredential(t *testing.T) {
+	clearCredentialEnv(t)
+
+	_, err := LoadAPICredential()
+	require.ErrorIs(t, err, ErrCredential)
+
+	t.Setenv(envAPIKey, "key-123")
+	credential, err := LoadAPICredential()
+	require.NoError(t, err)
+	assert.Equal(t, "key-123", credential.APIKey())
+	assert.NotContains(t, fmt.Sprintf("%v", credential), "key-123")
+}

--- a/internal/api/download.go
+++ b/internal/api/download.go
@@ -1,0 +1,36 @@
+package api
+
+import (
+	"fmt"
+	"net/url"
+	"strings"
+)
+
+// MODDownloadAPI builds authenticated MOD download URLs. Credentials are
+// resolved lazily so the environment is only consulted when a download
+// actually happens; the download itself is performed by internal/transfer.
+type MODDownloadAPI struct {
+	Credentials func() (ServiceCredential, error)
+	BaseURL     string
+}
+
+// NewMODDownloadAPI builds a download-URL builder with the default base URL.
+func NewMODDownloadAPI(credentials func() (ServiceCredential, error)) *MODDownloadAPI {
+	return &MODDownloadAPI{Credentials: credentials, BaseURL: DefaultPortalBaseURL}
+}
+
+// DownloadURL turns a relative download path from a Release into a full URL
+// with the username/token credentials attached.
+func (a *MODDownloadAPI) DownloadURL(downloadPath string) (string, error) {
+	if !strings.HasPrefix(downloadPath, "/") {
+		return "", fmt.Errorf("%w: download URL must be a relative path starting with '/', got %q", ErrInvalidArgument, downloadPath)
+	}
+	credential, err := a.Credentials()
+	if err != nil {
+		return "", err
+	}
+	params := url.Values{}
+	params.Set("username", credential.Username())
+	params.Set("token", credential.Token())
+	return a.BaseURL + downloadPath + "?" + params.Encode(), nil
+}

--- a/internal/api/download_test.go
+++ b/internal/api/download_test.go
@@ -1,0 +1,29 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func testCredentials() func() (ServiceCredential, error) {
+	return func() (ServiceCredential, error) {
+		return ServiceCredential{username: "alice", token: "tok"}, nil
+	}
+}
+
+func TestMODDownloadURL(t *testing.T) {
+	downloadAPI := NewMODDownloadAPI(testCredentials())
+
+	downloadURL, err := downloadAPI.DownloadURL("/download/test-mod/aaa")
+	require.NoError(t, err)
+	assert.Equal(t, "https://mods.factorio.com/download/test-mod/aaa?token=tok&username=alice", downloadURL)
+}
+
+func TestMODDownloadURLRejectsAbsolute(t *testing.T) {
+	downloadAPI := NewMODDownloadAPI(testCredentials())
+
+	_, err := downloadAPI.DownloadURL("https://evil.example.com/download")
+	require.ErrorIs(t, err, ErrInvalidArgument)
+}

--- a/internal/api/errors.go
+++ b/internal/api/errors.go
@@ -1,0 +1,10 @@
+package api
+
+import "errors"
+
+var (
+	ErrMODNotOnPortal  = errors.New("MOD not found on portal")
+	ErrCredential      = errors.New("credential error")
+	ErrInvalidArgument = errors.New("invalid argument")
+	ErrInvalidResponse = errors.New("invalid API response")
+)

--- a/internal/api/game_download.go
+++ b/internal/api/game_download.go
@@ -1,0 +1,134 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/url"
+	"path"
+	"slices"
+
+	"github.com/sakuro/factorix/internal/httpx"
+)
+
+// Base URLs for the game download endpoints.
+const (
+	DefaultGameDownloadBaseURL = "https://www.factorio.com"
+	DefaultGameAPIBaseURL      = "https://factorio.com"
+)
+
+// Valid build types, platforms, and release channels.
+var (
+	Builds    = []string{"alpha", "expansion", "demo", "headless"}
+	Platforms = []string{"win64", "win64-manual", "osx", "linux64"}
+	Channels  = []string{"stable", "experimental"}
+)
+
+// GameDownloadAPI talks to the game download endpoints.
+//
+// See https://wiki.factorio.com/Download_API
+type GameDownloadAPI struct {
+	Client          *httpx.Client
+	Credentials     func() (ServiceCredential, error)
+	Logger          *slog.Logger
+	DownloadBaseURL string
+	APIBaseURL      string
+}
+
+// NewGameDownloadAPI builds a game download client with the default URLs.
+func NewGameDownloadAPI(client *httpx.Client, credentials func() (ServiceCredential, error), logger *slog.Logger) *GameDownloadAPI {
+	if logger == nil {
+		logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	}
+	return &GameDownloadAPI{
+		Client:          client,
+		Credentials:     credentials,
+		Logger:          logger,
+		DownloadBaseURL: DefaultGameDownloadBaseURL,
+		APIBaseURL:      DefaultGameAPIBaseURL,
+	}
+}
+
+// LatestReleases is the /api/latest-releases response: version strings per
+// build, per channel.
+type LatestReleases struct {
+	Stable       map[string]string `json:"stable"`
+	Experimental map[string]string `json:"experimental"`
+}
+
+// GetLatestReleases fetches the latest release versions.
+func (a *GameDownloadAPI) GetLatestReleases(ctx context.Context) (*LatestReleases, error) {
+	a.Logger.Debug("Fetching latest releases")
+	resp, err := a.Client.Get(ctx, a.APIBaseURL+"/api/latest-releases")
+	if err != nil {
+		return nil, err
+	}
+	var releases LatestReleases
+	if err := json.Unmarshal(resp.Body, &releases); err != nil {
+		return nil, fmt.Errorf("%w: %s", ErrInvalidResponse, err)
+	}
+	return &releases, nil
+}
+
+// LatestVersion returns the latest version for a channel and build, or ""
+// when not available.
+func (a *GameDownloadAPI) LatestVersion(ctx context.Context, channel, build string) (string, error) {
+	if err := validateOneOf("channel", channel, Channels); err != nil {
+		return "", err
+	}
+	if err := validateOneOf("build", build, Builds); err != nil {
+		return "", err
+	}
+	releases, err := a.GetLatestReleases(ctx)
+	if err != nil {
+		return "", err
+	}
+	switch channel {
+	case "stable":
+		return releases.Stable[build], nil
+	default:
+		return releases.Experimental[build], nil
+	}
+}
+
+// ResolveFilename determines the download filename by following the
+// redirect of a HEAD request and taking the final URL's basename.
+func (a *GameDownloadAPI) ResolveFilename(ctx context.Context, version, build, platform string) (string, error) {
+	downloadURL, err := a.DownloadURL(version, build, platform)
+	if err != nil {
+		return "", err
+	}
+	resp, err := a.Client.Head(ctx, downloadURL)
+	if err != nil {
+		return "", err
+	}
+	return path.Base(resp.URL.Path), nil
+}
+
+// DownloadURL builds the authenticated download URL for a game build; the
+// download itself is performed by internal/transfer.
+func (a *GameDownloadAPI) DownloadURL(version, build, platform string) (string, error) {
+	if err := validateOneOf("build", build, Builds); err != nil {
+		return "", err
+	}
+	if err := validateOneOf("platform", platform, Platforms); err != nil {
+		return "", err
+	}
+	credential, err := a.Credentials()
+	if err != nil {
+		return "", err
+	}
+	params := url.Values{}
+	params.Set("username", credential.Username())
+	params.Set("token", credential.Token())
+	return fmt.Sprintf("%s/get-download/%s/%s/%s?%s", a.DownloadBaseURL, version, build, platform, params.Encode()), nil
+}
+
+func validateOneOf(name, value string, valid []string) error {
+	if slices.Contains(valid, value) {
+		return nil
+	}
+	return fmt.Errorf("%w: invalid %s: %q (valid: %v)", ErrInvalidArgument, name, value, valid)
+}

--- a/internal/api/game_download_test.go
+++ b/internal/api/game_download_test.go
@@ -1,0 +1,84 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sakuro/factorix/internal/httpx"
+)
+
+func newGameAPI(t *testing.T, handler http.HandlerFunc) *GameDownloadAPI {
+	t.Helper()
+	server := httptest.NewTLSServer(handler)
+	t.Cleanup(server.Close)
+	client := httpx.NewClient(httpx.Options{Transport: server.Client().Transport})
+	gameAPI := NewGameDownloadAPI(client, testCredentials(), nil)
+	gameAPI.APIBaseURL = server.URL
+	gameAPI.DownloadBaseURL = server.URL
+	return gameAPI
+}
+
+func TestLatestVersion(t *testing.T) {
+	gameAPI := newGameAPI(t, func(w http.ResponseWriter, r *http.Request) {
+		assert.Equal(t, "/api/latest-releases", r.URL.Path)
+		w.Write([]byte(`{
+			"stable": {"alpha": "2.0.28", "expansion": "2.0.28", "headless": "2.0.28"},
+			"experimental": {"alpha": "2.0.30"}
+		}`))
+	})
+
+	version, err := gameAPI.LatestVersion(context.Background(), "stable", "expansion")
+	require.NoError(t, err)
+	assert.Equal(t, "2.0.28", version)
+
+	version, err = gameAPI.LatestVersion(context.Background(), "experimental", "alpha")
+	require.NoError(t, err)
+	assert.Equal(t, "2.0.30", version)
+
+	// Unavailable build yields "".
+	version, err = gameAPI.LatestVersion(context.Background(), "experimental", "demo")
+	require.NoError(t, err)
+	assert.Empty(t, version)
+}
+
+func TestLatestVersionValidation(t *testing.T) {
+	gameAPI := NewGameDownloadAPI(nil, testCredentials(), nil)
+	ctx := context.Background()
+
+	_, err := gameAPI.LatestVersion(ctx, "nightly", "alpha")
+	require.ErrorIs(t, err, ErrInvalidArgument)
+	_, err = gameAPI.LatestVersion(ctx, "stable", "beta")
+	require.ErrorIs(t, err, ErrInvalidArgument)
+}
+
+func TestResolveFilename(t *testing.T) {
+	gameAPI := newGameAPI(t, func(w http.ResponseWriter, r *http.Request) {
+		if r.URL.Path == "/dl/factorio_linux64_2.0.28.tar.xz" {
+			w.WriteHeader(http.StatusOK)
+			return
+		}
+		assert.Equal(t, "alice", r.URL.Query().Get("username"))
+		assert.Equal(t, "tok", r.URL.Query().Get("token"))
+		http.Redirect(w, r, "/dl/factorio_linux64_2.0.28.tar.xz", http.StatusFound)
+	})
+
+	filename, err := gameAPI.ResolveFilename(context.Background(), "2.0.28", "alpha", "linux64")
+	require.NoError(t, err)
+	assert.Equal(t, "factorio_linux64_2.0.28.tar.xz", filename)
+}
+
+func TestGameDownloadURL(t *testing.T) {
+	gameAPI := NewGameDownloadAPI(nil, testCredentials(), nil)
+
+	downloadURL, err := gameAPI.DownloadURL("2.0.28", "headless", "linux64")
+	require.NoError(t, err)
+	assert.Equal(t, "https://www.factorio.com/get-download/2.0.28/headless/linux64?token=tok&username=alice", downloadURL)
+
+	_, err = gameAPI.DownloadURL("2.0.28", "bogus", "linux64")
+	require.ErrorIs(t, err, ErrInvalidArgument)
+}

--- a/internal/api/management.go
+++ b/internal/api/management.go
@@ -1,0 +1,251 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/http"
+	"net/url"
+	"slices"
+	"strconv"
+	"strings"
+
+	"github.com/sakuro/factorix/internal/httpx"
+)
+
+// Uploader performs multipart file uploads; implemented by
+// internal/transfer in Phase 8. fields are extra form fields, fieldName is
+// the file's form field (defaults to "file" when empty).
+type Uploader interface {
+	Upload(ctx context.Context, uploadURL, filePath string, fields map[string]string, fieldName string) ([]byte, error)
+}
+
+// Metadata fields accepted by FinishUpload (init_publish scenario only).
+var allowedUploadMetadata = []string{"description", "category", "license", "source_url"}
+
+// Metadata fields accepted by EditDetails.
+var allowedEditMetadata = []string{"description", "summary", "title", "category", "tags", "license", "homepage", "source_url", "faq", "deprecated"}
+
+// MODManagementAPI performs portal operations that require an API key:
+// publishing, uploading releases, editing details and images.
+//
+// See https://wiki.factorio.com/Mod_upload_API
+type MODManagementAPI struct {
+	Client   *httpx.Client
+	Uploader Uploader
+	Logger   *slog.Logger
+	BaseURL  string
+	// Credentials resolves the API key lazily so FACTORIO_API_KEY is only
+	// required when a management operation actually runs.
+	Credentials func() (APICredential, error)
+	// OnMODChanged is invoked with the MOD name after any operation that
+	// changes the MOD on the portal; wired to MODPortalAPI's cache
+	// invalidation. This replaces the Ruby dry-events subscription.
+	OnMODChanged func(ctx context.Context, name string)
+}
+
+// NewMODManagementAPI builds a management client with the default base URL.
+func NewMODManagementAPI(client *httpx.Client, uploader Uploader, credentials func() (APICredential, error), logger *slog.Logger) *MODManagementAPI {
+	if logger == nil {
+		logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	}
+	return &MODManagementAPI{
+		Client:      client,
+		Uploader:    uploader,
+		Logger:      logger,
+		BaseURL:     DefaultPortalBaseURL,
+		Credentials: credentials,
+	}
+}
+
+// InitPublish starts publication of a brand-new MOD and returns the upload URL.
+func (a *MODManagementAPI) InitPublish(ctx context.Context, name string) (string, error) {
+	a.Logger.Info("Initializing MOD publication", "mod", name)
+	return a.initUpload(ctx, "/api/v2/mods/init_publish", name)
+}
+
+// InitUpload starts a release upload to an existing MOD and returns the
+// upload URL.
+func (a *MODManagementAPI) InitUpload(ctx context.Context, name string) (string, error) {
+	a.Logger.Info("Initializing MOD upload", "mod", name)
+	uploadURL, err := a.initUpload(ctx, "/api/v2/mods/releases/init_upload", name)
+	if err != nil {
+		return "", mapNotFound(err, name)
+	}
+	return uploadURL, nil
+}
+
+// FinishUpload uploads the MOD file to the URL from InitPublish/InitUpload.
+// metadata is only meaningful for the publish scenario.
+func (a *MODManagementAPI) FinishUpload(ctx context.Context, name, uploadURL, filePath string, metadata map[string]string) error {
+	if err := validateMetadataKeys(keysOf(metadata), allowedUploadMetadata, "FinishUpload"); err != nil {
+		return err
+	}
+	a.Logger.Info("Uploading MOD file", "mod", name, "file", filePath, "metadata_count", len(metadata))
+	if _, err := a.Uploader.Upload(ctx, uploadURL, filePath, metadata, ""); err != nil {
+		return err
+	}
+	a.Logger.Info("Upload completed successfully", "mod", name)
+	a.notifyChanged(ctx, name)
+	return nil
+}
+
+// EditMetadata is the metadata accepted by EditDetails. Only non-zero
+// fields are sent; Deprecated needs the pointer to distinguish "unset"
+// from "set to false".
+type EditMetadata struct {
+	Description string
+	Summary     string
+	Title       string
+	Category    string
+	Tags        []string
+	License     string
+	Homepage    string
+	SourceURL   string
+	FAQ         string
+	Deprecated  *bool
+}
+
+func (m EditMetadata) formValues() url.Values {
+	values := url.Values{}
+	set := func(key, value string) {
+		if value != "" {
+			values.Set(key, value)
+		}
+	}
+	set("description", m.Description)
+	set("summary", m.Summary)
+	set("title", m.Title)
+	set("category", m.Category)
+	for _, tag := range m.Tags {
+		values.Add("tags", tag)
+	}
+	set("license", m.License)
+	set("homepage", m.Homepage)
+	set("source_url", m.SourceURL)
+	set("faq", m.FAQ)
+	if m.Deprecated != nil {
+		values.Set("deprecated", strconv.FormatBool(*m.Deprecated))
+	}
+	return values
+}
+
+// EditDetails updates a MOD's metadata on the portal.
+func (a *MODManagementAPI) EditDetails(ctx context.Context, name string, metadata EditMetadata) error {
+	form := metadata.formValues()
+	a.Logger.Info("Editing MOD details", "mod", name, "fields", len(form))
+	form.Set("mod", name)
+
+	if _, err := a.postForm(ctx, "/api/v2/mods/edit_details", form); err != nil {
+		return mapNotFound(err, name)
+	}
+	a.Logger.Info("Edit completed successfully", "mod", name)
+	a.notifyChanged(ctx, name)
+	return nil
+}
+
+// InitImageUpload starts an image upload and returns the upload URL.
+func (a *MODManagementAPI) InitImageUpload(ctx context.Context, name string) (string, error) {
+	a.Logger.Info("Initializing image upload", "mod", name)
+	uploadURL, err := a.initUpload(ctx, "/api/v2/mods/images/add", name)
+	if err != nil {
+		return "", mapNotFound(err, name)
+	}
+	return uploadURL, nil
+}
+
+// FinishImageUpload uploads the image to the URL from InitImageUpload and
+// returns the created image.
+func (a *MODManagementAPI) FinishImageUpload(ctx context.Context, name, uploadURL, imagePath string) (Image, error) {
+	a.Logger.Info("Uploading image file", "mod", name, "file", imagePath)
+	body, err := a.Uploader.Upload(ctx, uploadURL, imagePath, nil, "image")
+	if err != nil {
+		return Image{}, err
+	}
+	var image Image
+	if err := json.Unmarshal(body, &image); err != nil {
+		return Image{}, fmt.Errorf("%w: %s", ErrInvalidResponse, err)
+	}
+	a.Logger.Info("Image upload completed successfully", "mod", name, "image_id", image.ID)
+	a.notifyChanged(ctx, name)
+	return image, nil
+}
+
+// EditImages replaces the MOD's image list with the given IDs, in order.
+func (a *MODManagementAPI) EditImages(ctx context.Context, name string, imageIDs []string) error {
+	form := url.Values{}
+	form.Set("mod", name)
+	form.Set("images", strings.Join(imageIDs, ","))
+
+	a.Logger.Info("Editing MOD images", "mod", name, "image_count", len(imageIDs))
+	if _, err := a.postForm(ctx, "/api/v2/mods/images/edit", form); err != nil {
+		return mapNotFound(err, name)
+	}
+	a.Logger.Info("Images updated successfully", "mod", name)
+	a.notifyChanged(ctx, name)
+	return nil
+}
+
+func (a *MODManagementAPI) initUpload(ctx context.Context, endpoint, name string) (string, error) {
+	form := url.Values{}
+	form.Set("mod", name)
+	resp, err := a.postForm(ctx, endpoint, form)
+	if err != nil {
+		return "", err
+	}
+	var result struct {
+		UploadURL string `json:"upload_url"`
+	}
+	if err := json.Unmarshal(resp.Body, &result); err != nil {
+		return "", fmt.Errorf("%w: %s", ErrInvalidResponse, err)
+	}
+	if result.UploadURL == "" {
+		return "", fmt.Errorf("%w: missing upload_url", ErrInvalidResponse)
+	}
+	return result.UploadURL, nil
+}
+
+func (a *MODManagementAPI) postForm(ctx context.Context, endpoint string, form url.Values) (*httpx.Response, error) {
+	credential, err := a.Credentials()
+	if err != nil {
+		return nil, err
+	}
+	header := http.Header{}
+	header.Set("Authorization", "Bearer "+credential.APIKey())
+	header.Set("Content-Type", "application/x-www-form-urlencoded")
+	return a.Client.Request(ctx, http.MethodPost, a.BaseURL+endpoint, header, strings.NewReader(form.Encode()))
+}
+
+func (a *MODManagementAPI) notifyChanged(ctx context.Context, name string) {
+	if a.OnMODChanged != nil {
+		a.OnMODChanged(ctx, name)
+	}
+}
+
+func mapNotFound(err error, name string) error {
+	var statusErr *httpx.StatusError
+	if errors.As(err, &statusErr) && statusErr.IsNotFound() {
+		return fmt.Errorf("%w: %s", ErrMODNotOnPortal, name)
+	}
+	return err
+}
+
+func validateMetadataKeys(keys, allowed []string, context string) error {
+	for _, key := range keys {
+		if !slices.Contains(allowed, key) {
+			return fmt.Errorf("%w: invalid metadata for %s: %s (allowed: %v)", ErrInvalidArgument, context, key, allowed)
+		}
+	}
+	return nil
+}
+
+func keysOf(m map[string]string) []string {
+	keys := make([]string, 0, len(m))
+	for key := range m {
+		keys = append(keys, key)
+	}
+	return keys
+}

--- a/internal/api/management_test.go
+++ b/internal/api/management_test.go
@@ -1,0 +1,153 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"net/url"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sakuro/factorix/internal/httpx"
+)
+
+type fakeUploader struct {
+	uploadURL string
+	filePath  string
+	fields    map[string]string
+	fieldName string
+	response  []byte
+}
+
+func (f *fakeUploader) Upload(_ context.Context, uploadURL, filePath string, fields map[string]string, fieldName string) ([]byte, error) {
+	f.uploadURL = uploadURL
+	f.filePath = filePath
+	f.fields = fields
+	f.fieldName = fieldName
+	return f.response, nil
+}
+
+func testAPIKey() func() (APICredential, error) {
+	return func() (APICredential, error) {
+		return APICredential{apiKey: "key-123"}, nil
+	}
+}
+
+func newManagementAPI(t *testing.T, uploader Uploader, handler http.HandlerFunc) *MODManagementAPI {
+	t.Helper()
+	server := httptest.NewTLSServer(handler)
+	t.Cleanup(server.Close)
+	client := httpx.NewClient(httpx.Options{Transport: server.Client().Transport})
+	managementAPI := NewMODManagementAPI(client, uploader, testAPIKey(), nil)
+	managementAPI.BaseURL = server.URL
+	return managementAPI
+}
+
+func TestInitUpload(t *testing.T) {
+	var gotAuth, gotPath string
+	var gotForm url.Values
+	managementAPI := newManagementAPI(t, nil, func(w http.ResponseWriter, r *http.Request) {
+		gotAuth = r.Header.Get("Authorization")
+		gotPath = r.URL.Path
+		require.NoError(t, r.ParseForm())
+		gotForm = r.PostForm
+		w.Write([]byte(`{"upload_url": "https://uploads.example.com/abc"}`))
+	})
+
+	uploadURL, err := managementAPI.InitUpload(context.Background(), "test-mod")
+	require.NoError(t, err)
+	assert.Equal(t, "https://uploads.example.com/abc", uploadURL)
+	assert.Equal(t, "Bearer key-123", gotAuth)
+	assert.Equal(t, "/api/v2/mods/releases/init_upload", gotPath)
+	assert.Equal(t, "test-mod", gotForm.Get("mod"))
+}
+
+func TestInitUploadNotFound(t *testing.T) {
+	managementAPI := newManagementAPI(t, nil, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	_, err := managementAPI.InitUpload(context.Background(), "missing-mod")
+	require.ErrorIs(t, err, ErrMODNotOnPortal)
+}
+
+func TestFinishUpload(t *testing.T) {
+	uploader := &fakeUploader{response: []byte(`{}`)}
+	managementAPI := NewMODManagementAPI(nil, uploader, testAPIKey(), nil)
+
+	var changed []string
+	managementAPI.OnMODChanged = func(_ context.Context, name string) {
+		changed = append(changed, name)
+	}
+
+	metadata := map[string]string{"description": "desc", "license": "MIT"}
+	err := managementAPI.FinishUpload(context.Background(), "test-mod", "https://uploads.example.com/abc", "/tmp/test-mod_1.0.0.zip", metadata)
+	require.NoError(t, err)
+
+	assert.Equal(t, "https://uploads.example.com/abc", uploader.uploadURL)
+	assert.Equal(t, "/tmp/test-mod_1.0.0.zip", uploader.filePath)
+	assert.Equal(t, metadata, uploader.fields)
+	assert.Equal(t, []string{"test-mod"}, changed)
+}
+
+func TestFinishUploadRejectsInvalidMetadata(t *testing.T) {
+	managementAPI := NewMODManagementAPI(nil, &fakeUploader{}, testAPIKey(), nil)
+
+	err := managementAPI.FinishUpload(context.Background(), "test-mod", "https://uploads.example.com/abc", "/tmp/x.zip",
+		map[string]string{"summary": "not allowed on upload"})
+	require.ErrorIs(t, err, ErrInvalidArgument)
+}
+
+func TestEditDetails(t *testing.T) {
+	var gotForm url.Values
+	managementAPI := newManagementAPI(t, nil, func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, r.ParseForm())
+		gotForm = r.PostForm
+		w.Write([]byte(`{}`))
+	})
+
+	var changed []string
+	managementAPI.OnMODChanged = func(_ context.Context, name string) {
+		changed = append(changed, name)
+	}
+
+	deprecated := true
+	err := managementAPI.EditDetails(context.Background(), "test-mod", EditMetadata{
+		Title:      "New Title",
+		Tags:       []string{"combat", "storage"},
+		Deprecated: &deprecated,
+	})
+	require.NoError(t, err)
+
+	assert.Equal(t, "test-mod", gotForm.Get("mod"))
+	assert.Equal(t, "New Title", gotForm.Get("title"))
+	assert.Equal(t, []string{"combat", "storage"}, gotForm["tags"])
+	assert.Equal(t, "true", gotForm.Get("deprecated"))
+	assert.NotContains(t, gotForm, "summary")
+	assert.Equal(t, []string{"test-mod"}, changed)
+}
+
+func TestFinishImageUpload(t *testing.T) {
+	uploader := &fakeUploader{response: []byte(`{"id": "abc123", "url": "https://assets/img.png", "thumbnail": "https://assets/thumb.png"}`)}
+	managementAPI := NewMODManagementAPI(nil, uploader, testAPIKey(), nil)
+
+	image, err := managementAPI.FinishImageUpload(context.Background(), "test-mod", "https://uploads.example.com/img", "/tmp/shot.png")
+	require.NoError(t, err)
+	assert.Equal(t, "abc123", image.ID)
+	assert.Equal(t, "image", uploader.fieldName)
+}
+
+func TestEditImages(t *testing.T) {
+	var gotForm url.Values
+	managementAPI := newManagementAPI(t, nil, func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, r.ParseForm())
+		gotForm = r.PostForm
+		w.Write([]byte(`{}`))
+	})
+
+	err := managementAPI.EditImages(context.Background(), "test-mod", []string{"aaa", "bbb"})
+	require.NoError(t, err)
+	assert.Equal(t, "aaa,bbb", gotForm.Get("images"))
+}

--- a/internal/api/portal.go
+++ b/internal/api/portal.go
@@ -1,0 +1,199 @@
+package api
+
+import (
+	"context"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/url"
+	"slices"
+	"strconv"
+
+	"github.com/sakuro/factorix/internal/cache"
+	"github.com/sakuro/factorix/internal/httpx"
+)
+
+// DefaultPortalBaseURL is the MOD Portal endpoint.
+const DefaultPortalBaseURL = "https://mods.factorio.com"
+
+// MODPortalAPI retrieves MOD lists and details. No authentication is
+// required; response caching is provided by the client's CacheTransport,
+// and Cache is used to invalidate entries after portal-changing operations.
+type MODPortalAPI struct {
+	Client  *httpx.Client
+	Cache   cache.Cache
+	Logger  *slog.Logger
+	BaseURL string
+}
+
+// NewMODPortalAPI builds a portal client with the default base URL.
+func NewMODPortalAPI(client *httpx.Client, apiCache cache.Cache, logger *slog.Logger) *MODPortalAPI {
+	if logger == nil {
+		logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	}
+	return &MODPortalAPI{Client: client, Cache: apiCache, Logger: logger, BaseURL: DefaultPortalBaseURL}
+}
+
+// GetMODsOptions filters and pages the MOD list.
+type GetMODsOptions struct {
+	Namelist       []string
+	HideDeprecated *bool
+	Page           int    // 0 = unset
+	PageSize       string // "", a positive integer, or "max"
+	Sort           string // "", name, created_at, updated_at
+	SortOrder      string // "", asc, desc
+	Version        string // "", or a Factorio version like "2.0"
+}
+
+var (
+	validSorts    = []string{"name", "created_at", "updated_at"}
+	validOrders   = []string{"asc", "desc"}
+	validVersions = []string{"0.13", "0.14", "0.15", "0.16", "0.17", "0.18", "1.0", "1.1", "2.0"}
+)
+
+func (o GetMODsOptions) validate() error {
+	if o.PageSize != "" && o.PageSize != "max" {
+		if n, err := strconv.Atoi(o.PageSize); err != nil || n <= 0 {
+			return fmt.Errorf("%w: page_size must be a positive integer or \"max\", got %q", ErrInvalidArgument, o.PageSize)
+		}
+	}
+	if o.Sort != "" && !slices.Contains(validSorts, o.Sort) {
+		return fmt.Errorf("%w: sort must be one of %v, got %q", ErrInvalidArgument, validSorts, o.Sort)
+	}
+	if o.SortOrder != "" && !slices.Contains(validOrders, o.SortOrder) {
+		return fmt.Errorf("%w: sort_order must be one of %v, got %q", ErrInvalidArgument, validOrders, o.SortOrder)
+	}
+	if o.Version != "" && !slices.Contains(validVersions, o.Version) {
+		return fmt.Errorf("%w: version must be one of %v, got %q", ErrInvalidArgument, validVersions, o.Version)
+	}
+	return nil
+}
+
+// query builds the sorted query string; url.Values.Encode sorts keys, which
+// keeps cache keys stable for equivalent requests.
+func (o GetMODsOptions) query() string {
+	params := url.Values{}
+	namelist := slices.Clone(o.Namelist)
+	slices.Sort(namelist)
+	for _, name := range namelist {
+		params.Add("namelist", name)
+	}
+	if o.HideDeprecated != nil {
+		params.Set("hide_deprecated", strconv.FormatBool(*o.HideDeprecated))
+	}
+	if o.Page > 0 {
+		params.Set("page", strconv.Itoa(o.Page))
+	}
+	if o.PageSize != "" {
+		params.Set("page_size", o.PageSize)
+	}
+	if o.Sort != "" {
+		params.Set("sort", o.Sort)
+	}
+	if o.SortOrder != "" {
+		params.Set("sort_order", o.SortOrder)
+	}
+	if o.Version != "" {
+		params.Set("version", o.Version)
+	}
+	return params.Encode()
+}
+
+// GetMODs retrieves one page of the MOD list.
+func (a *MODPortalAPI) GetMODs(ctx context.Context, opts GetMODsOptions) (*MODsPage, error) {
+	if err := opts.validate(); err != nil {
+		return nil, err
+	}
+	requestURL := a.BaseURL + "/api/mods"
+	if query := opts.query(); query != "" {
+		requestURL += "?" + query
+	}
+	a.Logger.Debug("Fetching MOD list", "url", requestURL)
+
+	var page MODsPage
+	if err := a.getJSON(ctx, requestURL, &page); err != nil {
+		return nil, err
+	}
+	for i := range page.Results {
+		a.pruneInvalidReleases(&page.Results[i])
+	}
+	return &page, nil
+}
+
+// GetMOD retrieves basic information for a MOD (the short endpoint).
+func (a *MODPortalAPI) GetMOD(ctx context.Context, name string) (*MODInfo, error) {
+	return a.getMOD(ctx, name, a.modURL(name))
+}
+
+// GetMODFull retrieves full information for a MOD, including the detail
+// fields.
+func (a *MODPortalAPI) GetMODFull(ctx context.Context, name string) (*MODInfo, error) {
+	return a.getMOD(ctx, name, a.modFullURL(name))
+}
+
+func (a *MODPortalAPI) getMOD(ctx context.Context, name, requestURL string) (*MODInfo, error) {
+	a.Logger.Debug("Fetching MOD", "name", name, "url", requestURL)
+	var info MODInfo
+	if err := a.getJSON(ctx, requestURL, &info); err != nil {
+		var statusErr *httpx.StatusError
+		if errors.As(err, &statusErr) && statusErr.IsNotFound() {
+			return nil, fmt.Errorf("%w: %s", ErrMODNotOnPortal, name)
+		}
+		return nil, err
+	}
+	a.pruneInvalidReleases(&info)
+	return &info, nil
+}
+
+// InvalidateMODCache removes the cached short and full responses for a MOD,
+// typically after it changed on the portal. Wired as MODManagementAPI's
+// OnMODChanged callback.
+func (a *MODPortalAPI) InvalidateMODCache(ctx context.Context, name string) error {
+	for _, key := range []string{a.modURL(name), a.modFullURL(name)} {
+		err := a.Cache.WithLock(ctx, key, func() error {
+			_, err := a.Cache.Delete(ctx, key)
+			return err
+		})
+		if err != nil {
+			return err
+		}
+	}
+	a.Logger.Debug("Invalidated cache for MOD", "mod", name)
+	return nil
+}
+
+func (a *MODPortalAPI) modURL(name string) string {
+	return a.BaseURL + "/api/mods/" + url.PathEscape(name)
+}
+
+func (a *MODPortalAPI) modFullURL(name string) string {
+	return a.modURL(name) + "/full"
+}
+
+func (a *MODPortalAPI) getJSON(ctx context.Context, requestURL string, target any) error {
+	resp, err := a.Client.Get(ctx, requestURL)
+	if err != nil {
+		return err
+	}
+	if err := json.Unmarshal(resp.Body, target); err != nil {
+		return fmt.Errorf("%w: %s", ErrInvalidResponse, err)
+	}
+	return nil
+}
+
+// pruneInvalidReleases drops releases whose version could not be
+// represented; a MOD with such a release should still be usable.
+func (a *MODPortalAPI) pruneInvalidReleases(info *MODInfo) {
+	info.Releases = slices.DeleteFunc(info.Releases, func(r Release) bool {
+		if r.versionInvalid {
+			a.Logger.Warn("Skipping release with unsupported version", "mod", info.Name, "version", r.rawVersion)
+		}
+		return r.versionInvalid
+	})
+	if info.LatestRelease != nil && info.LatestRelease.versionInvalid {
+		a.Logger.Warn("Skipping latest release with unsupported version", "mod", info.Name, "version", info.LatestRelease.rawVersion)
+		info.LatestRelease = nil
+	}
+}

--- a/internal/api/portal_test.go
+++ b/internal/api/portal_test.go
@@ -1,0 +1,141 @@
+package api
+
+import (
+	"context"
+	"net/http"
+	"net/http/httptest"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sakuro/factorix/internal/httpx"
+	"github.com/sakuro/factorix/internal/mod"
+)
+
+const sampleMODJSON = `{
+	"name": "test-mod",
+	"title": "Test MOD",
+	"owner": "someone",
+	"summary": "A test",
+	"downloads_count": 42,
+	"category": "content",
+	"score": 12.3,
+	"thumbnail": "/assets/thumb.png",
+	"releases": [
+		{
+			"download_url": "/download/test-mod/aaa",
+			"file_name": "test-mod_1.0.0.zip",
+			"info_json": {"factorio_version": "2.0", "dependencies": ["base"]},
+			"released_at": "2024-06-01T12:00:00.000000Z",
+			"version": "1.0.0",
+			"sha1": "da39a3ee5e6b4b0d3255bfef95601890afd80709"
+		},
+		{
+			"download_url": "/download/test-mod/bbb",
+			"file_name": "test-mod_2019.11.20.zip",
+			"info_json": {"factorio_version": "2.0"},
+			"released_at": "2024-06-02T12:00:00.000000Z",
+			"version": "2019.11.20",
+			"sha1": "da39a3ee5e6b4b0d3255bfef95601890afd80709"
+		}
+	]
+}`
+
+func newPortalAPI(t *testing.T, handler http.HandlerFunc) *MODPortalAPI {
+	t.Helper()
+	server := httptest.NewTLSServer(handler)
+	t.Cleanup(server.Close)
+	client := httpx.NewClient(httpx.Options{Transport: server.Client().Transport})
+	portalAPI := NewMODPortalAPI(client, nil, nil)
+	portalAPI.BaseURL = server.URL
+	return portalAPI
+}
+
+func TestGetMOD(t *testing.T) {
+	var requestedPath string
+	portalAPI := newPortalAPI(t, func(w http.ResponseWriter, r *http.Request) {
+		requestedPath = r.URL.Path
+		w.Write([]byte(sampleMODJSON))
+	})
+
+	info, err := portalAPI.GetMOD(context.Background(), "test-mod")
+	require.NoError(t, err)
+
+	assert.Equal(t, "/api/mods/test-mod", requestedPath)
+	assert.Equal(t, "test-mod", info.Name)
+	assert.Equal(t, 42, info.DownloadsCount)
+	assert.Equal(t, "https://assets-mod.factorio.com/assets/thumb.png", info.ThumbnailURL())
+
+	// The 2019.11.20 release has version components over 255 and is dropped.
+	require.Len(t, info.Releases, 1)
+	assert.Equal(t, mod.MODVersion{Major: 1}, info.Releases[0].Version)
+	assert.Equal(t, []string{"base"}, info.Releases[0].InfoJSON.Dependencies)
+	assert.Equal(t, 2024, info.Releases[0].ReleasedAt.Year())
+}
+
+func TestGetMODNotFound(t *testing.T) {
+	portalAPI := newPortalAPI(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	_, err := portalAPI.GetMOD(context.Background(), "missing-mod")
+	require.ErrorIs(t, err, ErrMODNotOnPortal)
+	assert.Contains(t, err.Error(), "missing-mod")
+}
+
+func TestGetMODEscapesName(t *testing.T) {
+	var requestedURI string
+	portalAPI := newPortalAPI(t, func(w http.ResponseWriter, r *http.Request) {
+		requestedURI = r.URL.RequestURI()
+		w.Write([]byte(sampleMODJSON))
+	})
+
+	_, err := portalAPI.GetMODFull(context.Background(), "Mod With Spaces")
+	require.NoError(t, err)
+	assert.Equal(t, "/api/mods/Mod%20With%20Spaces/full", requestedURI)
+}
+
+func TestGetMODs(t *testing.T) {
+	var query string
+	portalAPI := newPortalAPI(t, func(w http.ResponseWriter, r *http.Request) {
+		query = r.URL.RawQuery
+		w.Write([]byte(`{"results": [` + sampleMODJSON + `], "pagination": {"count": 1, "page": 1, "page_count": 1, "page_size": 25}}`))
+	})
+
+	hide := true
+	page, err := portalAPI.GetMODs(context.Background(), GetMODsOptions{
+		Namelist:       []string{"zzz", "aaa"},
+		HideDeprecated: &hide,
+		Page:           2,
+		PageSize:       "25",
+		Sort:           "updated_at",
+		SortOrder:      "desc",
+		Version:        "2.0",
+	})
+	require.NoError(t, err)
+
+	// Query parameters are sorted and the namelist itself is sorted.
+	assert.Equal(t, "hide_deprecated=true&namelist=aaa&namelist=zzz&page=2&page_size=25&sort=updated_at&sort_order=desc&version=2.0", query)
+	require.Len(t, page.Results, 1)
+	assert.Equal(t, 1, page.Pagination.Count)
+}
+
+func TestGetMODsValidation(t *testing.T) {
+	portalAPI := NewMODPortalAPI(nil, nil, nil)
+	ctx := context.Background()
+
+	for _, opts := range []GetMODsOptions{
+		{PageSize: "0"},
+		{PageSize: "many"},
+		{Sort: "downloads"},
+		{SortOrder: "up"},
+		{Version: "3.0"},
+	} {
+		_, err := portalAPI.GetMODs(ctx, opts)
+		require.ErrorIs(t, err, ErrInvalidArgument, "%+v", opts)
+	}
+
+	// "max" is a valid page size but requires a server; validation alone passes.
+	require.NoError(t, GetMODsOptions{PageSize: "max"}.validate())
+}

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -1,0 +1,122 @@
+// Package api implements the Factorio MOD Portal and game download API
+// clients.
+//
+// See https://wiki.factorio.com/Mod_portal_API
+package api
+
+import (
+	"encoding/json"
+	"time"
+
+	"github.com/sakuro/factorix/internal/mod"
+)
+
+// License describes a MOD license.
+type License struct {
+	ID          string `json:"id"`
+	Name        string `json:"name"`
+	Title       string `json:"title"`
+	Description string `json:"description"`
+	URL         string `json:"url"`
+}
+
+// Image is one entry of a MOD's image gallery.
+type Image struct {
+	ID        string `json:"id"`
+	Thumbnail string `json:"thumbnail"`
+	URL       string `json:"url"`
+}
+
+// ReleaseInfoJSON is the subset of info.json the portal includes per release.
+type ReleaseInfoJSON struct {
+	FactorioVersion string   `json:"factorio_version"`
+	Dependencies    []string `json:"dependencies"`
+}
+
+// Release is one version of a MOD published on the portal.
+type Release struct {
+	DownloadURL  string          `json:"download_url"` // relative path
+	FileName     string          `json:"file_name"`
+	InfoJSON     ReleaseInfoJSON `json:"info_json"`
+	ReleasedAt   time.Time       `json:"released_at"`
+	Version      mod.MODVersion  `json:"-"`
+	SHA1         string          `json:"sha1"`
+	FeatureFlags []string        `json:"feature_flags"`
+
+	// versionInvalid marks releases whose version string cannot be
+	// represented (components over 255 — such MODs exist on the Portal).
+	// The API clients drop them after decoding.
+	versionInvalid bool
+	rawVersion     string
+}
+
+// UnmarshalJSON decodes a release, tolerating out-of-range version strings
+// so a single odd release does not fail the whole MOD.
+func (r *Release) UnmarshalJSON(data []byte) error {
+	type alias Release
+	raw := struct {
+		*alias
+		Version string `json:"version"`
+	}{alias: (*alias)(r)}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	r.rawVersion = raw.Version
+	version, err := mod.ParseMODVersion(raw.Version)
+	if err != nil {
+		r.versionInvalid = true
+		return nil
+	}
+	r.Version = version
+	return nil
+}
+
+// Pagination describes the paging of a MOD list response.
+type Pagination struct {
+	Count     int `json:"count"`
+	Page      int `json:"page"`
+	PageCount int `json:"page_count"`
+	PageSize  int `json:"page_size"`
+}
+
+// MODInfo is MOD metadata from the portal. The detail fields (Changelog
+// through Deprecated) are only populated by the full endpoint.
+type MODInfo struct {
+	Name           string    `json:"name"`
+	Title          string    `json:"title"`
+	Owner          string    `json:"owner"`
+	Summary        string    `json:"summary"`
+	DownloadsCount int       `json:"downloads_count"`
+	Category       string    `json:"category"`
+	Score          float64   `json:"score"`
+	Thumbnail      string    `json:"thumbnail"` // relative asset path
+	LatestRelease  *Release  `json:"latest_release"`
+	Releases       []Release `json:"releases"`
+
+	Changelog         string    `json:"changelog"`
+	CreatedAt         time.Time `json:"created_at"`
+	UpdatedAt         time.Time `json:"updated_at"`
+	LastHighlightedAt time.Time `json:"last_highlighted_at"`
+	Description       string    `json:"description"`
+	SourceURL         string    `json:"source_url"`
+	Homepage          string    `json:"homepage"`
+	FAQ               string    `json:"faq"`
+	Tags              []string  `json:"tags"`
+	License           *License  `json:"license"`
+	Images            []Image   `json:"images"`
+	Deprecated        bool      `json:"deprecated"`
+}
+
+// ThumbnailURL returns the absolute thumbnail URL, or "" when absent.
+func (m *MODInfo) ThumbnailURL() string {
+	if m.Thumbnail == "" {
+		return ""
+	}
+	return "https://assets-mod.factorio.com" + m.Thumbnail
+}
+
+// MODsPage is one page of a MOD list response.
+type MODsPage struct {
+	Results    []MODInfo  `json:"results"`
+	Pagination Pagination `json:"pagination"`
+}

--- a/internal/httpx/client.go
+++ b/internal/httpx/client.go
@@ -17,11 +17,13 @@ import (
 
 const maxRedirects = 10
 
-// Response is a fully-read HTTP response.
+// Response is a fully-read HTTP response. URL is the final URL after
+// redirects.
 type Response struct {
 	StatusCode int
 	Header     http.Header
 	Body       []byte
+	URL        *url.URL
 }
 
 // Options configures a Client.
@@ -110,6 +112,12 @@ func (c *Client) Do(ctx context.Context, method, rawURL string, header http.Head
 	return c.hc.Do(req)
 }
 
+// Request executes a request and returns the buffered response, mapping
+// non-2xx statuses to StatusError.
+func (c *Client) Request(ctx context.Context, method, rawURL string, header http.Header, body io.Reader) (*Response, error) {
+	return c.buffered(ctx, method, rawURL, header, body)
+}
+
 // Get executes a GET request and returns the buffered response.
 func (c *Client) Get(ctx context.Context, rawURL string) (*Response, error) {
 	return c.buffered(ctx, http.MethodGet, rawURL, nil, nil)
@@ -160,7 +168,7 @@ func (c *Client) buffered(ctx context.Context, method, rawURL string, header htt
 		c.logger.Error("HTTP error response", "status", resp.Status, "error", err)
 		return nil, err
 	}
-	return &Response{StatusCode: resp.StatusCode, Header: resp.Header, Body: data}, nil
+	return &Response{StatusCode: resp.StatusCode, Header: resp.Header, Body: data, URL: resp.Request.URL}, nil
 }
 
 func (c *Client) statusError(resp *http.Response, body []byte) *StatusError {

--- a/lib/factorix/cli/commands/launch.rb
+++ b/lib/factorix/cli/commands/launch.rb
@@ -51,7 +51,7 @@ module Factorix
         def call(wait: false, args: [], **)
           logger.info("Launching Factorio", args:)
 
-          async = args.none? {|arg| SYNCHRONOUS_OPTIONS.include?(arg) }
+          async = !args.intersect?(SYNCHRONOUS_OPTIONS)
 
           runtime.launch(*args, async:)
           logger.info("Factorio launched successfully", async:)


### PR DESCRIPTION
## Summary
Phase 7 of the Go migration roadmap: the MOD Portal, download, game-download, and management API clients with credentials.

## Changes
- `types.go`: `MODInfo`/`Release`/`Image`/`License` as JSON-tagged structs; a release whose version has components over 255 is dropped after decoding with a warning instead of failing the whole MOD (the Ruby `rescue RangeError` guard no longer matches since errors became `VersionParseError`, so such a release would actually crash Ruby — the Go version implements the original intent)
- `portal.go`: `GetMODs` (validated filters, sorted query for stable cache keys), `GetMOD`/`GetMODFull` (404 → `ErrMODNotOnPortal`), and `InvalidateMODCache`. Since Go decodes JSON straight into typed structs, the Ruby `Portal` facade's conversion role disappears; its upload orchestration moves to Phase 10
- `download.go`/`game_download.go`: authenticated download-URL builders (username/token), latest-release lookup, and redirect-based filename resolution; the actual streaming download is Phase 8
- `management.go`: init/finish upload, edit details (tags as repeated params, tri-state `deprecated`), image add/edit — all behind Bearer auth with an `OnMODChanged` callback replacing the dry-events subscription; file uploads go through an `Uploader` interface that `internal/transfer` implements in Phase 8
- `credential.go`: `ServiceCredential` (env pair or `player-data.json`; setting only one env var is an error) and `APICredential` (`FACTORIO_API_KEY`), lazily resolved and masked in string rendering
- `httpx`: add `Client.Request` (custom headers, for Bearer auth) and the final post-redirect URL on `Response`

## Test Plan
- `go build ./... && go vet ./... && go test ./...` pass locally
- API clients are tested against `httptest.NewTLSServer` (query shape, auth header, form fields, 404 mapping, release pruning); credentials cover env/player-data/partial-env cases and masking
