### PR TITLE
:sparkles: Implement downloader and uploader (Phase 8)

### DIFF
--- a/doc/go-migration-roadmap.md
+++ b/doc/go-migration-roadmap.md
@@ -367,14 +367,19 @@ All API response types are plain structs with JSON tags.
 
 **Goal:** Download and upload MOD files with progress reporting.
 
-- [ ] `internal/transfer/downloader.go`
-  - Check cache → stream to cache on miss
-  - SHA1 verification
-  - Fire `ProgressListener` events
+- [x] `internal/transfer/downloader.go`
+  - Check cache → stream to cache on miss (cache lock serializes concurrent
+    downloads of the same URL)
+  - SHA1 verification, including invalidation of corrupted cache entries
+  - Fire `progress.Listener` events (cache hits synthesize start/update/finish;
+    the Ruby `on_cache_hit` method is not needed)
   - Strip auth params from cache key
-  - Parallel downloads via `errgroup` + mpb multi-bar
-- [ ] `internal/transfer/uploader.go`
-  - Multipart form upload with progress
+  - Parallel downloads (errgroup) and mpb presentation live with the
+    `mod install`/`update` commands in Phase 10
+- [x] `internal/transfer/uploader.go`
+  - Multipart form upload with progress, staged in a temporary file so large
+    ZIPs never sit in memory; the body is not replayable, so uploads run
+    exactly once (no transport retry — upload URLs are one-shot anyway)
 
 ---
 

--- a/internal/progress/progress.go
+++ b/internal/progress/progress.go
@@ -1,0 +1,36 @@
+// Package progress defines the listener interface for transfer and scan
+// progress. Terminal presentation (mpb bars) arrives with the CLI commands.
+package progress
+
+// Listener receives progress events. Implementations must tolerate
+// OnStart being called again after OnFinish: a retried transfer restarts
+// its progress.
+type Listener interface {
+	// OnStart reports the total size in bytes; -1 when unknown.
+	OnStart(total int64)
+	// OnProgress reports the bytes transferred so far.
+	OnProgress(current int64)
+	// OnFinish reports completion.
+	OnFinish()
+}
+
+// Start calls OnStart when the listener is non-nil.
+func Start(l Listener, total int64) {
+	if l != nil {
+		l.OnStart(total)
+	}
+}
+
+// Update calls OnProgress when the listener is non-nil.
+func Update(l Listener, current int64) {
+	if l != nil {
+		l.OnProgress(current)
+	}
+}
+
+// Finish calls OnFinish when the listener is non-nil.
+func Finish(l Listener) {
+	if l != nil {
+		l.OnFinish()
+	}
+}

