### PR TITLE
:sparkles: Implement blueprint and changelog handling (Phase 9)

### DIFF
--- a/doc/go-migration-roadmap.md
+++ b/doc/go-migration-roadmap.md
@@ -387,10 +387,12 @@ All API response types are plain structs with JSON tags.
 
 **Goal:** Features independent of the MOD Portal pipeline.
 
-- [ ] `internal/blueprint/blueprint.go` — blueprint string encode/decode
-  (version byte + base64 + zlib + JSON)
-- [ ] `internal/changelog/changelog.go` — parse/manipulate Factorio `changelog.txt`
-  (sections, categories, entry add/check/extract/release)
+- [x] `internal/blueprint/blueprint.go` — blueprint string encode/decode
+  (version byte + base64 + zlib + JSON); the JSON text is kept verbatim so
+  key order survives decode/encode round trips
+- [x] `internal/changelog/changelog.go` — parse/manipulate Factorio `changelog.txt`
+  (hand-rolled line parser replacing Parslet; sections, ordered categories,
+  entry add / release; check/extract are command-level concerns in Phase 10)
 
 ---
 

--- a/internal/blueprint/blueprint.go
+++ b/internal/blueprint/blueprint.go
@@ -1,0 +1,92 @@
+// Package blueprint encodes and decodes Factorio blueprint strings
+// (a version byte followed by Base64-encoded zlib-compressed JSON).
+package blueprint
+
+import (
+	"bytes"
+	"compress/zlib"
+	"encoding/base64"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"io"
+)
+
+// The only supported version byte.
+const supportedVersion = '0'
+
+var (
+	ErrUnsupportedVersion = errors.New("unsupported blueprint version")
+	ErrFormat             = errors.New("invalid blueprint")
+)
+
+// Blueprint holds the blueprint's JSON. The original text is kept as-is so
+// key order survives a decode/encode round trip.
+type Blueprint struct {
+	json []byte
+}
+
+// Decode parses a blueprint string.
+func Decode(s string) (*Blueprint, error) {
+	if len(s) == 0 || s[0] != supportedVersion {
+		version := "(empty)"
+		if len(s) > 0 {
+			version = string(s[0])
+		}
+		return nil, fmt.Errorf("%w: %s", ErrUnsupportedVersion, version)
+	}
+
+	compressed, err := base64.StdEncoding.DecodeString(s[1:])
+	if err != nil {
+		return nil, fmt.Errorf("%w: invalid Base64 encoding: %s", ErrFormat, err)
+	}
+	r, err := zlib.NewReader(bytes.NewReader(compressed))
+	if err != nil {
+		return nil, fmt.Errorf("%w: invalid zlib data: %s", ErrFormat, err)
+	}
+	defer r.Close()
+	jsonData, err := io.ReadAll(r)
+	if err != nil {
+		return nil, fmt.Errorf("%w: invalid zlib data: %s", ErrFormat, err)
+	}
+	return FromJSON(jsonData)
+}
+
+// FromJSON builds a Blueprint from JSON content.
+func FromJSON(data []byte) (*Blueprint, error) {
+	if !json.Valid(data) {
+		return nil, fmt.Errorf("%w: invalid JSON", ErrFormat)
+	}
+	return &Blueprint{json: data}, nil
+}
+
+// Encode renders the blueprint string.
+func (b *Blueprint) Encode() (string, error) {
+	var compact bytes.Buffer
+	if err := json.Compact(&compact, b.json); err != nil {
+		return "", fmt.Errorf("%w: %s", ErrFormat, err)
+	}
+
+	var compressed bytes.Buffer
+	w, err := zlib.NewWriterLevel(&compressed, zlib.BestCompression)
+	if err != nil {
+		return "", err
+	}
+	if _, err := w.Write(compact.Bytes()); err != nil {
+		return "", err
+	}
+	if err := w.Close(); err != nil {
+		return "", err
+	}
+	return string(supportedVersion) + base64.StdEncoding.EncodeToString(compressed.Bytes()), nil
+}
+
+// JSON renders the blueprint content as pretty-printed JSON, preserving the
+// original key order.
+func (b *Blueprint) JSON() ([]byte, error) {
+	var pretty bytes.Buffer
+	if err := json.Indent(&pretty, b.json, "", "  "); err != nil {
+		return nil, err
+	}
+	return pretty.Bytes(), nil
+}

