### PR TITLE
:sparkles: Implement mod enable/disable commands (Phase 10b)

### DIFF
--- a/doc/go-migration-roadmap.md
+++ b/doc/go-migration-roadmap.md
@@ -416,7 +416,10 @@ than one pass over the full list below.
 
 #### Local MOD Management
 - [x] `mod list` — list installed MODs
-- [ ] `mod enable` / `mod disable` — recursively handle dependencies/dependents
+- [x] `mod enable` / `mod disable` — recursively handle dependencies/dependents
+      (planning logic lives in `internal/dependency` — `PlanEnable`,
+      `ValidateNoConflicts`, `PlanDisable`/`PlanDisableAll` — so the CLI layer
+      stays thin)
 - [x] `mod check` — validate dependency graph
 - [ ] `mod sync` — sync MOD states from a save file
 - [x] `mod settings dump` / `restore` — export/import `mod-settings.dat` (JSON)

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -2,6 +2,8 @@ package cli
 
 import (
 	"bytes"
+	"encoding/json"
+	"fmt"
 	"os"
 	"path/filepath"
 	"strings"
@@ -64,6 +66,65 @@ func (s *sandbox) copyDir(t *testing.T, from, to string) {
 	require.NoError(t, os.CopyFS(dest, os.DirFS(from)))
 }
 
+// writeInstalledMOD creates a directory-form installed MOD under
+// factorio/mods/<name> with the given version and dependency strings.
+func (s *sandbox) writeInstalledMOD(t *testing.T, name, version string, dependencies []string) {
+	t.Helper()
+	depsJSON, err := json.Marshal(dependencies)
+	require.NoError(t, err)
+	info := fmt.Sprintf(`{"name": %q, "version": %q, "title": %q, "author": "test", "dependencies": %s}`,
+		name, version, name, depsJSON)
+	dir := filepath.Join(s.root, "factorio", "mods", name)
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(dir, "info.json"), []byte(info), 0o644))
+}
+
+// modListEntry is one entry to write into mod-list.json via writeMODList.
+type modListEntry struct {
+	name    string
+	enabled bool
+	version string // "" omits the field, matching a MOD never explicitly versioned
+}
+
+func (s *sandbox) writeMODList(t *testing.T, entries ...modListEntry) {
+	t.Helper()
+	type entry struct {
+		Name    string `json:"name"`
+		Enabled bool   `json:"enabled"`
+		Version string `json:"version,omitempty"`
+	}
+	doc := struct {
+		Mods []entry `json:"mods"`
+	}{}
+	for _, e := range entries {
+		doc.Mods = append(doc.Mods, entry{Name: e.name, Enabled: e.enabled, Version: e.version})
+	}
+	data, err := json.MarshalIndent(doc, "", "  ")
+	require.NoError(t, err)
+	path := filepath.Join(s.root, "factorio", "mods", "mod-list.json")
+	require.NoError(t, os.WriteFile(path, data, 0o644))
+}
+
+// readMODList reads back mod-list.json as a name -> enabled map for
+// assertions.
+func (s *sandbox) readMODList(t *testing.T) map[string]bool {
+	t.Helper()
+	data, err := os.ReadFile(filepath.Join(s.root, "factorio", "mods", "mod-list.json"))
+	require.NoError(t, err)
+	var doc struct {
+		Mods []struct {
+			Name    string `json:"name"`
+			Enabled bool   `json:"enabled"`
+		} `json:"mods"`
+	}
+	require.NoError(t, json.Unmarshal(data, &doc))
+	result := map[string]bool{}
+	for _, m := range doc.Mods {
+		result[m.Name] = m.Enabled
+	}
+	return result
+}
+
 func e2eFile(elems ...string) string {
 	return filepath.Join(append([]string{"..", "..", "e2e", "cases"}, elems...)...)
 }