--- a/internal/transfer/downloader.go
+++ b/internal/transfer/downloader.go
@@ -1,0 +1,196 @@
+// Package transfer downloads and uploads files with caching and progress
+// reporting.
+package transfer
+
+import (
+	"context"
+	"crypto/sha1"
+	"encoding/hex"
+	"fmt"
+	"io"
+	"log/slog"
+	"net/url"
+	"os"
+	"path/filepath"
+
+	"github.com/sakuro/factorix/internal/cache"
+	"github.com/sakuro/factorix/internal/httpx"
+	"github.com/sakuro/factorix/internal/progress"
+)
+
+// Downloader downloads files with caching. Concurrent downloads of the same
+// URL are serialized by the cache lock, so only one process fetches while
+// the others wait and then hit the cache.
+type Downloader struct {
+	Cache  cache.Cache
+	Client *httpx.Client // retry only; caching is handled here, not by CacheTransport
+	Logger *slog.Logger
+}
+
+// NewDownloader builds a downloader.
+func NewDownloader(c cache.Cache, client *httpx.Client, logger *slog.Logger) *Downloader {
+	if logger == nil {
+		logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	}
+	return &Downloader{Cache: c, Client: client, Logger: logger}
+}
+
+// DownloadOptions modify a download.
+type DownloadOptions struct {
+	// ExpectedSHA1 enables digest verification of both cached and freshly
+	// downloaded content.
+	ExpectedSHA1 string
+	Listener     progress.Listener
+}
+
+// Download fetches rawURL to the output path, serving from the cache when
+// possible. A cached file failing SHA1 verification is invalidated and
+// re-downloaded.
+func (d *Downloader) Download(ctx context.Context, rawURL, output string, opts DownloadOptions) error {
+	cacheKey, err := stripQuery(rawURL)
+	if err != nil {
+		return err
+	}
+	d.Logger.Info("Starting download", "output", output)
+
+	hit, err := d.tryCacheHit(ctx, cacheKey, output, opts)
+	if err != nil {
+		return err
+	}
+	if hit {
+		return nil
+	}
+	d.Logger.Debug("Cache miss, downloading", "output", output)
+
+	return d.Cache.WithLock(ctx, cacheKey, func() error {
+		// Another process may have completed the download while we waited.
+		hit, err := d.tryCacheHit(ctx, cacheKey, output, opts)
+		if err != nil || hit {
+			return err
+		}
+
+		tempDir, err := os.MkdirTemp("", "factorix-download")
+		if err != nil {
+			return err
+		}
+		defer os.RemoveAll(tempDir)
+		tempFile := filepath.Join(tempDir, "download")
+
+		if err := d.downloadWithProgress(ctx, rawURL, tempFile, opts.Listener); err != nil {
+			return err
+		}
+		if opts.ExpectedSHA1 != "" {
+			if err := verifySHA1(tempFile, opts.ExpectedSHA1); err != nil {
+				return err
+			}
+		}
+		if _, err := d.Cache.Store(ctx, cacheKey, tempFile); err != nil {
+			return err
+		}
+		// Copy from the temp file, not the cache, so a store skipped by a
+		// size limit still produces the output.
+		return copyFile(tempFile, output)
+	})
+}
+
+// tryCacheHit writes cached content to output. On a SHA1 mismatch the entry
+// is invalidated and (false, nil) is returned to trigger a re-download.
+func (d *Downloader) tryCacheHit(ctx context.Context, cacheKey, output string, opts DownloadOptions) (bool, error) {
+	found, err := d.Cache.WriteTo(ctx, cacheKey, output)
+	if err != nil || !found {
+		return false, err
+	}
+	d.Logger.Info("Cache hit", "output", output)
+
+	if opts.ExpectedSHA1 != "" {
+		if err := verifySHA1(output, opts.ExpectedSHA1); err != nil {
+			d.Logger.Warn("Cache corrupted, invalidating", "output", output, "error", err)
+			if _, deleteErr := d.Cache.Delete(ctx, cacheKey); deleteErr != nil {
+				return false, deleteErr
+			}
+			return false, nil
+		}
+	}
+
+	if info, err := os.Stat(output); err == nil {
+		progress.Start(opts.Listener, info.Size())
+		progress.Update(opts.Listener, info.Size())
+		progress.Finish(opts.Listener)
+	}
+	return true, nil
+}
+
+func (d *Downloader) downloadWithProgress(ctx context.Context, rawURL, output string, listener progress.Listener) error {
+	resp, err := d.Client.GetStream(ctx, rawURL)
+	if err != nil {
+		return err
+	}
+	defer resp.Body.Close()
+
+	progress.Start(listener, resp.ContentLength) // -1 when unknown
+
+	file, err := os.Create(output)
+	if err != nil {
+		return err
+	}
+	defer file.Close()
+
+	counter := &countingWriter{listener: listener}
+	if _, err := io.Copy(io.MultiWriter(file, counter), resp.Body); err != nil {
+		return err
+	}
+	if err := file.Close(); err != nil {
+		return err
+	}
+	progress.Finish(listener)
+	return nil
+}
+
+// countingWriter forwards the cumulative byte count to the listener.
+type countingWriter struct {
+	listener progress.Listener
+	current  int64
+}
+
+func (w *countingWriter) Write(p []byte) (int, error) {
+	w.current += int64(len(p))
+	progress.Update(w.listener, w.current)
+	return len(p), nil
+}
+
+func verifySHA1(path, expected string) error {
+	f, err := os.Open(path)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	h := sha1.New()
+	if _, err := io.Copy(h, f); err != nil {
+		return err
+	}
+	actual := hex.EncodeToString(h.Sum(nil))
+	if actual != expected {
+		return fmt.Errorf("%w: expected %s, got %s", ErrDigestMismatch, expected, actual)
+	}
+	return nil
+}
+
+// stripQuery removes the query from the URL so credentials (username/token)
+// never end up in cache keys or metadata.
+func stripQuery(rawURL string) (string, error) {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return "", err
+	}
+	u.RawQuery = ""
+	return u.String(), nil
+}
+
+func copyFile(src, dst string) error {
+	data, err := os.ReadFile(src)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(dst, data, 0o644)
+}