--- a/internal/blueprint/blueprint_test.go
+++ b/internal/blueprint/blueprint_test.go
@@ -1,0 +1,58 @@
+package blueprint
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+const sampleJSON = `{"blueprint":{"item":"blueprint","label":"Test","entities":[{"entity_number":1,"name":"transport-belt"}],"version":281479275675648}}`
+
+func TestEncodeDecodeRoundTrip(t *testing.T) {
+	original, err := FromJSON([]byte(sampleJSON))
+	require.NoError(t, err)
+
+	encoded, err := original.Encode()
+	require.NoError(t, err)
+	assert.Equal(t, byte('0'), encoded[0])
+
+	decoded, err := Decode(encoded)
+	require.NoError(t, err)
+
+	// Key order survives the round trip because the JSON text is kept as-is.
+	reencoded, err := decoded.Encode()
+	require.NoError(t, err)
+	assert.Equal(t, encoded, reencoded)
+
+	pretty, err := decoded.JSON()
+	require.NoError(t, err)
+	assert.Contains(t, string(pretty), `"label": "Test"`)
+	assert.JSONEq(t, sampleJSON, string(pretty))
+}
+
+func TestDecodeUnsupportedVersion(t *testing.T) {
+	_, err := Decode("1eJyrVspLzE1VslIqSy0qzszPU9JRKkotzi8tSk4FyRmZ6BnrKtUCAKO6DK0=")
+	require.ErrorIs(t, err, ErrUnsupportedVersion)
+
+	_, err = Decode("")
+	require.ErrorIs(t, err, ErrUnsupportedVersion)
+}
+
+func TestDecodeInvalidBase64(t *testing.T) {
+	_, err := Decode("0!!!not-base64!!!")
+	require.ErrorIs(t, err, ErrFormat)
+	assert.Contains(t, err.Error(), "Base64")
+}
+
+func TestDecodeInvalidZlib(t *testing.T) {
+	// Valid Base64 of non-zlib bytes.
+	_, err := Decode("0aGVsbG8gd29ybGQ=")
+	require.ErrorIs(t, err, ErrFormat)
+	assert.Contains(t, err.Error(), "zlib")
+}
+
+func TestFromJSONInvalid(t *testing.T) {
+	_, err := FromJSON([]byte(`{"unclosed"`))
+	require.ErrorIs(t, err, ErrFormat)
+}