@@ -89,10 +150,18 @@ func setupMODListSandbox(t *testing.T) *sandbox {
 // invocation would print (and thus the e2e expected_stdout.txt fixtures).
 func runCLI(t *testing.T, args ...string) (string, error) {
 	t.Helper()
+	return runCLIWithStdin(t, "", args...)
+}
+
+// runCLIWithStdin is runCLI with an explicit stdin, for commands that
+// prompt for confirmation.
+func runCLIWithStdin(t *testing.T, stdin string, args ...string) (string, error) {
+	t.Helper()
 	root, reportError := NewRootCommand()
 	var out bytes.Buffer
 	root.SetOut(&out)
 	root.SetErr(&out)
+	root.SetIn(strings.NewReader(stdin))
 	root.SetArgs(args)
 	err := root.Execute()
 	if err != nil {

--- a/internal/cli/confirm.go
+++ b/internal/cli/confirm.go
@@ -1,0 +1,35 @@
+package cli
+
+import (
+	"bufio"
+	"errors"
+	"fmt"
+	"io"
+	"strings"
+
+	"github.com/spf13/cobra"
+)
+
+var errConfirmRequiresYes = errors.New("cannot prompt for confirmation in quiet mode; use --yes to proceed automatically")
+
+// confirm asks the user for a yes/no answer, matching Ruby's Confirmable
+// mixin: --yes skips the prompt, quiet mode without --yes is an error (a
+// suppressed prompt would otherwise hang or silently default), and only an
+// explicit "y"/"yes" (case-insensitive) counts as yes — anything else,
+// including EOF, is no.
+func confirm(cmd *cobra.Command, quiet, yes bool, message string) (bool, error) {
+	if yes {
+		return true, nil
+	}
+	if quiet {
+		return false, errConfirmRequiresYes
+	}
+
+	fmt.Fprintf(cmd.OutOrStdout(), "%s [y/N] ", message)
+	line, err := bufio.NewReader(cmd.InOrStdin()).ReadString('\n')
+	if err != nil && !errors.Is(err, io.EOF) {
+		return false, err
+	}
+	response := strings.ToLower(strings.TrimSpace(line))
+	return response == "y" || response == "yes", nil
+}

--- a/internal/cli/mod_disable.go
+++ b/internal/cli/mod_disable.go
@@ -1,0 +1,82 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/sakuro/factorix/internal/dependency"
+	"github.com/sakuro/factorix/internal/mod"
+)
+
+func newMODDisableCommand(c *cli) *cobra.Command {
+	var yes, all bool
+
+	cmd := &cobra.Command{
+		Use:   "disable [mod-name]...",
+		Short: "Disable MOD(s) in mod-list.json (recursively disables dependent MOD(s))",
+		Args:  cobra.ArbitraryArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if all && len(args) > 0 {
+				return fmt.Errorf("Cannot specify MOD names with --all option")
+			}
+			if !all && len(args) == 0 {
+				return fmt.Errorf("Must specify MOD names or use --all option")
+			}
+
+			application, err := c.App()
+			if err != nil {
+				return err
+			}
+			if err := application.RequireGameStopped(); err != nil {
+				return err
+			}
+
+			state, err := loadMODState(application)
+			if err != nil {
+				return err
+			}
+
+			p := c.printer(cmd)
+			var targets []mod.MOD
+			if all {
+				targets = dependency.PlanDisableAll(state.graph)
+			} else {
+				for _, name := range args {
+					m := mod.MOD{Name: name}
+					if m.IsBase() {
+						return fmt.Errorf("%w: %s", mod.ErrCannotDisableBaseMOD, m)
+					}
+					if !state.graph.Contains(m) {
+						p.Warn("MOD not installed, skipping: " + m.String())
+					}
+					targets = append(targets, m)
+				}
+			}
+
+			planned := dependency.PlanDisable(state.graph, targets)
+
+			if len(planned) == 0 {
+				p.Info("All specified MOD(s) are already disabled")
+				return nil
+			}
+			p.Info(fmt.Sprintf("Planning to disable %d MOD(s):", len(planned)))
+			for _, m := range planned {
+				p.Say("  - " + m.String())
+			}
+
+			confirmed, err := confirm(cmd, c.quiet, yes, "Do you want to disable these MOD(s)?")
+			if err != nil {
+				return err
+			}
+			if !confirmed {
+				return nil
+			}
+
+			return applyMODListChange(cmd, c, application, state, planned, "Disabled", (*mod.MODList).Disable)
+		},
+	}
+	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "Skip confirmation prompts")
+	cmd.Flags().BoolVar(&all, "all", false, "Disable all MOD(s) (except base)")
+	return cmd
+}