--- a/internal/transfer/downloader_test.go
+++ b/internal/transfer/downloader_test.go
@@ -1,0 +1,131 @@
+package transfer
+
+import (
+	"context"
+	"crypto/sha1"
+	"encoding/hex"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sakuro/factorix/internal/cache"
+	"github.com/sakuro/factorix/internal/httpx"
+)
+
+type recordingListener struct {
+	started  []int64
+	progress []int64
+	finished int
+}
+
+func (l *recordingListener) OnStart(total int64)      { l.started = append(l.started, total) }
+func (l *recordingListener) OnProgress(current int64) { l.progress = append(l.progress, current) }
+func (l *recordingListener) OnFinish()                { l.finished++ }
+
+func sha1Hex(data string) string {
+	sum := sha1.Sum([]byte(data))
+	return hex.EncodeToString(sum[:])
+}
+
+func newDownloader(t *testing.T, handler http.HandlerFunc) (*Downloader, *httptest.Server) {
+	t.Helper()
+	server := httptest.NewTLSServer(handler)
+	t.Cleanup(server.Close)
+	fs, err := cache.NewFileSystem(filepath.Join(t.TempDir(), "download"), cache.FileSystemOptions{})
+	require.NoError(t, err)
+	client := httpx.NewClient(httpx.Options{Transport: server.Client().Transport})
+	return NewDownloader(fs, client, nil), server
+}
+
+func TestDownload(t *testing.T) {
+	calls := 0
+	downloader, server := newDownloader(t, func(w http.ResponseWriter, r *http.Request) {
+		calls++
+		// The auth query must reach the server but stay out of the cache key.
+		assert.Equal(t, "tok", r.URL.Query().Get("token"))
+		w.Write([]byte("mod-content"))
+	})
+
+	ctx := context.Background()
+	listener := &recordingListener{}
+	output := filepath.Join(t.TempDir(), "mod.zip")
+
+	err := downloader.Download(ctx, server.URL+"/download/mod?username=alice&token=tok", output,
+		DownloadOptions{ExpectedSHA1: sha1Hex("mod-content"), Listener: listener})
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(output)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("mod-content"), data)
+	assert.Equal(t, 1, calls)
+	require.NotEmpty(t, listener.started)
+	assert.Equal(t, int64(11), listener.started[0])
+	assert.Equal(t, 1, listener.finished)
+
+	// Second download of the same path (even with different credentials)
+	// is served from the cache.
+	listener2 := &recordingListener{}
+	output2 := filepath.Join(t.TempDir(), "mod2.zip")
+	err = downloader.Download(ctx, server.URL+"/download/mod?username=bob&token=other", output2,
+		DownloadOptions{Listener: listener2})
+	require.NoError(t, err)
+	assert.Equal(t, 1, calls, "second download must hit the cache")
+
+	data, err = os.ReadFile(output2)
+	require.NoError(t, err)
+	assert.Equal(t, []byte("mod-content"), data)
+	assert.Equal(t, []int64{11}, listener2.started)
+	assert.Equal(t, 1, listener2.finished)
+}
+
+func TestDownloadSHA1Mismatch(t *testing.T) {
+	downloader, server := newDownloader(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte("tampered"))
+	})
+
+	err := downloader.Download(context.Background(), server.URL+"/download/mod",
+		filepath.Join(t.TempDir(), "mod.zip"),
+		DownloadOptions{ExpectedSHA1: sha1Hex("legit")})
+	require.ErrorIs(t, err, ErrDigestMismatch)
+}
+
+func TestDownloadCorruptedCacheIsInvalidated(t *testing.T) {
+	content := "good-content"
+	downloader, server := newDownloader(t, func(w http.ResponseWriter, r *http.Request) {
+		w.Write([]byte(content))
+	})
+	ctx := context.Background()
+
+	// Prime the cache with corrupted content under the download's cache key.
+	corrupted := filepath.Join(t.TempDir(), "src")
+	require.NoError(t, os.WriteFile(corrupted, []byte("corrupted"), 0o644))
+	stored, err := downloader.Cache.Store(ctx, server.URL+"/download/mod", corrupted)
+	require.NoError(t, err)
+	require.True(t, stored)
+
+	output := filepath.Join(t.TempDir(), "mod.zip")
+	err = downloader.Download(ctx, server.URL+"/download/mod", output,
+		DownloadOptions{ExpectedSHA1: sha1Hex(content)})
+	require.NoError(t, err)
+
+	data, err := os.ReadFile(output)
+	require.NoError(t, err)
+	assert.Equal(t, []byte(content), data)
+}
+
+func TestDownloadHTTPError(t *testing.T) {
+	downloader, server := newDownloader(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusNotFound)
+	})
+
+	err := downloader.Download(context.Background(), server.URL+"/download/missing",
+		filepath.Join(t.TempDir(), "mod.zip"), DownloadOptions{})
+	var statusErr *httpx.StatusError
+	require.ErrorAs(t, err, &statusErr)
+	assert.True(t, statusErr.IsNotFound())
+}