--- a/internal/changelog/changelog.go
+++ b/internal/changelog/changelog.go
@@ -1,0 +1,285 @@
+// Package changelog parses and manipulates Factorio changelog.txt files.
+//
+// See https://wiki.factorio.com/Tutorial:Mod_changelog_format
+package changelog
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"slices"
+	"strings"
+
+	"github.com/sakuro/factorix/internal/mod"
+)
+
+// Separator is the section separator line (99 dashes).
+var Separator = strings.Repeat("-", 99)
+
+// Unreleased is the version label of the unreleased section.
+const Unreleased = "Unreleased"
+
+var (
+	ErrParse            = errors.New("invalid changelog")
+	ErrInvalidArgument  = errors.New("invalid argument")
+	ErrInvalidOperation = errors.New("invalid operation")
+)
+
+// Category is one named group of entries within a section, in file order.
+type Category struct {
+	Name    string
+	Entries []string // multi-line entries contain "\n"
+}
+
+// Section is one version block of the changelog. A nil Version marks the
+// Unreleased section.
+type Section struct {
+	Version    *mod.MODVersion
+	Date       string
+	Categories []Category
+}
+
+// VersionLabel renders the version as it appears in the file.
+func (s *Section) VersionLabel() string {
+	if s.Version == nil {
+		return Unreleased
+	}
+	return s.Version.String()
+}
+
+func (s *Section) matches(version *mod.MODVersion) bool {
+	if version == nil || s.Version == nil {
+		return version == nil && s.Version == nil
+	}
+	return *s.Version == *version
+}
+
+func (s *Section) category(name string) *Category {
+	for i := range s.Categories {
+		if s.Categories[i].Name == name {
+			return &s.Categories[i]
+		}
+	}
+	return nil
+}
+
+// Changelog is an ordered list of sections, newest first.
+type Changelog struct {
+	sections []*Section
+}
+
+// New returns an empty changelog.
+func New() *Changelog {
+	return &Changelog{}
+}
+
+// Sections returns the sections, newest first.
+func (c *Changelog) Sections() []*Section {
+	return c.sections
+}
+
+// FindSection returns the section for the version (nil = Unreleased).
+func (c *Changelog) FindSection(version *mod.MODVersion) (*Section, bool) {
+	for _, section := range c.sections {
+		if section.matches(version) {
+			return section, true
+		}
+	}
+	return nil, false
+}
+
+// AddEntry appends an entry to the category of the version's section
+// (nil = Unreleased), creating the section at the top and the category at
+// the end as needed. Blank and duplicate entries are rejected.
+func (c *Changelog) AddEntry(version *mod.MODVersion, categoryName, entry string) error {
+	if strings.TrimSpace(entry) == "" {
+		return fmt.Errorf("%w: entry must not be blank", ErrInvalidArgument)
+	}
+
+	section, ok := c.FindSection(version)
+	if !ok {
+		section = &Section{Version: version}
+		c.sections = append([]*Section{section}, c.sections...)
+	}
+
+	category := section.category(categoryName)
+	if category == nil {
+		section.Categories = append(section.Categories, Category{Name: categoryName})
+		category = &section.Categories[len(section.Categories)-1]
+	}
+	if slices.Contains(category.Entries, entry) {
+		return fmt.Errorf("%w: duplicate entry: %s", ErrInvalidArgument, entry)
+	}
+	category.Entries = append(category.Entries, entry)
+	return nil
+}
+
+// ReleaseSection turns the leading Unreleased section into a released one
+// with the given version and date.
+func (c *Changelog) ReleaseSection(version mod.MODVersion, date string) error {
+	if len(c.sections) == 0 || c.sections[0].Version != nil {
+		return fmt.Errorf("%w: first section is not %s", ErrInvalidOperation, Unreleased)
+	}
+	if _, ok := c.FindSection(&version); ok {
+		return fmt.Errorf("%w: version %s already exists", ErrInvalidOperation, version)
+	}
+	c.sections[0].Version = &version
+	c.sections[0].Date = date
+	return nil
+}
+
+// String renders the changelog in the changelog.txt format.
+func (c *Changelog) String() string {
+	var b strings.Builder
+	for i, section := range c.sections {
+		if i > 0 {
+			b.WriteString("\n")
+		}
+		b.WriteString(Separator + "\n")
+		b.WriteString(formatSection(section))
+	}
+	b.WriteString("\n")
+	return b.String()
+}
+
+func formatSection(section *Section) string {
+	var lines []string
+	lines = append(lines, "Version: "+section.VersionLabel())
+	if section.Date != "" {
+		lines = append(lines, "Date: "+section.Date)
+	}
+	for _, category := range section.Categories {
+		lines = append(lines, "  "+category.Name+":")
+		for _, entry := range category.Entries {
+			entryLines := strings.Split(entry, "\n")
+			lines = append(lines, "    - "+entryLines[0])
+			for _, continuation := range entryLines[1:] {
+				lines = append(lines, "      "+continuation)
+			}
+		}
+	}
+	return strings.Join(lines, "\n")
+}
+
+// Load reads a changelog file; a missing file yields an empty changelog.
+func Load(path string) (*Changelog, error) {
+	data, err := os.ReadFile(path)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return New(), nil
+		}
+		return nil, err
+	}
+	return Parse(string(data))
+}
+
+// Save writes the changelog to a file.
+func (c *Changelog) Save(path string) error {
+	return os.WriteFile(path, []byte(c.String()), 0o644)
+}
+
+// parser walks the changelog line by line.
+type parser struct {
+	lines []string
+	pos   int
+}
+
+// Parse parses changelog.txt content.
+func Parse(text string) (*Changelog, error) {
+	// Normalize CRLF; the writer always emits LF.
+	text = strings.ReplaceAll(text, "\r\n", "\n")
+	p := &parser{lines: strings.Split(text, "\n")}
+	// strings.Split leaves a trailing empty element for text ending in \n.
+	if n := len(p.lines); n > 0 && p.lines[n-1] == "" {
+		p.lines = p.lines[:n-1]
+	}
+
+	var sections []*Section
+	for !p.done() {
+		section, err := p.parseSection()
+		if err != nil {
+			return nil, err
+		}
+		sections = append(sections, section)
+	}
+	if len(sections) == 0 {
+		return nil, fmt.Errorf("%w: no sections found", ErrParse)
+	}
+	return &Changelog{sections: sections}, nil
+}
+
+func (p *parser) done() bool {
+	return p.pos >= len(p.lines)
+}
+
+func (p *parser) peek() string {
+	return p.lines[p.pos]
+}
+
+func (p *parser) next() string {
+	line := p.lines[p.pos]
+	p.pos++
+	return line
+}
+
+func (p *parser) parseSection() (*Section, error) {
+	if p.done() || p.peek() != Separator {
+		return nil, fmt.Errorf("%w: line %d: expected separator", ErrParse, p.pos+1)
+	}
+	p.next()
+
+	if p.done() || !strings.HasPrefix(p.peek(), "Version: ") {
+		return nil, fmt.Errorf("%w: line %d: expected \"Version: \"", ErrParse, p.pos+1)
+	}
+	versionText := strings.TrimSpace(strings.TrimPrefix(p.next(), "Version: "))
+	section := &Section{}
+	if !strings.EqualFold(versionText, Unreleased) {
+		version, err := mod.ParseMODVersion(versionText)
+		if err != nil {
+			return nil, fmt.Errorf("%w: line %d: %s", ErrParse, p.pos, err)
+		}
+		section.Version = &version
+	}
+
+	if !p.done() && strings.HasPrefix(p.peek(), "Date: ") {
+		section.Date = strings.TrimSpace(strings.TrimPrefix(p.next(), "Date: "))
+	}
+
+	p.skipBlankLines()
+	for !p.done() && strings.HasPrefix(p.peek(), "  ") && strings.HasSuffix(p.peek(), ":") && !strings.HasPrefix(p.peek(), "    ") {
+		category, err := p.parseCategory()
+		if err != nil {
+			return nil, err
+		}
+		section.Categories = append(section.Categories, *category)
+	}
+	p.skipBlankLines()
+	return section, nil
+}
+
+func (p *parser) parseCategory() (*Category, error) {
+	line := p.next()
+	name := strings.TrimSuffix(strings.TrimPrefix(line, "  "), ":")
+	if name == "" {
+		return nil, fmt.Errorf("%w: line %d: empty category name", ErrParse, p.pos)
+	}
+	category := &Category{Name: name}
+
+	for !p.done() && strings.HasPrefix(p.peek(), "    - ") {
+		entryLines := []string{strings.TrimPrefix(p.next(), "    - ")}
+		for !p.done() && strings.HasPrefix(p.peek(), "      ") {
+			entryLines = append(entryLines, strings.TrimPrefix(p.next(), "      "))
+		}
+		category.Entries = append(category.Entries, strings.Join(entryLines, "\n"))
+	}
+	if len(category.Entries) == 0 {
+		return nil, fmt.Errorf("%w: line %d: category %q has no entries", ErrParse, p.pos, name)
+	}
+	return category, nil
+}
+
+func (p *parser) skipBlankLines() {
+	for !p.done() && strings.TrimSpace(p.peek()) == "" {
+		p.next()
+	}
+}