--- a/internal/cli/mod_enable.go
+++ b/internal/cli/mod_enable.go
@@ -1,0 +1,104 @@
+package cli
+
+import (
+	"fmt"
+
+	"github.com/spf13/cobra"
+
+	"github.com/sakuro/factorix/internal/app"
+	"github.com/sakuro/factorix/internal/dependency"
+	"github.com/sakuro/factorix/internal/mod"
+)
+
+func newMODEnableCommand(c *cli) *cobra.Command {
+	var yes bool
+
+	cmd := &cobra.Command{
+		Use:   "enable <mod-name>...",
+		Short: "Enable MOD(s) in mod-list.json (recursively enables dependencies)",
+		Args:  cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			application, err := c.App()
+			if err != nil {
+				return err
+			}
+			// Checked before any other work, matching Ruby's RequiresGameStopped
+			// (an outer wrapper that runs before the command body).
+			if err := application.RequireGameStopped(); err != nil {
+				return err
+			}
+
+			state, err := loadMODState(application)
+			if err != nil {
+				return err
+			}
+
+			targets := make([]mod.MOD, len(args))
+			for i, name := range args {
+				targets[i] = mod.MOD{Name: name}
+			}
+			for _, m := range targets {
+				if !state.graph.Contains(m) {
+					return fmt.Errorf("MOD '%s' is not installed", m)
+				}
+			}
+
+			planned, err := dependency.PlanEnable(state.graph, targets)
+			if err != nil {
+				return err
+			}
+			if err := dependency.ValidateNoConflicts(state.graph, planned); err != nil {
+				return err
+			}
+
+			p := c.printer(cmd)
+			if len(planned) == 0 {
+				p.Info("All specified MOD(s) are already enabled")
+				return nil
+			}
+			p.Info(fmt.Sprintf("Planning to enable %d MOD(s):", len(planned)))
+			for _, m := range planned {
+				p.Say("  - " + m.String())
+			}
+
+			confirmed, err := confirm(cmd, c.quiet, yes, "Do you want to enable these MOD(s)?")
+			if err != nil {
+				return err
+			}
+			if !confirmed {
+				return nil
+			}
+
+			return applyMODListChange(cmd, c, application, state, planned, "Enabled", (*mod.MODList).Enable)
+		},
+	}
+	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "Skip confirmation prompts")
+	return cmd
+}
+
+// applyMODListChange applies fn (MODList.Enable or MODList.Disable) to each
+// MOD in planned, reporting success per MOD, then backs up and saves
+// mod-list.json. This is the shared tail of the enable and disable commands.
+func applyMODListChange(cmd *cobra.Command, c *cli, application *app.App, state *modState, planned []mod.MOD, verb string, fn func(*mod.MODList, mod.MOD) error) error {
+	p := c.printer(cmd)
+	for _, m := range planned {
+		if err := fn(state.modList, m); err != nil {
+			return err
+		}
+		p.Success(verb + " " + m.String())
+	}
+
+	modListPath, err := application.Runtime.MODListPath()
+	if err != nil {
+		return err
+	}
+	if err := backupIfExists(modListPath); err != nil {
+		return err
+	}
+	if err := state.modList.Save(modListPath); err != nil {
+		return err
+	}
+	p.Success(fmt.Sprintf("%s %d MOD(s)", verb, len(planned)))
+	p.Success("Saved mod-list.json")
+	return nil
+}