--- a/internal/transfer/errors.go
+++ b/internal/transfer/errors.go
@@ -1,0 +1,5 @@
+package transfer
+
+import "errors"
+
+var ErrDigestMismatch = errors.New("SHA1 digest mismatch")

--- a/internal/transfer/uploader.go
+++ b/internal/transfer/uploader.go
@@ -1,0 +1,167 @@
+package transfer
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"mime/multipart"
+	"net/http"
+	"net/textproto"
+	"net/url"
+	"os"
+	"path/filepath"
+	"sort"
+	"strings"
+
+	"github.com/sakuro/factorix/internal/httpx"
+	"github.com/sakuro/factorix/internal/progress"
+)
+
+var mimeTypes = map[string]string{
+	".zip":  "application/zip",
+	".png":  "image/png",
+	".jpg":  "image/jpeg",
+	".jpeg": "image/jpeg",
+	".gif":  "image/gif",
+}
+
+const defaultMIMEType = "application/octet-stream"
+
+// Uploader posts files as multipart/form-data. It implements the api.Uploader
+// interface. The multipart body is staged in a temporary file so arbitrarily
+// large MOD ZIPs never sit in memory; the body is not replayable, so the
+// retry transport performs uploads exactly once.
+type Uploader struct {
+	Client *httpx.Client
+	Logger *slog.Logger
+	// Listener receives progress for uploads performed by this Uploader.
+	// It is a field rather than a parameter because the api.Uploader
+	// interface knows nothing about progress; the CLI sets it per command.
+	Listener progress.Listener
+}
+
+// NewUploader builds an uploader.
+func NewUploader(client *httpx.Client, logger *slog.Logger) *Uploader {
+	if logger == nil {
+		logger = slog.New(slog.NewTextHandler(io.Discard, nil))
+	}
+	return &Uploader{Client: client, Logger: logger}
+}
+
+// Upload posts the file to uploadURL with the given extra form fields.
+// fieldName is the file's form field; empty means "file". It returns the
+// response body.
+func (u *Uploader) Upload(ctx context.Context, uploadURL, filePath string, fields map[string]string, fieldName string) ([]byte, error) {
+	if fieldName == "" {
+		fieldName = "file"
+	}
+	u.Logger.Info("Uploading file", "url", httpx.MaskURL(mustParseForLog(uploadURL), []string{"username", "token", "secure"}), "file", filePath)
+
+	body, size, err := u.buildMultipartFile(filePath, fields, fieldName)
+	if err != nil {
+		return nil, err
+	}
+	defer os.Remove(body.Name())
+	defer body.Close()
+
+	progress.Start(u.Listener, size)
+	reader := io.TeeReader(body, &countingWriter{listener: u.Listener})
+
+	header := http.Header{}
+	header.Set("Content-Type", body.contentType)
+
+	resp, err := u.Client.Request(ctx, http.MethodPost, uploadURL, header, reader)
+	if err != nil {
+		return nil, err
+	}
+	progress.Finish(u.Listener)
+	u.Logger.Info("Upload completed", "file", filePath)
+	return resp.Body, nil
+}
+
+// multipartFile is the staged multipart body with its content type.
+type multipartFile struct {
+	*os.File
+	contentType string
+}
+
+// buildMultipartFile stages the complete multipart body in a temporary file
+// and returns it positioned at the start, along with its total size.
+func (u *Uploader) buildMultipartFile(filePath string, fields map[string]string, fieldName string) (*multipartFile, int64, error) {
+	file, err := os.Open(filePath)
+	if err != nil {
+		return nil, 0, err
+	}
+	defer file.Close()
+
+	tmp, err := os.CreateTemp("", "factorix-upload")
+	if err != nil {
+		return nil, 0, err
+	}
+	cleanup := func() {
+		tmp.Close()
+		os.Remove(tmp.Name())
+	}
+
+	writer := multipart.NewWriter(tmp)
+
+	// Deterministic field order keeps requests reproducible.
+	names := make([]string, 0, len(fields))
+	for name := range fields {
+		names = append(names, name)
+	}
+	sort.Strings(names)
+	for _, name := range names {
+		if err := writer.WriteField(name, fields[name]); err != nil {
+			cleanup()
+			return nil, 0, err
+		}
+	}
+
+	partHeader := textproto.MIMEHeader{}
+	partHeader.Set("Content-Disposition",
+		fmt.Sprintf(`form-data; name=%q; filename=%q`, fieldName, filepath.Base(filePath)))
+	partHeader.Set("Content-Type", detectContentType(filePath))
+	part, err := writer.CreatePart(partHeader)
+	if err != nil {
+		cleanup()
+		return nil, 0, err
+	}
+	if _, err := io.Copy(part, file); err != nil {
+		cleanup()
+		return nil, 0, err
+	}
+	if err := writer.Close(); err != nil {
+		cleanup()
+		return nil, 0, err
+	}
+
+	size, err := tmp.Seek(0, io.SeekEnd)
+	if err != nil {
+		cleanup()
+		return nil, 0, err
+	}
+	if _, err := tmp.Seek(0, io.SeekStart); err != nil {
+		cleanup()
+		return nil, 0, err
+	}
+	return &multipartFile{File: tmp, contentType: writer.FormDataContentType()}, size, nil
+}
+
+func detectContentType(filePath string) string {
+	if mimeType, ok := mimeTypes[strings.ToLower(filepath.Ext(filePath))]; ok {
+		return mimeType
+	}
+	return defaultMIMEType
+}
+
+// mustParseForLog parses the URL for masking; on failure the raw string is
+// not logged at all.
+func mustParseForLog(rawURL string) *url.URL {
+	u, err := url.Parse(rawURL)
+	if err != nil {
+		return &url.URL{}
+	}
+	return u
+}