--- a/internal/changelog/changelog_test.go
+++ b/internal/changelog/changelog_test.go
@@ -1,0 +1,153 @@
+package changelog
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sakuro/factorix/internal/mod"
+)
+
+func fixture(t *testing.T, name string) string {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join("..", "..", "spec", "fixtures", "changelog", name))
+	require.NoError(t, err)
+	return string(data)
+}
+
+func versionPtr(major, minor, patch uint16) *mod.MODVersion {
+	v, err := mod.NewMODVersion(major, minor, patch)
+	if err != nil {
+		panic(err)
+	}
+	return &v
+}
+
+func TestParseBasic(t *testing.T) {
+	c, err := Parse(fixture(t, "basic.txt"))
+	require.NoError(t, err)
+
+	sections := c.Sections()
+	require.Len(t, sections, 2)
+	assert.Equal(t, "1.1.0", sections[0].VersionLabel())
+	assert.Equal(t, "1.0.0", sections[1].VersionLabel())
+
+	require.Len(t, sections[0].Categories, 2)
+	assert.Equal(t, "Features", sections[0].Categories[0].Name)
+	assert.Equal(t, []string{"Added new feature A", "Added new feature B"}, sections[0].Categories[0].Entries)
+	assert.Equal(t, "Bugfixes", sections[0].Categories[1].Name)
+}
+
+func TestParseWithDateAndUnreleased(t *testing.T) {
+	c, err := Parse(fixture(t, "with_date.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, "2025-01-15", c.Sections()[0].Date)
+
+	c, err = Parse(fixture(t, "with_unreleased.txt"))
+	require.NoError(t, err)
+	assert.Nil(t, c.Sections()[0].Version)
+	assert.Equal(t, Unreleased, c.Sections()[0].VersionLabel())
+
+	unreleased, ok := c.FindSection(nil)
+	require.True(t, ok)
+	assert.Equal(t, "Features", unreleased.Categories[0].Name)
+}
+
+func TestParseMultilineEntry(t *testing.T) {
+	c, err := Parse(fixture(t, "multiline_entry.txt"))
+	require.NoError(t, err)
+
+	entries := c.Sections()[0].Categories[0].Entries
+	require.Len(t, entries, 2)
+	assert.Equal(t, "Added a complex feature that spans\nmultiple lines of description", entries[0])
+	assert.Equal(t, "Simple entry", entries[1])
+}
+
+func TestRoundTrip(t *testing.T) {
+	for _, name := range []string{"basic.txt", "with_date.txt", "with_unreleased.txt", "multiline_entry.txt", "unreleased_not_first.txt", "wrong_order.txt"} {
+		t.Run(name, func(t *testing.T) {
+			text := fixture(t, name)
+			c, err := Parse(text)
+			require.NoError(t, err)
+			assert.Equal(t, text, c.String())
+		})
+	}
+}
+
+func TestParseErrors(t *testing.T) {
+	inputs := map[string]string{
+		"empty":             "",
+		"no separator":      "Version: 1.0.0\n",
+		"short separator":   "---\nVersion: 1.0.0\n",
+		"missing version":   Separator + "\nDate: 2024-01-01\n",
+		"bad version":       Separator + "\nVersion: not-a-version\n",
+		"category no entry": Separator + "\nVersion: 1.0.0\n  Features:\n",
+	}
+	for name, input := range inputs {
+		t.Run(name, func(t *testing.T) {
+			_, err := Parse(input)
+			require.ErrorIs(t, err, ErrParse, "input: %q", input)
+		})
+	}
+}
+
+func TestAddEntry(t *testing.T) {
+	c := New()
+
+	// Adding to a missing section creates it at the top.
+	require.NoError(t, c.AddEntry(nil, "Features", "New thing"))
+	require.NoError(t, c.AddEntry(nil, "Features", "Another thing"))
+	require.NoError(t, c.AddEntry(nil, "Bugfixes", "Fixed thing"))
+
+	unreleased, ok := c.FindSection(nil)
+	require.True(t, ok)
+	assert.Equal(t, []string{"New thing", "Another thing"}, unreleased.Categories[0].Entries)
+
+	err := c.AddEntry(nil, "Features", "New thing")
+	require.ErrorIs(t, err, ErrInvalidArgument) // duplicate
+
+	err = c.AddEntry(nil, "Features", "   ")
+	require.ErrorIs(t, err, ErrInvalidArgument) // blank
+}
+
+func TestReleaseSection(t *testing.T) {
+	c, err := Parse(fixture(t, "with_unreleased.txt"))
+	require.NoError(t, err)
+
+	require.NoError(t, c.ReleaseSection(*versionPtr(1, 1, 0), "2025-02-01"))
+	assert.Equal(t, "1.1.0", c.Sections()[0].VersionLabel())
+	assert.Equal(t, "2025-02-01", c.Sections()[0].Date)
+
+	// No Unreleased section anymore.
+	err = c.ReleaseSection(*versionPtr(1, 2, 0), "2025-03-01")
+	require.ErrorIs(t, err, ErrInvalidOperation)
+}
+
+func TestReleaseSectionExistingVersion(t *testing.T) {
+	c, err := Parse(fixture(t, "with_unreleased.txt"))
+	require.NoError(t, err)
+
+	err = c.ReleaseSection(*versionPtr(1, 0, 0), "2025-02-01")
+	require.ErrorIs(t, err, ErrInvalidOperation)
+}
+
+func TestLoadMissingFile(t *testing.T) {
+	c, err := Load(filepath.Join(t.TempDir(), "changelog.txt"))
+	require.NoError(t, err)
+	assert.Empty(t, c.Sections())
+}
+
+func TestSaveAndLoad(t *testing.T) {
+	c := New()
+	require.NoError(t, c.AddEntry(nil, "Features", "First"))
+
+	path := filepath.Join(t.TempDir(), "changelog.txt")
+	require.NoError(t, c.Save(path))
+
+	loaded, err := Load(path)
+	require.NoError(t, err)
+	assert.Equal(t, c.String(), loaded.String())
+}


### PR DESCRIPTION
## Summary
Phase 9 of the Go migration roadmap: blueprint string encoding/decoding and changelog.txt handling.

## Changes
- `internal/blueprint`: decode (version byte `0` + Base64 + zlib + JSON) and encode with best compression. The JSON is stored as verbatim text and pretty-printed via `json.Indent`, so key order survives decode/encode round trips — Go maps would randomize it, and Ruby preserved it via ordered Hashes
- `internal/changelog`: a hand-rolled line parser replacing Parslet, producing sections with ordered categories (Ruby used insertion-ordered Hashes); `AddEntry` (blank/duplicate rejection, creates sections at the top), `ReleaseSection` (Unreleased → versioned), and `String` rendering. The Unreleased section is modeled as a nil `*MODVersion` rather than a string/version union
- The `changelog check`/`extract` behaviors are command-level concerns and arrive with Phase 10

## Test Plan
- `go build ./... && go vet ./... && go test ./...` pass locally
- All six Ruby changelog fixtures parse and re-render byte-identically; blueprint tests cover the encode/decode round trip (including key order) and each malformed-input class