--- a/internal/cli/mod_enable_disable_test.go
+++ b/internal/cli/mod_enable_disable_test.go
@@ -1,0 +1,200 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// baseSandbox sets up base (always enabled) plus the given MODs, listed in
+// mod-list.json in the given enabled state with no pinned version.
+func baseSandbox(t *testing.T) *sandbox {
+	t.Helper()
+	s := newSandbox(t)
+	s.copyFile(t, e2eFile("mod-list", "table", "files", "base-info.json"), "factorio/data/base/info.json")
+	return s
+}
+
+func TestMODEnableSimple(t *testing.T) {
+	s := baseSandbox(t)
+	s.writeInstalledMOD(t, "app", "1.0.0", []string{"lib"})
+	s.writeInstalledMOD(t, "lib", "1.0.0", nil)
+	s.writeMODList(t,
+		modListEntry{name: "base", enabled: true},
+		modListEntry{name: "app", enabled: false},
+		modListEntry{name: "lib", enabled: false},
+	)
+
+	out, err := runCLI(t, "mod", "enable", "app", "-y")
+	require.NoError(t, err)
+	assert.Equal(t, "ℹ Planning to enable 2 MOD(s):\n"+
+		"  - app\n"+
+		"  - lib\n"+
+		"✓ Enabled app\n"+
+		"✓ Enabled lib\n"+
+		"✓ Enabled 2 MOD(s)\n"+
+		"✓ Saved mod-list.json\n", out)
+
+	states := s.readMODList(t)
+	assert.True(t, states["app"])
+	assert.True(t, states["lib"])
+}
+
+func TestMODEnableAlreadyEnabled(t *testing.T) {
+	s := baseSandbox(t)
+	s.writeInstalledMOD(t, "app", "1.0.0", nil)
+	s.writeMODList(t, modListEntry{name: "base", enabled: true}, modListEntry{name: "app", enabled: true})
+
+	out, err := runCLI(t, "mod", "enable", "app")
+	require.NoError(t, err)
+	assert.Equal(t, "ℹ All specified MOD(s) are already enabled\n", out)
+}
+
+func TestMODEnableNotInstalled(t *testing.T) {
+	s := baseSandbox(t)
+	s.writeMODList(t, modListEntry{name: "base", enabled: true})
+
+	_, err := runCLI(t, "mod", "enable", "ghost")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "MOD 'ghost' is not installed")
+}
+
+func TestMODEnableMissingDependency(t *testing.T) {
+	s := baseSandbox(t)
+	s.writeInstalledMOD(t, "app", "1.0.0", []string{"missing-lib"})
+	s.writeMODList(t, modListEntry{name: "base", enabled: true}, modListEntry{name: "app", enabled: false})
+
+	_, err := runCLI(t, "mod", "enable", "app", "-y")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "MOD 'app' requires 'missing-lib' which is not installed")
+
+	// Nothing was saved: the plan failed before any changes.
+	assert.False(t, s.readMODList(t)["app"])
+}
+
+func TestMODEnableConflict(t *testing.T) {
+	s := baseSandbox(t)
+	s.writeInstalledMOD(t, "app", "1.0.0", []string{"! rival"})
+	s.writeInstalledMOD(t, "rival", "1.0.0", nil)
+	s.writeMODList(t,
+		modListEntry{name: "base", enabled: true},
+		modListEntry{name: "app", enabled: false},
+		modListEntry{name: "rival", enabled: true},
+	)
+
+	_, err := runCLI(t, "mod", "enable", "app", "-y")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "conflicts with rival which is currently enabled")
+}
+
+func TestMODEnablePromptAccept(t *testing.T) {
+	s := baseSandbox(t)
+	s.writeInstalledMOD(t, "app", "1.0.0", nil)
+	s.writeMODList(t, modListEntry{name: "base", enabled: true}, modListEntry{name: "app", enabled: false})
+
+	out, err := runCLIWithStdin(t, "y\n", "mod", "enable", "app")
+	require.NoError(t, err)
+	assert.Contains(t, out, "Do you want to enable these MOD(s)? [y/N] ")
+	assert.True(t, s.readMODList(t)["app"])
+}
+
+func TestMODEnablePromptDecline(t *testing.T) {
+	s := baseSandbox(t)
+	s.writeInstalledMOD(t, "app", "1.0.0", nil)
+	s.writeMODList(t, modListEntry{name: "base", enabled: true}, modListEntry{name: "app", enabled: false})
+
+	_, err := runCLIWithStdin(t, "n\n", "mod", "enable", "app")
+	require.NoError(t, err)
+	assert.False(t, s.readMODList(t)["app"])
+}
+
+func TestMODEnableQuietRequiresYes(t *testing.T) {
+	s := baseSandbox(t)
+	s.writeInstalledMOD(t, "app", "1.0.0", nil)
+	s.writeMODList(t, modListEntry{name: "base", enabled: true}, modListEntry{name: "app", enabled: false})
+
+	_, err := runCLI(t, "mod", "enable", "app", "-q")
+	require.ErrorIs(t, err, errConfirmRequiresYes)
+	assert.False(t, s.readMODList(t)["app"])
+}
+
+func TestMODDisableSimple(t *testing.T) {
+	s := baseSandbox(t)
+	s.writeInstalledMOD(t, "app", "1.0.0", []string{"lib"})
+	s.writeInstalledMOD(t, "lib", "1.0.0", nil)
+	s.writeMODList(t,
+		modListEntry{name: "base", enabled: true},
+		modListEntry{name: "app", enabled: true},
+		modListEntry{name: "lib", enabled: true},
+	)
+
+	// Disabling the dependency pulls in the dependent.
+	out, err := runCLI(t, "mod", "disable", "lib", "-y")
+	require.NoError(t, err)
+	assert.Equal(t, "ℹ Planning to disable 2 MOD(s):\n"+
+		"  - lib\n"+
+		"  - app\n"+
+		"✓ Disabled lib\n"+
+		"✓ Disabled app\n"+
+		"✓ Disabled 2 MOD(s)\n"+
+		"✓ Saved mod-list.json\n", out)
+
+	states := s.readMODList(t)
+	assert.False(t, states["lib"])
+	assert.False(t, states["app"])
+}
+
+func TestMODDisableAll(t *testing.T) {
+	s := baseSandbox(t)
+	s.writeInstalledMOD(t, "app", "1.0.0", nil)
+	s.writeMODList(t, modListEntry{name: "base", enabled: true}, modListEntry{name: "app", enabled: true})
+
+	out, err := runCLI(t, "mod", "disable", "--all", "-y")
+	require.NoError(t, err)
+	assert.Contains(t, out, "Disabled app")
+	assert.True(t, s.readMODList(t)["base"], "base must stay enabled")
+	assert.False(t, s.readMODList(t)["app"])
+}
+
+func TestMODDisableBaseRejected(t *testing.T) {
+	s := baseSandbox(t)
+	s.writeMODList(t, modListEntry{name: "base", enabled: true})
+
+	_, err := runCLI(t, "mod", "disable", "base", "-y")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "cannot disable the base MOD")
+}
+
+func TestMODDisableNotInstalledWarns(t *testing.T) {
+	s := baseSandbox(t)
+	s.writeMODList(t, modListEntry{name: "base", enabled: true})
+
+	out, err := runCLI(t, "mod", "disable", "ghost", "-y")
+	require.NoError(t, err)
+	assert.Contains(t, out, "⚠︎ MOD not installed, skipping: ghost")
+	assert.Contains(t, out, "All specified MOD(s) are already disabled")
+}
+
+func TestMODDisableArgumentValidation(t *testing.T) {
+	baseSandbox(t)
+
+	_, err := runCLI(t, "mod", "disable")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Must specify MOD names or use --all option")
+
+	_, err = runCLI(t, "mod", "disable", "app", "--all")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Cannot specify MOD names with --all option")
+}
+
+func TestMODEnableRequiresGameStopped(t *testing.T) {
+	s := baseSandbox(t)
+	require.NoError(t, os.WriteFile(filepath.Join(s.root, "factorio", ".lock"), nil, 0o644))
+
+	_, err := runCLI(t, "mod", "enable", "app")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "running")
+}