--- a/internal/transfer/uploader_test.go
+++ b/internal/transfer/uploader_test.go
@@ -1,0 +1,112 @@
+package transfer
+
+import (
+	"context"
+	"io"
+	"net/http"
+	"net/http/httptest"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sakuro/factorix/internal/api"
+	"github.com/sakuro/factorix/internal/httpx"
+)
+
+// The Uploader must satisfy the interface the management API consumes.
+var _ api.Uploader = (*Uploader)(nil)
+
+func newUploader(t *testing.T, handler http.HandlerFunc) (*Uploader, *httptest.Server) {
+	t.Helper()
+	server := httptest.NewTLSServer(handler)
+	t.Cleanup(server.Close)
+	client := httpx.NewClient(httpx.Options{Transport: server.Client().Transport})
+	return NewUploader(client, nil), server
+}
+
+func modZip(t *testing.T) string {
+	t.Helper()
+	path := filepath.Join(t.TempDir(), "test-mod_1.0.0.zip")
+	require.NoError(t, os.WriteFile(path, []byte("zip-bytes"), 0o644))
+	return path
+}
+
+func TestUpload(t *testing.T) {
+	var gotFields map[string]string
+	var gotFileName, gotFileContentType, gotFileBody string
+	uploader, server := newUploader(t, func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, r.ParseMultipartForm(1<<20))
+		gotFields = map[string]string{}
+		for name, values := range r.MultipartForm.Value {
+			gotFields[name] = values[0]
+		}
+		file, header, err := r.FormFile("file")
+		require.NoError(t, err)
+		defer file.Close()
+		body, err := io.ReadAll(file)
+		require.NoError(t, err)
+		gotFileName = header.Filename
+		gotFileContentType = header.Header.Get("Content-Type")
+		gotFileBody = string(body)
+		w.Write([]byte(`{"success": true}`))
+	})
+
+	listener := &recordingListener{}
+	uploader.Listener = listener
+
+	body, err := uploader.Upload(context.Background(), server.URL+"/upload", modZip(t),
+		map[string]string{"description": "A MOD", "license": "MIT"}, "")
+	require.NoError(t, err)
+
+	assert.JSONEq(t, `{"success": true}`, string(body))
+	assert.Equal(t, map[string]string{"description": "A MOD", "license": "MIT"}, gotFields)
+	assert.Equal(t, "test-mod_1.0.0.zip", gotFileName)
+	assert.Equal(t, "application/zip", gotFileContentType)
+	assert.Equal(t, "zip-bytes", gotFileBody)
+
+	require.NotEmpty(t, listener.started)
+	assert.Positive(t, listener.started[0])
+	assert.Equal(t, 1, listener.finished)
+}
+
+func TestUploadCustomFieldName(t *testing.T) {
+	uploader, server := newUploader(t, func(w http.ResponseWriter, r *http.Request) {
+		require.NoError(t, r.ParseMultipartForm(1<<20))
+		_, _, err := r.FormFile("image")
+		assert.NoError(t, err)
+		w.Write([]byte(`{}`))
+	})
+
+	imagePath := filepath.Join(t.TempDir(), "shot.png")
+	require.NoError(t, os.WriteFile(imagePath, []byte("png-bytes"), 0o644))
+
+	_, err := uploader.Upload(context.Background(), server.URL+"/upload", imagePath, nil, "image")
+	require.NoError(t, err)
+}
+
+func TestUploadMissingFile(t *testing.T) {
+	uploader := NewUploader(nil, nil)
+	_, err := uploader.Upload(context.Background(), "https://example.com/upload",
+		filepath.Join(t.TempDir(), "absent.zip"), nil, "")
+	require.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestUploadServerError(t *testing.T) {
+	uploader, server := newUploader(t, func(w http.ResponseWriter, r *http.Request) {
+		w.WriteHeader(http.StatusBadRequest)
+	})
+
+	_, err := uploader.Upload(context.Background(), server.URL+"/upload", modZip(t), nil, "")
+	var statusErr *httpx.StatusError
+	require.ErrorAs(t, err, &statusErr)
+	assert.True(t, statusErr.IsClientError())
+}
+
+func TestDetectContentType(t *testing.T) {
+	assert.Equal(t, "application/zip", detectContentType("mod.ZIP"))
+	assert.Equal(t, "image/jpeg", detectContentType("photo.jpeg"))
+	assert.Equal(t, "application/octet-stream", detectContentType("data.bin"))
+}


### PR DESCRIPTION
## Summary
Phase 8 of the Go migration roadmap: the caching downloader and multipart uploader with progress reporting.

## Changes
- `internal/progress`: the `Listener` interface (`OnStart`/`OnProgress`/`OnFinish`, total -1 when unknown) with nil-safe helpers; the Ruby `on_cache_hit` method disappears — the downloader synthesizes a full start/update/finish sequence on cache hits. mpb presentation and errgroup-parallel downloads arrive with the Phase 10 commands
- `internal/transfer/downloader.go`: cache-first download with the cache lock serializing concurrent fetches of the same URL, SHA1 verification of both cached and fresh content (corrupted entries are invalidated and re-downloaded), credentials stripped from cache keys, and output written from the temp file rather than the cache so a size-limit-skipped store still produces the file (a latent Ruby gap)
- `internal/transfer/uploader.go`: multipart/form-data upload implementing `api.Uploader`. The body is staged in a temporary file so large MOD ZIPs never sit in memory; as a consequence it is not replayable and uploads run exactly once (Ruby retried uploads, but upload URLs are one-shot, so a blind retry is questionable anyway). The progress listener is a struct field because the `api.Uploader` interface knows nothing about progress

## Test Plan
- `go build ./... && go vet ./... && go test ./...` pass locally
- Downloader tests cover cache hit/miss, credential stripping (server sees the token, the cache key does not), SHA1 mismatch, corrupted-cache recovery, and progress events; uploader tests parse the multipart body server-side (fields, filename, per-part content type)