--- a/internal/cli/mod_list.go
+++ b/internal/cli/mod_list.go
@@ -63,7 +63,7 @@ func (f listFilters) validate() error {
 		}
 	}
 	if len(active) > 1 {
-		return fmt.Errorf("cannot combine %s options", strings.Join(active, ", "))
+		return fmt.Errorf("Cannot combine %s options", strings.Join(active, ", "))
 	}
 	return nil
 }

--- a/internal/cli/stubs.go
+++ b/internal/cli/stubs.go
@@ -47,8 +47,10 @@ func newMODCommand(c *cli) *cobra.Command {
 		newMODListCommand(c),
 		newMODCheckCommand(c),
 		newMODSettingsCommand(c),
+		newMODEnableCommand(c),
+		newMODDisableCommand(c),
 	)
-	for _, use := range []string{"show", "search", "enable", "disable", "install", "uninstall", "update", "download", "upload", "edit", "sync"} {
+	for _, use := range []string{"show", "search", "install", "uninstall", "update", "download", "upload", "edit", "sync"} {
 		mod.AddCommand(&cobra.Command{Use: use, Short: "MOD " + use, RunE: notImplemented})
 	}
 

--- a/internal/dependency/plan.go
+++ b/internal/dependency/plan.go
@@ -1,0 +1,134 @@
+package dependency
+
+import (
+	"errors"
+	"fmt"
+
+	"github.com/sakuro/factorix/internal/mod"
+)
+
+var (
+	ErrDependencyMissing = errors.New("dependency missing")
+	ErrDependencyVersion = errors.New("dependency version requirement not satisfied")
+	ErrMODConflict       = errors.New("MOD conflict")
+)
+
+// PlanEnable computes the MODs to enable when enabling targets, pulling in
+// required dependencies (BFS discovery order). The base MOD is always
+// available and is never pulled in as a dependency. Targets already
+// installed are assumed to exist in the graph; the caller validates that
+// before calling PlanEnable.
+func PlanEnable(g *Graph, targets []mod.MOD) ([]mod.MOD, error) {
+	planned := map[mod.MOD]bool{}
+	var order []mod.MOD
+	queue := append([]mod.MOD(nil), targets...)
+
+	for len(queue) > 0 {
+		m := queue[0]
+		queue = queue[1:]
+
+		node, ok := g.Node(m)
+		if !ok || node.Enabled || planned[m] {
+			continue
+		}
+		planned[m] = true
+		order = append(order, m)
+
+		for _, edge := range g.EdgesFrom(m) {
+			if edge.Type != TypeRequired || edge.To.IsBase() {
+				continue
+			}
+			depNode, ok := g.Node(edge.To)
+			if !ok {
+				return nil, fmt.Errorf("%w: MOD '%s' requires '%s' which is not installed", ErrDependencyMissing, m, edge.To)
+			}
+			if !edge.SatisfiedBy(depNode.Version) {
+				return nil, fmt.Errorf("%w: cannot enable %s: dependency %s version requirement not satisfied (required: %s, installed: %s)",
+					ErrDependencyVersion, m, edge.To, edge.Requirement, depNode.Version)
+			}
+			if !depNode.Enabled && !planned[edge.To] {
+				queue = append(queue, edge.To)
+			}
+		}
+	}
+	return order, nil
+}
+
+// ValidateNoConflicts checks that none of the planned MODs conflict (via an
+// incompatible edge, in either direction) with a currently-enabled MOD or
+// another MOD in the same plan.
+func ValidateNoConflicts(g *Graph, planned []mod.MOD) error {
+	plannedSet := map[mod.MOD]bool{}
+	for _, m := range planned {
+		plannedSet[m] = true
+	}
+
+	for _, m := range planned {
+		for _, edge := range g.EdgesFrom(m) {
+			if edge.Type != TypeIncompatible {
+				continue
+			}
+			if err := checkConflict(g, m, edge.To, plannedSet); err != nil {
+				return err
+			}
+		}
+		for _, edge := range g.EdgesTo(m) {
+			if edge.Type != TypeIncompatible {
+				continue
+			}
+			if err := checkConflict(g, m, edge.From, plannedSet); err != nil {
+				return err
+			}
+		}
+	}
+	return nil
+}
+
+func checkConflict(g *Graph, m, other mod.MOD, plannedSet map[mod.MOD]bool) error {
+	if node, ok := g.Node(other); ok && node.Enabled {
+		return fmt.Errorf("%w: cannot enable %s: conflicts with %s which is currently enabled", ErrMODConflict, m, other)
+	}
+	if plannedSet[other] {
+		return fmt.Errorf("%w: cannot enable %s: conflicts with %s which is also being enabled", ErrMODConflict, m, other)
+	}
+	return nil
+}
+
+// PlanDisableAll returns every enabled MOD except base.
+func PlanDisableAll(g *Graph) []mod.MOD {
+	var mods []mod.MOD
+	for _, node := range g.Nodes() {
+		if node.Enabled && !node.MOD.IsBase() {
+			mods = append(mods, node.MOD)
+		}
+	}
+	return mods
+}
+
+// PlanDisable computes the MODs to disable when disabling targets, pulling
+// in enabled dependents recursively (BFS). Targets not present in the
+// graph, or already disabled, are silently skipped — the caller is
+// responsible for warning about targets that are not installed.
+func PlanDisable(g *Graph, targets []mod.MOD) []mod.MOD {
+	planned := map[mod.MOD]bool{}
+	var order []mod.MOD
+	queue := append([]mod.MOD(nil), targets...)
+
+	for len(queue) > 0 {
+		m := queue[0]
+		queue = queue[1:]
+
+		node, ok := g.Node(m)
+		if !ok || !node.Enabled || planned[m] {
+			continue
+		}
+		for _, dependent := range g.FindEnabledDependents(m) {
+			if !planned[dependent] {
+				queue = append(queue, dependent)
+			}
+		}
+		planned[m] = true
+		order = append(order, m)
+	}
+	return order
+}

--- a/internal/dependency/plan_test.go
+++ b/internal/dependency/plan_test.go
@@ -1,0 +1,128 @@
+package dependency
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sakuro/factorix/internal/mod"
+)
+
+func disabledNode(t *testing.T, g *Graph, name string) {
+	t.Helper()
+	require.NoError(t, g.AddNode(Node{MOD: testMOD(name), Version: mod.MODVersion{Major: 1}, Enabled: false, Installed: true}))
+}
+
+func TestPlanEnablePullsInRequiredDeps(t *testing.T) {
+	g := NewGraph()
+	disabledNode(t, g, "app")
+	disabledNode(t, g, "lib")
+	requireEdge(t, g, "app", "lib", TypeRequired)
+	requireEdge(t, g, "app", "base", TypeRequired) // base is skipped
+
+	planned, err := PlanEnable(g, []mod.MOD{testMOD("app")})
+	require.NoError(t, err)
+	assert.Equal(t, []mod.MOD{testMOD("app"), testMOD("lib")}, planned)
+}
+
+func TestPlanEnableSkipsAlreadyEnabled(t *testing.T) {
+	g := NewGraph()
+	disabledNode(t, g, "app")
+	addNodes(t, g, "lib") // enabled
+	requireEdge(t, g, "app", "lib", TypeRequired)
+
+	planned, err := PlanEnable(g, []mod.MOD{testMOD("app")})
+	require.NoError(t, err)
+	assert.Equal(t, []mod.MOD{testMOD("app")}, planned)
+}
+
+func TestPlanEnableMissingDependency(t *testing.T) {
+	g := NewGraph()
+	disabledNode(t, g, "app")
+	requireEdge(t, g, "app", "ghost", TypeRequired)
+
+	_, err := PlanEnable(g, []mod.MOD{testMOD("app")})
+	require.ErrorIs(t, err, ErrDependencyMissing)
+}
+
+func TestPlanEnableVersionMismatch(t *testing.T) {
+	g := NewGraph()
+	disabledNode(t, g, "app")
+	disabledNode(t, g, "lib") // version 1
+	require.NoError(t, g.AddEdge(Edge{
+		From: testMOD("app"), To: testMOD("lib"), Type: TypeRequired,
+		Requirement: &VersionRequirement{Operator: OpGreaterEqual, Version: mod.MODVersion{Major: 2}},
+	}))
+
+	_, err := PlanEnable(g, []mod.MOD{testMOD("app")})
+	require.ErrorIs(t, err, ErrDependencyVersion)
+}
+
+func TestValidateNoConflictsWithEnabled(t *testing.T) {
+	g := NewGraph()
+	disabledNode(t, g, "app")
+	addNodes(t, g, "rival") // enabled
+	requireEdge(t, g, "app", "rival", TypeIncompatible)
+
+	err := ValidateNoConflicts(g, []mod.MOD{testMOD("app")})
+	require.ErrorIs(t, err, ErrMODConflict)
+}
+
+func TestValidateNoConflictsWithinPlan(t *testing.T) {
+	g := NewGraph()
+	disabledNode(t, g, "a")
+	disabledNode(t, g, "b")
+	requireEdge(t, g, "a", "b", TypeIncompatible)
+
+	err := ValidateNoConflicts(g, []mod.MOD{testMOD("a"), testMOD("b")})
+	require.ErrorIs(t, err, ErrMODConflict)
+}
+
+func TestValidateNoConflictsIncomingEdge(t *testing.T) {
+	g := NewGraph()
+	disabledNode(t, g, "app")
+	addNodes(t, g, "rival") // enabled
+	requireEdge(t, g, "rival", "app", TypeIncompatible)
+
+	err := ValidateNoConflicts(g, []mod.MOD{testMOD("app")})
+	require.ErrorIs(t, err, ErrMODConflict)
+}
+
+func TestValidateNoConflictsPasses(t *testing.T) {
+	g := NewGraph()
+	disabledNode(t, g, "app")
+
+	err := ValidateNoConflicts(g, []mod.MOD{testMOD("app")})
+	require.NoError(t, err)
+}
+
+func TestPlanDisableAll(t *testing.T) {
+	g := NewGraph()
+	addNodes(t, g, "base", "app") // both enabled
+	require.NoError(t, g.AddNode(Node{MOD: testMOD("off"), Version: mod.MODVersion{Major: 1}, Enabled: false, Installed: true}))
+
+	planned := PlanDisableAll(g)
+	assert.ElementsMatch(t, []mod.MOD{testMOD("app")}, planned)
+}
+
+func TestPlanDisablePullsInDependents(t *testing.T) {
+	g := NewGraph()
+	addNodes(t, g, "app", "lib")
+	requireEdge(t, g, "app", "lib", TypeRequired)
+
+	planned := PlanDisable(g, []mod.MOD{testMOD("lib")})
+	assert.Equal(t, []mod.MOD{testMOD("lib"), testMOD("app")}, planned)
+}
+
+func TestPlanDisableSkipsNotInstalledOrAlreadyDisabled(t *testing.T) {
+	g := NewGraph()
+	addNodes(t, g, "app")
+
+	planned := PlanDisable(g, []mod.MOD{testMOD("ghost"), testMOD("app")})
+	assert.Equal(t, []mod.MOD{testMOD("app")}, planned)
+
+	disabledNode(t, g, "off")
+	planned = PlanDisable(g, []mod.MOD{testMOD("off")})
+	assert.Empty(t, planned)
+}


### PR DESCRIPTION
## Summary
Second slice of Phase 10 (CLI commands): `mod enable` and `mod disable`, with dependency/conflict resolution.

## Changes
- `internal/dependency/plan.go`: `PlanEnable` (BFS pulling in required dependencies, skipping the always-available base MOD, erroring on a missing dependency or an unsatisfied version requirement), `ValidateNoConflicts` (checks incompatibility edges in both directions against currently-enabled MODs and the plan itself), `PlanDisableAll`, and `PlanDisable` (BFS pulling in enabled dependents). Kept in the `dependency` package — planning is graph algorithm, not CLI concern — so `internal/cli` stays a thin orchestrator (load state, show the plan, confirm, apply, save)
- `internal/cli/confirm.go`: the `--yes`/`--quiet`/prompt behavior shared by both commands, matching Ruby's `Confirmable` mixin exactly — only `y`/`yes` (case-insensitive) counts as yes, EOF is no, and quiet mode without `--yes` is an error rather than silently defaulting
- `mod enable <name>...`: errors on a target that isn't installed; pulls in required dependencies and validates no conflicts before showing the plan and prompting
- `mod disable [name]... [--all]`: mutually exclusive with named targets (`--all` disables everything except base); warns and skips a named target that isn't installed instead of erroring — this is a real difference from `enable`, not an inconsistency, and matches Ruby's `validate_target_mods` vs `validate_target_mods_exist`
- Both check `RequireGameStopped` before any other work (matching Ruby's `RequiresGameStopped`, an outer wrapper that runs before the command body) and back up `mod-list.json` to `.bak` before saving

## Bug fixed in passing
`mod list`'s conflicting-filters error was accidentally lowercased ("cannot combine...") in the Phase 10a PR — Ruby's actual message is "Cannot combine...". Fixed for consistency, since these user-facing messages are part of the eventual Ruby-vs-Go e2e parity surface.

## Test Plan
- `go build ./... && go vet ./... && go test ./...` pass locally (`mise run default`)
- `internal/dependency`: unit tests for `PlanEnable`/`ValidateNoConflicts`/`PlanDisable`/`PlanDisableAll` covering dependency pull-in, missing/version-mismatched dependencies, conflicts in both edge directions, and dependent pull-in on disable
- `internal/cli`: sandbox tests covering the full command surface (dependency propagation, already-enabled/disabled no-ops, missing target, conflict, prompt accept/decline, `--quiet` without `--yes`, `--all`, base rejection, not-installed warning, argument validation, game-running guard)
- Manually built the real binary and ran `mod list` → `mod enable app -y` → `mod list` → `mod disable lib -y` → `mod list` end to end against a scratch sandbox, confirming stdout and the saved `mod-list.json` match expectations
