### PR TITLE
:sparkles: Implement mod search/show/download commands (Phase 10c)

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -36,3 +36,6 @@
 
 # Go vendored dependencies (managed via go.mod/go.sum)
 /vendor/
+
+# Go build output (mise run build)
+/factorix

--- a/doc/go-migration-roadmap.md
+++ b/doc/go-migration-roadmap.md
@@ -421,7 +421,10 @@ than one pass over the full list below.
       `ValidateNoConflicts`, `PlanDisable`/`PlanDisableAll` — so the CLI layer
       stays thin)
 - [x] `mod check` — validate dependency graph
-- [ ] `mod sync` — sync MOD states from a save file
+- [ ] `mod sync` — sync MOD states from a save file. Despite living under Local
+      MOD Management, this needs the Portal-dependent machinery below (it
+      installs MODs present in the save but missing locally), so it was
+      sequenced after `mod search`/`show`/`download` rather than before them
 - [x] `mod settings dump` / `restore` — export/import `mod-settings.dat` (JSON)
 
 #### MOD Author Tools
@@ -429,9 +432,17 @@ than one pass over the full list below.
 - [ ] `blueprint encode` / `decode`
 
 #### Portal-dependent
-- [ ] `mod search` / `mod show`
+- [x] `mod search` / `mod show` — `api.Category`/`api.License` display catalogs added
+      here (deferred from Phase 7); Category falls back to the raw value for
+      codes the Portal may add later instead of erroring the way Ruby's
+      `Category.for` does
 - [ ] `mod install` / `mod uninstall` / `mod update`
-- [ ] `mod download` — download without installing
+- [x] `mod download` — download without installing; shared download-planning
+      logic lives in `internal/cli/download_support.go` (parse spec, resolve
+      release, build targets, parallel fetch) for reuse by install/update/sync.
+      `internal/app` gained `Downloader()`/`MODDownloadAPI()` (Client → Retry,
+      no cache decorator, matching Ruby) and `FACTORIX_MODS_PORTAL_URL` as an
+      optional endpoint override (mirrors/tests)
 - [ ] `mod upload` / `mod edit` / `mod image list/add/edit`
 - [ ] `download` — download the game itself
 

--- a/doc/go-migration-roadmap.md
+++ b/doc/go-migration-roadmap.md
@@ -432,10 +432,10 @@ than one pass over the full list below.
 - [ ] `blueprint encode` / `decode`
 
 #### Portal-dependent
-- [x] `mod search` / `mod show` — `api.Category`/`api.License` display catalogs added
-      here (deferred from Phase 7); Category falls back to the raw value for
-      codes the Portal may add later instead of erroring the way Ruby's
-      `Category.for` does
+- [x] `mod search` / `mod show` — `api.Category` display catalog added here
+      (deferred from Phase 7); an unrecognized category value errors, matching
+      Ruby's `Category.for` (`KeyError`) — categories change rarely, so an
+      unknown one means the catalog is stale and needs a code change
 - [ ] `mod install` / `mod uninstall` / `mod update`
 - [x] `mod download` — download without installing; shared download-planning
       logic lives in `internal/cli/download_support.go` (parse spec, resolve

--- a/internal/api/category.go
+++ b/internal/api/category.go
@@ -1,0 +1,34 @@
+package api
+
+// Category is a MOD Portal category's display information.
+//
+// See https://wiki.factorio.com/Mod_details_API#Category
+type Category struct {
+	Value       string
+	Name        string
+	Description string
+}
+
+var categories = map[string]Category{
+	"":              {"", "No category", "Unassigned category"},
+	"no-category":   {"", "No category", "Unassigned category"},
+	"content":       {"content", "Content", "Mods introducing new content into the game"},
+	"overhaul":      {"overhaul", "Overhaul", "Large total conversion mods"},
+	"tweaks":        {"tweaks", "Tweaks", "Small changes concerning balance, gameplay, or graphics"},
+	"utilities":     {"utilities", "Utilities", "Providing the player with new tools or adjusting the game interface"},
+	"scenarios":     {"scenarios", "Scenarios", "Scenarios, maps, and puzzles"},
+	"mod-packs":     {"mod-packs", "Mod packs", "Collections of mods with tweaks to make them work together"},
+	"localizations": {"localizations", "Localizations", "Translations for other mods"},
+	"internal":      {"internal", "Internal", "Lua libraries for use by other mods"},
+}
+
+// CategoryFor returns the display Category for a raw API category value.
+// An unrecognized value (the Portal may add categories after this catalog
+// was last updated) falls back to a Category using the raw value as its
+// name, rather than failing outright the way Ruby's Category.for does.
+func CategoryFor(value string) Category {
+	if c, ok := categories[value]; ok {
+		return c
+	}
+	return Category{Value: value, Name: value}
+}

--- a/internal/api/category.go
+++ b/internal/api/category.go
@@ -1,5 +1,7 @@
 package api
 
+import "fmt"
+
 // Category is a MOD Portal category's display information.
 //
 // See https://wiki.factorio.com/Mod_details_API#Category
@@ -23,12 +25,13 @@ var categories = map[string]Category{
 }
 
 // CategoryFor returns the display Category for a raw API category value.
-// An unrecognized value (the Portal may add categories after this catalog
-// was last updated) falls back to a Category using the raw value as its
-// name, rather than failing outright the way Ruby's Category.for does.
-func CategoryFor(value string) Category {
+// Categories change rarely; an unrecognized value means this catalog is
+// out of date and needs a code change, not a value to paper over, so this
+// errors rather than degrading to a raw-string display (matching Ruby's
+// Category.for, which raises KeyError for the same case).
+func CategoryFor(value string) (Category, error) {
 	if c, ok := categories[value]; ok {
-		return c
+		return c, nil
 	}
-	return Category{Value: value, Name: value}
+	return Category{}, fmt.Errorf("%w: unknown category %q", ErrInvalidResponse, value)
 }

--- a/internal/api/types.go
+++ b/internal/api/types.go
@@ -6,6 +6,7 @@ package api
 
 import (
 	"encoding/json"
+	"fmt"
 	"time"
 
 	"github.com/sakuro/factorix/internal/mod"
@@ -105,6 +106,34 @@ type MODInfo struct {
 	License           *License  `json:"license"`
 	Images            []Image   `json:"images"`
 	Deprecated        bool      `json:"deprecated"`
+}
+
+// UnmarshalJSON decodes MOD info. LastHighlightedAt gets its own pass: the
+// Portal represents it as either a full RFC3339 timestamp or a bare
+// "2006-01-02" date — both valid ISO 8601, but only the former is valid
+// RFC3339, which is all time.Time's own UnmarshalJSON accepts.
+// CreatedAt/UpdatedAt are always full timestamps in observed Portal
+// responses and keep the standard time.Time decoding.
+func (m *MODInfo) UnmarshalJSON(data []byte) error {
+	type alias MODInfo
+	raw := struct {
+		*alias
+		LastHighlightedAt string `json:"last_highlighted_at"`
+	}{alias: (*alias)(m)}
+	if err := json.Unmarshal(data, &raw); err != nil {
+		return err
+	}
+	if raw.LastHighlightedAt == "" {
+		return nil
+	}
+	t, err := time.Parse(time.RFC3339, raw.LastHighlightedAt)
+	if err != nil {
+		if t, err = time.Parse("2006-01-02", raw.LastHighlightedAt); err != nil {
+			return fmt.Errorf("%w: cannot parse last_highlighted_at %q", ErrInvalidResponse, raw.LastHighlightedAt)
+		}
+	}
+	m.LastHighlightedAt = t
+	return nil
 }
 
 // ThumbnailURL returns the absolute thumbnail URL, or "" when absent.

--- a/internal/api/types_test.go
+++ b/internal/api/types_test.go
@@ -1,0 +1,52 @@
+package api
+
+import (
+	"encoding/json"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// TestMODInfoLastHighlightedAtDateOnly guards against a regression found
+// against the real Portal: Krastorio2's last_highlighted_at was returned as
+// a bare "2026-05-18" (valid ISO 8601, but not valid RFC3339, which is all
+// time.Time's own UnmarshalJSON accepts), while created_at/updated_at were
+// full timestamps.
+func TestMODInfoLastHighlightedAtDateOnly(t *testing.T) {
+	var info MODInfo
+	err := json.Unmarshal([]byte(`{
+		"name": "Krastorio2",
+		"title": "Krastorio 2",
+		"owner": "raiguard",
+		"created_at": "2020-03-13T15:52:58.015000Z",
+		"updated_at": "2026-06-29T03:22:48.111000Z",
+		"last_highlighted_at": "2026-05-18"
+	}`), &info)
+	require.NoError(t, err)
+
+	assert.Equal(t, time.Date(2026, 5, 18, 0, 0, 0, 0, time.UTC), info.LastHighlightedAt)
+	assert.True(t, info.CreatedAt.Equal(time.Date(2020, 3, 13, 15, 52, 58, 15000000, time.UTC)))
+	assert.True(t, info.UpdatedAt.Equal(time.Date(2026, 6, 29, 3, 22, 48, 111000000, time.UTC)))
+}
+
+func TestMODInfoLastHighlightedAtFullTimestamp(t *testing.T) {
+	var info MODInfo
+	err := json.Unmarshal([]byte(`{"name": "m", "last_highlighted_at": "2024-01-02T03:04:05Z"}`), &info)
+	require.NoError(t, err)
+	assert.True(t, info.LastHighlightedAt.Equal(time.Date(2024, 1, 2, 3, 4, 5, 0, time.UTC)))
+}
+
+func TestMODInfoLastHighlightedAtAbsent(t *testing.T) {
+	var info MODInfo
+	err := json.Unmarshal([]byte(`{"name": "m"}`), &info)
+	require.NoError(t, err)
+	assert.True(t, info.LastHighlightedAt.IsZero())
+}
+
+func TestMODInfoLastHighlightedAtInvalid(t *testing.T) {
+	var info MODInfo
+	err := json.Unmarshal([]byte(`{"name": "m", "last_highlighted_at": "not-a-date"}`), &info)
+	require.ErrorIs(t, err, ErrInvalidResponse)
+}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -17,7 +17,12 @@ import (
 	"github.com/sakuro/factorix/internal/httpx"
 	"github.com/sakuro/factorix/internal/logging"
 	"github.com/sakuro/factorix/internal/platform"
+	"github.com/sakuro/factorix/internal/transfer"
 )
+
+// maskedQueryParams are query parameter names masked in HTTP logs across
+// every client the app builds (credentials passed via URL query).
+var maskedQueryParams = []string{"username", "token", "secure"}
 
 // App holds the application-wide object graph. Expensive components are
 // built lazily on first use.
@@ -31,6 +36,14 @@ type App struct {
 	portalOnce sync.Once
 	portal     *api.MODPortalAPI
 	portalErr  error
+
+	downloaderOnce sync.Once
+	downloader     *transfer.Downloader
+	downloaderErr  error
+
+	modDownloadOnce sync.Once
+	modDownload     *api.MODDownloadAPI
+	modDownloadErr  error
 }
 
 // Options select the configuration and log level.
@@ -129,12 +142,24 @@ func (a *App) PortalAPI() (*api.MODPortalAPI, error) {
 		)
 		client := httpx.NewClient(httpx.Options{
 			Transport:    transport,
-			MaskedParams: []string{"username", "token", "secure"},
+			MaskedParams: maskedQueryParams,
 			Logger:       a.Logger,
 		})
 		a.portal = api.NewMODPortalAPI(client, apiCache, a.Logger)
+		a.portal.BaseURL = modsPortalBaseURL()
 	})
 	return a.portal, a.portalErr
+}
+
+// modsPortalBaseURL is api.DefaultPortalBaseURL, overridable via
+// FACTORIX_MODS_PORTAL_URL — useful for pointing at a portal mirror, and
+// for tests to run the real command tree against an httptest server rather
+// than stubbing at the api package boundary.
+func modsPortalBaseURL() string {
+	if v := os.Getenv("FACTORIX_MODS_PORTAL_URL"); v != "" {
+		return v
+	}
+	return api.DefaultPortalBaseURL
 }
 
 func (a *App) newCache(name string, cfg config.CacheType) (cache.Cache, error) {
@@ -153,6 +178,52 @@ func (a *App) newCache(name string, cfg config.CacheType) (cache.Cache, error) {
 		CompressionThreshold: cfg.FileSystem.CompressionThreshold,
 		Logger:               a.Logger,
 	})
+}
+
+// Downloader returns the MOD file downloader, wired as Client → Retry (no
+// cache decorator: the downloader manages its own download-type cache
+// directly, matching Ruby's download_http_client).
+func (a *App) Downloader() (*transfer.Downloader, error) {
+	a.downloaderOnce.Do(func() {
+		downloadCache, err := a.newCache("download", a.Config.Cache.Download)
+		if err != nil {
+			a.downloaderErr = err
+			return
+		}
+		transport := httpx.NewRetryTransport(
+			httpx.NewBaseTransport(
+				time.Duration(a.Config.HTTP.ConnectTimeout)*time.Second,
+				time.Duration(a.Config.HTTP.ReadTimeout)*time.Second,
+			),
+			httpx.RetryOptions{Logger: a.Logger},
+		)
+		client := httpx.NewClient(httpx.Options{
+			Transport:    transport,
+			MaskedParams: maskedQueryParams,
+			Logger:       a.Logger,
+		})
+		a.downloader = transfer.NewDownloader(downloadCache, client, a.Logger)
+	})
+	return a.downloader, a.downloaderErr
+}
+
+// MODDownloadAPI returns the client for building authenticated MOD download
+// URLs. Credentials resolve lazily on first use, not here, so commands that
+// never actually download never require FACTORIO_USERNAME/FACTORIO_TOKEN or
+// player-data.json.
+func (a *App) MODDownloadAPI() (*api.MODDownloadAPI, error) {
+	a.modDownloadOnce.Do(func() {
+		playerDataPath, err := a.Runtime.PlayerDataPath()
+		if err != nil {
+			a.modDownloadErr = err
+			return
+		}
+		a.modDownload = api.NewMODDownloadAPI(func() (api.ServiceCredential, error) {
+			return api.LoadServiceCredential(playerDataPath)
+		})
+		a.modDownload.BaseURL = modsPortalBaseURL()
+	})
+	return a.modDownload, a.modDownloadErr
 }
 
 // RequireGameStopped fails when Factorio is running; commands that modify

--- a/internal/cli/download_support.go
+++ b/internal/cli/download_support.go
@@ -1,0 +1,183 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+	"strings"
+
+	"golang.org/x/sync/errgroup"
+
+	"github.com/sakuro/factorix/internal/api"
+	"github.com/sakuro/factorix/internal/app"
+	"github.com/sakuro/factorix/internal/dependency"
+	"github.com/sakuro/factorix/internal/mod"
+	"github.com/sakuro/factorix/internal/transfer"
+)
+
+var errInvalidFilename = errors.New("invalid filename")
+
+// modSpec is a parsed "name", "name@version", or "name@latest" argument.
+type modSpec struct {
+	MOD     mod.MOD
+	Latest  bool
+	Version mod.MODVersion // meaningless when Latest
+}
+
+// parseMODSpec parses a MOD specification. "latest" and the bare name both
+// mean the latest release.
+func parseMODSpec(spec string) (modSpec, error) {
+	name, versionStr, hasVersion := strings.Cut(spec, "@")
+	if !hasVersion || versionStr == "" || versionStr == "latest" {
+		return modSpec{MOD: mod.MOD{Name: name}, Latest: true}, nil
+	}
+	version, err := mod.ParseMODVersion(versionStr)
+	if err != nil {
+		return modSpec{}, err
+	}
+	return modSpec{MOD: mod.MOD{Name: name}, Version: version}, nil
+}
+
+// findRelease returns the release matching spec: the most recently released
+// one for "latest", or the exact version otherwise.
+func findRelease(info *api.MODInfo, spec modSpec) *api.Release {
+	if spec.Latest {
+		return latestByReleaseDate(info.Releases)
+	}
+	for i := range info.Releases {
+		if info.Releases[i].Version == spec.Version {
+			return &info.Releases[i]
+		}
+	}
+	return nil
+}
+
+// findCompatibleRelease returns the most recently released version
+// satisfying requirement (or the most recent release of any version when
+// requirement is nil).
+func findCompatibleRelease(info *api.MODInfo, requirement *dependency.VersionRequirement) *api.Release {
+	if requirement == nil {
+		return latestByReleaseDate(info.Releases)
+	}
+	var compatible []api.Release
+	for _, r := range info.Releases {
+		if requirement.SatisfiedBy(r.Version) {
+			compatible = append(compatible, r)
+		}
+	}
+	return latestByReleaseDate(compatible)
+}
+
+func latestByReleaseDate(releases []api.Release) *api.Release {
+	if len(releases) == 0 {
+		return nil
+	}
+	latest := &releases[0]
+	for i := 1; i < len(releases); i++ {
+		if releases[i].ReleasedAt.After(latest.ReleasedAt) {
+			latest = &releases[i]
+		}
+	}
+	return latest
+}
+
+// downloadTarget is a MOD release resolved to a local output path.
+type downloadTarget struct {
+	MOD        mod.MOD
+	MODInfo    *api.MODInfo
+	Release    api.Release
+	OutputPath string
+}
+
+// validateFilename rejects a release file_name that could escape the
+// intended output directory. The Portal is expected to return a plain
+// filename; this guards against a compromised or malformed response.
+func validateFilename(filename string) error {
+	if filename == "" {
+		return fmt.Errorf("%w: filename is empty", errInvalidFilename)
+	}
+	if strings.ContainsAny(filename, `/\`) {
+		return fmt.Errorf("%w: filename contains path separators: %q", errInvalidFilename, filename)
+	}
+	if strings.Contains(filename, "..") {
+		return fmt.Errorf("%w: filename contains parent directory reference: %q", errInvalidFilename, filename)
+	}
+	return nil
+}
+
+func buildDownloadTargets(infos []fetchedMODInfo, outputDir string) ([]downloadTarget, error) {
+	targets := make([]downloadTarget, 0, len(infos))
+	for _, info := range infos {
+		if err := validateFilename(info.Release.FileName); err != nil {
+			return nil, err
+		}
+		targets = append(targets, downloadTarget{
+			MOD:        info.MOD,
+			MODInfo:    info.MODInfo,
+			Release:    info.Release,
+			OutputPath: filepath.Join(outputDir, info.Release.FileName),
+		})
+	}
+	return targets, nil
+}
+
+// fetchedMODInfo pairs a resolved release with its MOD and full info,
+// carried through target-building and (for downloads) dependency resolution.
+type fetchedMODInfo struct {
+	MOD     mod.MOD
+	MODInfo *api.MODInfo
+	Release api.Release
+}
+
+// fetchMODInfoConcurrently resolves each spec to a release via resolve, run
+// with up to jobs concurrent Portal requests.
+func fetchMODInfoConcurrently(ctx context.Context, jobs int, specs []modSpec, resolve func(context.Context, modSpec) (fetchedMODInfo, error)) ([]fetchedMODInfo, error) {
+	results := make([]fetchedMODInfo, len(specs))
+	group, ctx := errgroup.WithContext(ctx)
+	group.SetLimit(jobs)
+	for i, spec := range specs {
+		group.Go(func() error {
+			result, err := resolve(ctx, spec)
+			if err != nil {
+				return err
+			}
+			results[i] = result
+			return nil
+		})
+	}
+	if err := group.Wait(); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+
+// downloadTargets downloads each target to its OutputPath, up to jobs
+// concurrently. Progress reporting is deferred to a later pass (see
+// doc/go-migration-roadmap.md Phase 10) — stdout, the only e2e-compared
+// stream, is unaffected either way.
+func downloadTargets(ctx context.Context, application *app.App, targets []downloadTarget, jobs int) error {
+	downloader, err := application.Downloader()
+	if err != nil {
+		return err
+	}
+	downloadAPI, err := application.MODDownloadAPI()
+	if err != nil {
+		return err
+	}
+
+	group, ctx := errgroup.WithContext(ctx)
+	group.SetLimit(jobs)
+	for _, target := range targets {
+		group.Go(func() error {
+			downloadURL, err := downloadAPI.DownloadURL(target.Release.DownloadURL)
+			if err != nil {
+				return err
+			}
+			return downloader.Download(ctx, downloadURL, target.OutputPath, transfer.DownloadOptions{
+				ExpectedSHA1: target.Release.SHA1,
+			})
+		})
+	}
+	return group.Wait()
+}

--- a/internal/cli/download_support_test.go
+++ b/internal/cli/download_support_test.go
@@ -1,0 +1,119 @@
+package cli
+
+import (
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sakuro/factorix/internal/api"
+	"github.com/sakuro/factorix/internal/dependency"
+	"github.com/sakuro/factorix/internal/mod"
+)
+
+func release(version string, releasedAt time.Time) api.Release {
+	v, err := mod.ParseMODVersion(version)
+	if err != nil {
+		panic(err)
+	}
+	return api.Release{Version: v, ReleasedAt: releasedAt, FileName: "test-mod_" + version + ".zip"}
+}
+
+func TestParseMODSpec(t *testing.T) {
+	tests := []struct {
+		input string
+		want  modSpec
+	}{
+		{"some-mod", modSpec{MOD: mod.MOD{Name: "some-mod"}, Latest: true}},
+		{"some-mod@latest", modSpec{MOD: mod.MOD{Name: "some-mod"}, Latest: true}},
+		{"some-mod@", modSpec{MOD: mod.MOD{Name: "some-mod"}, Latest: true}},
+		{"some-mod@1.2.0", modSpec{MOD: mod.MOD{Name: "some-mod"}, Version: mod.MODVersion{Major: 1, Minor: 2}}},
+	}
+	for _, tt := range tests {
+		t.Run(tt.input, func(t *testing.T) {
+			got, err := parseMODSpec(tt.input)
+			require.NoError(t, err)
+			assert.Equal(t, tt.want, got)
+		})
+	}
+
+	_, err := parseMODSpec("some-mod@not-a-version")
+	require.Error(t, err)
+}
+
+func TestFindRelease(t *testing.T) {
+	older := release("1.0.0", time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
+	newer := release("1.1.0", time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC))
+	info := &api.MODInfo{Releases: []api.Release{older, newer}}
+
+	got := findRelease(info, modSpec{Latest: true})
+	require.NotNil(t, got)
+	assert.Equal(t, "1.1.0", got.Version.String())
+
+	got = findRelease(info, modSpec{Version: mod.MODVersion{Major: 1}})
+	require.NotNil(t, got)
+	assert.Equal(t, "1.0.0", got.Version.String())
+
+	got = findRelease(info, modSpec{Version: mod.MODVersion{Major: 9}})
+	assert.Nil(t, got)
+}
+
+func TestFindCompatibleRelease(t *testing.T) {
+	v1 := release("1.0.0", time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
+	v2 := release("2.0.0", time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC))
+	info := &api.MODInfo{Releases: []api.Release{v1, v2}}
+
+	got := findCompatibleRelease(info, nil)
+	require.NotNil(t, got)
+	assert.Equal(t, "2.0.0", got.Version.String())
+
+	requirement := &dependency.VersionRequirement{Operator: dependency.OpLessEqual, Version: mod.MODVersion{Major: 1}}
+	got = findCompatibleRelease(info, requirement)
+	require.NotNil(t, got)
+	assert.Equal(t, "1.0.0", got.Version.String())
+
+	requirement = &dependency.VersionRequirement{Operator: dependency.OpGreaterEqual, Version: mod.MODVersion{Major: 9}}
+	assert.Nil(t, findCompatibleRelease(info, requirement))
+}
+
+func TestValidateFilename(t *testing.T) {
+	require.NoError(t, validateFilename("test-mod_1.0.0.zip"))
+
+	for _, bad := range []string{"", "a/b.zip", `a\b.zip`, "../escape.zip"} {
+		require.Error(t, validateFilename(bad), bad)
+	}
+}
+
+func TestBuildDownloadTargets(t *testing.T) {
+	infos := []fetchedMODInfo{
+		{MOD: mod.MOD{Name: "some-mod"}, MODInfo: &api.MODInfo{Name: "some-mod"}, Release: release("1.0.0", time.Now())},
+	}
+	targets, err := buildDownloadTargets(infos, "/tmp/downloads")
+	require.NoError(t, err)
+	require.Len(t, targets, 1)
+	assert.Equal(t, "/tmp/downloads/test-mod_1.0.0.zip", targets[0].OutputPath)
+
+	infos[0].Release.FileName = "../escape.zip"
+	_, err = buildDownloadTargets(infos, "/tmp/downloads")
+	require.ErrorIs(t, err, errInvalidFilename)
+}
+
+func TestCollectNewDependencies(t *testing.T) {
+	known := map[string]fetchedMODInfo{
+		"app": {
+			MOD: mod.MOD{Name: "app"},
+			Release: api.Release{InfoJSON: api.ReleaseInfoJSON{
+				Dependencies: []string{"base", "lib >= 1.0", "? optional-lib", "elevated-rails"},
+			}},
+		},
+	}
+	deps := collectNewDependencies([]string{"app"}, known, map[string]bool{})
+	require.Len(t, deps, 1)
+	assert.Equal(t, "lib", deps[0].name)
+	require.NotNil(t, deps[0].requirement)
+	assert.Equal(t, dependency.OpGreaterEqual, deps[0].requirement.Operator)
+
+	// Already-processed names yield nothing on a second pass.
+	assert.Empty(t, collectNewDependencies([]string{"app"}, known, map[string]bool{"app": true}))
+}

--- a/internal/cli/mod_download.go
+++ b/internal/cli/mod_download.go
@@ -1,0 +1,245 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"slices"
+
+	"github.com/spf13/cobra"
+
+	"github.com/sakuro/factorix/internal/app"
+	"github.com/sakuro/factorix/internal/dependency"
+	"github.com/sakuro/factorix/internal/mod"
+)
+
+var builtinMODs = []string{"base", "elevated-rails", "quality", "space-age"}
+
+func newMODDownloadCommand(c *cli) *cobra.Command {
+	var directory string
+	var jobs int
+	var recursive bool
+
+	cmd := &cobra.Command{
+		Use:   "download <mod-spec>...",
+		Short: "Download MOD files from Factorio MOD Portal",
+		Args:  cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			application, err := c.App()
+			if err != nil {
+				return err
+			}
+
+			downloadDir, err := filepath.Abs(directory)
+			if err != nil {
+				return err
+			}
+			if info, err := os.Stat(downloadDir); err != nil || !info.IsDir() {
+				return fmt.Errorf("Download directory does not exist: %s", downloadDir)
+			}
+			sameDir, err := sameDirAsMODDir(application, downloadDir)
+			if err != nil {
+				return err
+			}
+			if sameDir {
+				return fmt.Errorf("Cannot download to MOD directory. Use 'mod install' instead.")
+			}
+
+			specs := make([]modSpec, len(args))
+			for i, arg := range args {
+				spec, err := parseMODSpec(arg)
+				if err != nil {
+					return err
+				}
+				specs[i] = spec
+			}
+
+			targets, err := planDownload(cmd.Context(), application, specs, downloadDir, jobs, recursive)
+			if err != nil {
+				return err
+			}
+
+			p := c.printer(cmd)
+			if len(targets) == 0 {
+				p.Info("No MOD(s) to download")
+				return nil
+			}
+
+			if err := downloadTargets(cmd.Context(), application, targets, jobs); err != nil {
+				return err
+			}
+			p.Success(fmt.Sprintf("Downloaded %d MOD(s)", len(targets)))
+			return nil
+		},
+	}
+	cmd.Flags().StringVarP(&directory, "directory", "d", ".", "Download directory")
+	cmd.Flags().IntVarP(&jobs, "jobs", "j", 4, "Number of parallel downloads")
+	cmd.Flags().BoolVarP(&recursive, "recursive", "r", false, "Include required dependencies recursively")
+	return cmd
+}
+
+// sameDirAsMODDir reports whether dir and the MOD directory are the same
+// path, resolving symlinks. A nonexistent MOD directory can't be equal to
+// anything, so it short-circuits rather than erroring on EvalSymlinks.
+func sameDirAsMODDir(application *app.App, dir string) (bool, error) {
+	modDir, err := application.Runtime.MODDir()
+	if err != nil {
+		return false, err
+	}
+	if _, err := os.Stat(modDir); err != nil {
+		return false, nil
+	}
+	realDownloadDir, err := filepath.EvalSymlinks(dir)
+	if err != nil {
+		return false, err
+	}
+	realMODDir, err := filepath.EvalSymlinks(modDir)
+	if err != nil {
+		return false, err
+	}
+	return realDownloadDir == realMODDir, nil
+}
+
+func planDownload(ctx context.Context, application *app.App, specs []modSpec, downloadDir string, jobs int, recursive bool) ([]downloadTarget, error) {
+	portalAPI, err := application.PortalAPI()
+	if err != nil {
+		return nil, err
+	}
+
+	initial, err := fetchMODInfoConcurrently(ctx, jobs, specs, func(ctx context.Context, spec modSpec) (fetchedMODInfo, error) {
+		info, err := portalAPI.GetMOD(ctx, spec.MOD.Name)
+		if err != nil {
+			return fetchedMODInfo{}, err
+		}
+		release := findRelease(info, spec)
+		if release == nil {
+			return fetchedMODInfo{}, fmt.Errorf("Release not found for %s@%s", spec.MOD.Name, specVersionLabel(spec))
+		}
+		return fetchedMODInfo{MOD: spec.MOD, MODInfo: info, Release: *release}, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	all := initial
+	if recursive {
+		all, err = resolveDownloadDependencies(ctx, application, initial, jobs)
+		if err != nil {
+			return nil, err
+		}
+	}
+	return buildDownloadTargets(all, downloadDir)
+}
+
+func specVersionLabel(spec modSpec) string {
+	if spec.Latest {
+		return "latest"
+	}
+	return spec.Version.String()
+}
+
+type requiredDependency struct {
+	name        string
+	requirement *dependency.VersionRequirement
+}
+
+// resolveDownloadDependencies expands the initial fetch set with required
+// dependencies (recursively), skipping builtin MODs. A dependency with no
+// compatible release, or that errors while fetching, is skipped with a
+// warning rather than failing the whole download — a single incompatible
+// dependency should not block installing the MODs the user actually asked
+// for.
+func resolveDownloadDependencies(ctx context.Context, application *app.App, initial []fetchedMODInfo, jobs int) ([]fetchedMODInfo, error) {
+	portalAPI, err := application.PortalAPI()
+	if err != nil {
+		return nil, err
+	}
+
+	known := map[string]fetchedMODInfo{}
+	frontier := make([]string, 0, len(initial))
+	for _, info := range initial {
+		known[info.MOD.Name] = info
+		frontier = append(frontier, info.MOD.Name)
+	}
+	processed := map[string]bool{}
+
+	for len(frontier) > 0 {
+		newDeps := collectNewDependencies(frontier, known, processed)
+		frontier = nil
+		if len(newDeps) == 0 {
+			continue
+		}
+
+		specs := make([]modSpec, len(newDeps))
+		for i, dep := range newDeps {
+			specs[i] = modSpec{MOD: mod.MOD{Name: dep.name}}
+		}
+		results, err := fetchMODInfoConcurrently(ctx, jobs, specs, func(ctx context.Context, spec modSpec) (fetchedMODInfo, error) {
+			info, err := portalAPI.GetMOD(ctx, spec.MOD.Name)
+			if err != nil {
+				return fetchedMODInfo{}, warnAndSkip(application, spec.MOD.Name, err)
+			}
+			i := slices.IndexFunc(newDeps, func(d requiredDependency) bool { return d.name == spec.MOD.Name })
+			release := findCompatibleRelease(info, newDeps[i].requirement)
+			if release == nil {
+				return fetchedMODInfo{}, warnAndSkip(application, spec.MOD.Name, errors.New("no compatible release found"))
+			}
+			return fetchedMODInfo{MOD: spec.MOD, MODInfo: info, Release: *release}, nil
+		})
+		if err != nil {
+			return nil, err
+		}
+
+		for _, r := range results {
+			if r.MODInfo == nil {
+				continue // skipped: warnAndSkip already logged the reason
+			}
+			known[r.MOD.Name] = r
+			frontier = append(frontier, r.MOD.Name)
+		}
+	}
+
+	all := make([]fetchedMODInfo, 0, len(known))
+	for _, info := range known {
+		all = append(all, info)
+	}
+	return all, nil
+}
+
+// warnAndSkip logs and returns nil so the caller treats the dependency as
+// skippable rather than fatal.
+func warnAndSkip(application *app.App, modName string, cause error) error {
+	application.Logger.Warn("Skipping dependency", "mod", modName, "reason", cause)
+	return nil
+}
+
+func collectNewDependencies(batch []string, known map[string]fetchedMODInfo, processed map[string]bool) []requiredDependency {
+	var newDeps []requiredDependency
+	for _, name := range batch {
+		if processed[name] {
+			continue
+		}
+		processed[name] = true
+
+		info, ok := known[name]
+		if !ok {
+			continue
+		}
+		for _, depString := range info.Release.InfoJSON.Dependencies {
+			entry, err := dependency.Parse(depString)
+			if err != nil || entry.Type != dependency.TypeRequired {
+				continue
+			}
+			if slices.Contains(builtinMODs, entry.MOD.Name) {
+				continue
+			}
+			if _, ok := known[entry.MOD.Name]; ok {
+				continue
+			}
+			newDeps = append(newDeps, requiredDependency{name: entry.MOD.Name, requirement: entry.Requirement})
+		}
+	}
+	return newDeps
+}

--- a/internal/cli/mod_portal_readonly_test.go
+++ b/internal/cli/mod_portal_readonly_test.go
@@ -1,0 +1,82 @@
+package cli
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sakuro/factorix/internal/mod"
+)
+
+func TestMODShowRejectsBuiltinMODs(t *testing.T) {
+	newSandbox(t)
+
+	_, err := runCLI(t, "mod", "show", "base")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Cannot show base MOD")
+
+	_, err = runCLI(t, "mod", "show", "space-age")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Cannot show expansion MOD: space-age")
+}
+
+func TestMODDownloadRejectsMissingDirectory(t *testing.T) {
+	newSandbox(t)
+
+	_, err := runCLI(t, "mod", "download", "-d", "/nonexistent/directory/xyz", "some-mod")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Download directory does not exist")
+}
+
+func TestMODDownloadRejectsMODDirAsTarget(t *testing.T) {
+	s := newSandbox(t)
+
+	_, err := runCLI(t, "mod", "download", "-d", filepath.Join(s.root, "factorio", "mods"), "some-mod")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Cannot download to MOD directory")
+}
+
+func TestDefaultFactorioVersion(t *testing.T) {
+	baseSandbox(t)
+
+	application, err := (&cli{}).App()
+	require.NoError(t, err)
+
+	version, err := defaultFactorioVersion(application)
+	require.NoError(t, err)
+	assert.Equal(t, "1.1", version) // base-info.json fixture is version 1.1.110
+}
+
+func TestFetchLocalStatusNotInstalled(t *testing.T) {
+	s := baseSandbox(t)
+	s.writeMODList(t, modListEntry{name: "base", enabled: true})
+
+	application, err := (&cli{}).App()
+	require.NoError(t, err)
+
+	status, err := fetchLocalStatus(application, mod.MOD{Name: "ghost"})
+	require.NoError(t, err)
+	assert.False(t, status.Installed)
+	assert.Nil(t, status.LocalVersion)
+}
+
+func TestFetchLocalStatusInstalledAndEnabled(t *testing.T) {
+	s := baseSandbox(t)
+	s.writeInstalledMOD(t, "some-mod", "1.2.0", nil)
+	s.writeMODList(t,
+		modListEntry{name: "base", enabled: true},
+		modListEntry{name: "some-mod", enabled: true},
+	)
+
+	application, err := (&cli{}).App()
+	require.NoError(t, err)
+
+	status, err := fetchLocalStatus(application, mod.MOD{Name: "some-mod"})
+	require.NoError(t, err)
+	assert.True(t, status.Installed)
+	assert.True(t, status.Enabled)
+	require.NotNil(t, status.LocalVersion)
+	assert.Equal(t, "1.2.0", status.LocalVersion.String())
+}

--- a/internal/cli/mod_search.go
+++ b/internal/cli/mod_search.go
@@ -65,8 +65,7 @@ func newMODSearchCommand(c *cli) *cobra.Command {
 			if jsonOutput {
 				return outputSearchJSON(p, result.Results)
 			}
-			outputSearchTable(p, result.Results)
-			return nil
+			return outputSearchTable(p, result.Results)
 		},
 	}
 	cmd.Flags().BoolVar(&hideDeprecated, "hide-deprecated", true, "Hide deprecated MOD(s)")
@@ -93,10 +92,10 @@ func defaultFactorioVersion(application *app.App) (string, error) {
 	return strconv.Itoa(int(base.Version.Major)) + "." + strconv.Itoa(int(base.Version.Minor)), nil
 }
 
-func outputSearchTable(p *printer, mods []api.MODInfo) {
+func outputSearchTable(p *printer, mods []api.MODInfo) error {
 	if len(mods) == 0 {
 		p.Info("No MOD(s) found")
-		return
+		return nil
 	}
 
 	type row struct{ name, title, category, owner, latest string }
@@ -106,7 +105,11 @@ func outputSearchTable(p *printer, mods []api.MODInfo) {
 		if m.LatestRelease != nil {
 			latest = m.LatestRelease.Version.String()
 		}
-		rows[i] = row{m.Name, m.Title, api.CategoryFor(m.Category).Name, m.Owner, latest}
+		category, err := api.CategoryFor(m.Category)
+		if err != nil {
+			return err
+		}
+		rows[i] = row{m.Name, m.Title, category.Name, m.Owner, latest}
 	}
 
 	headers := []string{"NAME", "TITLE", "CATEGORY", "OWNER", "LATEST"}
@@ -128,6 +131,7 @@ func outputSearchTable(p *printer, mods []api.MODInfo) {
 	}
 
 	p.Info(strconv.Itoa(len(mods)) + " MOD(s) found")
+	return nil
 }
 
 func outputSearchJSON(p *printer, mods []api.MODInfo) error {

--- a/internal/cli/mod_search.go
+++ b/internal/cli/mod_search.go
@@ -1,0 +1,195 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"path/filepath"
+	"strconv"
+
+	"github.com/spf13/cobra"
+
+	"github.com/sakuro/factorix/internal/api"
+	"github.com/sakuro/factorix/internal/app"
+	"github.com/sakuro/factorix/internal/mod"
+)
+
+func newMODSearchCommand(c *cli) *cobra.Command {
+	var hideDeprecated bool
+	var page, pageSize int
+	var sort, sortOrder, version string
+	var jsonOutput bool
+
+	cmd := &cobra.Command{
+		Use:   "search [mod-name]...",
+		Short: "Search MOD(s) on Factorio MOD Portal",
+		Args:  cobra.ArbitraryArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			application, err := c.App()
+			if err != nil {
+				return err
+			}
+
+			if version == "" {
+				version, err = defaultFactorioVersion(application)
+				if err != nil {
+					return err
+				}
+			}
+
+			opts := api.GetMODsOptions{
+				Namelist:  args,
+				Page:      page,
+				PageSize:  strconv.Itoa(pageSize),
+				Sort:      sort,
+				SortOrder: sortOrder,
+				Version:   version,
+			}
+			// Ruby only ever sends hide_deprecated=true or omits the param
+			// (--no-hide-deprecated maps to nil, not false); mirrored here so
+			// the query the portal sees is identical.
+			if hideDeprecated {
+				t := true
+				opts.HideDeprecated = &t
+			}
+
+			portalAPI, err := application.PortalAPI()
+			if err != nil {
+				return err
+			}
+			result, err := portalAPI.GetMODs(cmd.Context(), opts)
+			if err != nil {
+				return err
+			}
+
+			p := c.printer(cmd)
+			if jsonOutput {
+				return outputSearchJSON(p, result.Results)
+			}
+			outputSearchTable(p, result.Results)
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&hideDeprecated, "hide-deprecated", true, "Hide deprecated MOD(s)")
+	cmd.Flags().IntVar(&page, "page", 1, "Page number")
+	cmd.Flags().IntVar(&pageSize, "page-size", 25, "Results per page (max 500)")
+	cmd.Flags().StringVar(&sort, "sort", "", "Sort field (name, created_at, updated_at)")
+	cmd.Flags().StringVar(&sortOrder, "sort-order", "", "Sort order (asc, desc)")
+	cmd.Flags().StringVar(&version, "version", "", "Filter by Factorio version (default: installed version)")
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSON format")
+	return cmd
+}
+
+// defaultFactorioVersion reads the installed base MOD's major.minor as the
+// implicit Factorio version filter, matching Ruby's default_factorio_version.
+func defaultFactorioVersion(application *app.App) (string, error) {
+	dataDir, err := application.Runtime.DataDir()
+	if err != nil {
+		return "", err
+	}
+	base, err := mod.InstalledMODFromDirectory(filepath.Join(dataDir, "base"))
+	if err != nil {
+		return "", err
+	}
+	return strconv.Itoa(int(base.Version.Major)) + "." + strconv.Itoa(int(base.Version.Minor)), nil
+}
+
+func outputSearchTable(p *printer, mods []api.MODInfo) {
+	if len(mods) == 0 {
+		p.Info("No MOD(s) found")
+		return
+	}
+
+	type row struct{ name, title, category, owner, latest string }
+	rows := make([]row, len(mods))
+	for i, m := range mods {
+		latest := ""
+		if m.LatestRelease != nil {
+			latest = m.LatestRelease.Version.String()
+		}
+		rows[i] = row{m.Name, m.Title, api.CategoryFor(m.Category).Name, m.Owner, latest}
+	}
+
+	headers := []string{"NAME", "TITLE", "CATEGORY", "OWNER", "LATEST"}
+	widths := make([]int, len(headers))
+	for i, h := range headers {
+		widths[i] = len(h)
+	}
+	for _, r := range rows {
+		widths[0] = max(widths[0], len(r.name))
+		widths[1] = max(widths[1], len(r.title))
+		widths[2] = max(widths[2], len(r.category))
+		widths[3] = max(widths[3], len(r.owner))
+		widths[4] = max(widths[4], len(r.latest))
+	}
+
+	p.Printf("%-*s  %-*s  %-*s  %-*s  %-*s\n", widths[0], headers[0], widths[1], headers[1], widths[2], headers[2], widths[3], headers[3], widths[4], headers[4])
+	for _, r := range rows {
+		p.Printf("%-*s  %-*s  %-*s  %-*s  %-*s\n", widths[0], r.name, widths[1], r.title, widths[2], r.category, widths[3], r.owner, widths[4], r.latest)
+	}
+
+	p.Info(strconv.Itoa(len(mods)) + " MOD(s) found")
+}
+
+func outputSearchJSON(p *printer, mods []api.MODInfo) error {
+	type releaseJSON struct {
+		Version         string `json:"version"`
+		FileName        string `json:"file_name"`
+		ReleasedAt      string `json:"released_at"`
+		FactorioVersion string `json:"factorio_version"`
+		SHA1            string `json:"sha1"`
+	}
+	type modJSON struct {
+		Name           string        `json:"name"`
+		Title          string        `json:"title"`
+		Owner          string        `json:"owner"`
+		Summary        string        `json:"summary"`
+		DownloadsCount int           `json:"downloads_count"`
+		Category       string        `json:"category"`
+		Score          float64       `json:"score"`
+		Thumbnail      *string       `json:"thumbnail"`
+		LatestRelease  *releaseJSON  `json:"latest_release"`
+		Releases       []releaseJSON `json:"releases"`
+	}
+
+	toReleaseJSON := func(r api.Release) releaseJSON {
+		return releaseJSON{
+			Version:         r.Version.String(),
+			FileName:        r.FileName,
+			ReleasedAt:      r.ReleasedAt.Format("2006-01-02T15:04:05Z07:00"),
+			FactorioVersion: r.InfoJSON.FactorioVersion,
+			SHA1:            r.SHA1,
+		}
+	}
+
+	entries := make([]modJSON, len(mods))
+	for i, m := range mods {
+		var thumbnail *string
+		if url := m.ThumbnailURL(); url != "" {
+			thumbnail = &url
+		}
+		var latest *releaseJSON
+		if m.LatestRelease != nil {
+			r := toReleaseJSON(*m.LatestRelease)
+			latest = &r
+		}
+		releases := make([]releaseJSON, len(m.Releases))
+		for j, r := range m.Releases {
+			releases[j] = toReleaseJSON(r)
+		}
+		entries[i] = modJSON{
+			Name: m.Name, Title: m.Title, Owner: m.Owner, Summary: m.Summary,
+			DownloadsCount: m.DownloadsCount, Category: m.Category, Score: m.Score,
+			Thumbnail: thumbnail, LatestRelease: latest, Releases: releases,
+		}
+	}
+
+	var buf bytes.Buffer
+	encoder := json.NewEncoder(&buf)
+	encoder.SetEscapeHTML(false)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(entries); err != nil {
+		return err
+	}
+	p.Printf("%s", buf.String())
+	return nil
+}

--- a/internal/cli/mod_search_test.go
+++ b/internal/cli/mod_search_test.go
@@ -27,7 +27,7 @@ func TestOutputSearchTable(t *testing.T) {
 	var buf bytes.Buffer
 	p := &printer{out: &buf}
 
-	outputSearchTable(p, sampleSearchMODs())
+	require.NoError(t, outputSearchTable(p, sampleSearchMODs()))
 
 	out := buf.String()
 	assert.Contains(t, out, "NAME")
@@ -42,8 +42,17 @@ func TestOutputSearchTable(t *testing.T) {
 func TestOutputSearchTableEmpty(t *testing.T) {
 	var buf bytes.Buffer
 	p := &printer{out: &buf}
-	outputSearchTable(p, nil)
+	require.NoError(t, outputSearchTable(p, nil))
 	assert.Contains(t, buf.String(), "No MOD(s) found")
+}
+
+func TestOutputSearchTableUnknownCategory(t *testing.T) {
+	var buf bytes.Buffer
+	p := &printer{out: &buf}
+	mods := []api.MODInfo{{Name: "some-mod", Category: "not-a-real-category"}}
+
+	err := outputSearchTable(p, mods)
+	require.ErrorIs(t, err, api.ErrInvalidResponse)
 }
 
 func TestOutputSearchJSON(t *testing.T) {

--- a/internal/cli/mod_search_test.go
+++ b/internal/cli/mod_search_test.go
@@ -1,0 +1,58 @@
+package cli
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sakuro/factorix/internal/api"
+	"github.com/sakuro/factorix/internal/mod"
+)
+
+func sampleSearchMODs() []api.MODInfo {
+	v, _ := mod.ParseMODVersion("1.2.0")
+	return []api.MODInfo{
+		{
+			Name: "some-mod", Title: "Some MOD", Owner: "alice", Category: "content",
+			LatestRelease: &api.Release{Version: v},
+		},
+		{Name: "no-release-mod", Title: "No Release", Owner: "bob", Category: "utilities"},
+	}
+}
+
+func TestOutputSearchTable(t *testing.T) {
+	t.Setenv("NO_COLOR", "1")
+	var buf bytes.Buffer
+	p := &printer{out: &buf}
+
+	outputSearchTable(p, sampleSearchMODs())
+
+	out := buf.String()
+	assert.Contains(t, out, "NAME")
+	assert.Contains(t, out, "CATEGORY")
+	assert.Contains(t, out, "some-mod")
+	assert.Contains(t, out, "Content") // display name, not the raw "content" value
+	assert.Contains(t, out, "Utilities")
+	assert.Contains(t, out, "1.2.0")
+	assert.Contains(t, out, "2 MOD(s) found")
+}
+
+func TestOutputSearchTableEmpty(t *testing.T) {
+	var buf bytes.Buffer
+	p := &printer{out: &buf}
+	outputSearchTable(p, nil)
+	assert.Contains(t, buf.String(), "No MOD(s) found")
+}
+
+func TestOutputSearchJSON(t *testing.T) {
+	var buf bytes.Buffer
+	p := &printer{out: &buf}
+	require.NoError(t, outputSearchJSON(p, sampleSearchMODs()))
+
+	out := buf.String()
+	assert.Contains(t, out, `"category": "content"`) // raw value, not display name
+	assert.Contains(t, out, `"thumbnail": null`)
+	assert.Contains(t, out, `"latest_release": null`) // no-release-mod has none
+}

--- a/internal/cli/mod_show.go
+++ b/internal/cli/mod_show.go
@@ -51,8 +51,7 @@ func newMODShowCommand(c *cli) *cobra.Command {
 			if jsonOutput {
 				return outputShowJSON(p, info, localStatus)
 			}
-			displayShow(p, info, localStatus)
-			return nil
+			return displayShow(p, info, localStatus)
 		},
 	}
 	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSON format")
@@ -121,7 +120,7 @@ func latestByVersion(releases []api.Release) *api.Release {
 	return latest
 }
 
-func displayShow(p *printer, info *api.MODInfo, status localMODStatus) {
+func displayShow(p *printer, info *api.MODInfo, status localMODStatus) error {
 	title := color.New(color.Bold, color.Underline)
 	header := color.New(color.Bold)
 	incompatible := color.New(color.FgRed)
@@ -138,7 +137,9 @@ func displayShow(p *printer, info *api.MODInfo, status localMODStatus) {
 	}
 	p.Println()
 
-	displayBasicInfo(p, info, status)
+	if err := displayBasicInfo(p, info, status); err != nil {
+		return err
+	}
 
 	p.Println(header.Sprint("Links"))
 	p.Println("  MOD Portal: https://mods.factorio.com/mod/" + info.Name)
@@ -152,7 +153,7 @@ func displayShow(p *printer, info *api.MODInfo, status localMODStatus) {
 
 	latest := latestReleaseOf(info)
 	if latest == nil {
-		return
+		return nil
 	}
 	required, optional, incompatibleDeps := classifyDependencies(latest.InfoJSON.Dependencies)
 
@@ -177,9 +178,10 @@ func displayShow(p *printer, info *api.MODInfo, status localMODStatus) {
 		}
 		p.Println()
 	}
+	return nil
 }
 
-func displayBasicInfo(p *printer, info *api.MODInfo, status localMODStatus) {
+func displayBasicInfo(p *printer, info *api.MODInfo, status localMODStatus) error {
 	latest := latestReleaseOf(info)
 	factorioVersion := "N/A"
 	if latest != nil && latest.InfoJSON.FactorioVersion != "" {
@@ -200,9 +202,13 @@ func displayBasicInfo(p *printer, info *api.MODInfo, status localMODStatus) {
 		}
 		rows = append(rows, row{"Installed Version", status.LocalVersion.String() + note})
 	}
+	category, err := api.CategoryFor(info.Category)
+	if err != nil {
+		return err
+	}
 	rows = append(rows,
 		row{"Author", info.Owner},
-		row{"Category", api.CategoryFor(info.Category).Name},
+		row{"Category", category.Name},
 		row{"License", formatLicense(info)},
 		row{"Factorio Version", factorioVersion},
 		row{"Downloads", fmt.Sprintf("%d", info.DownloadsCount)},
@@ -216,6 +222,7 @@ func displayBasicInfo(p *printer, info *api.MODInfo, status localMODStatus) {
 		p.Printf("%-*s  %s\n", width, r.label, r.value)
 	}
 	p.Println()
+	return nil
 }
 
 func formatLocalStatus(status localMODStatus) string {
@@ -299,6 +306,10 @@ func outputShowJSON(p *printer, info *api.MODInfo, status localMODStatus) error 
 	if info.Homepage != "" {
 		homepage = &info.Homepage
 	}
+	category, err := api.CategoryFor(info.Category)
+	if err != nil {
+		return err
+	}
 
 	doc := struct {
 		Name             string  `json:"name"`
@@ -321,7 +332,7 @@ func outputShowJSON(p *printer, info *api.MODInfo, status localMODStatus) error 
 		Dependencies []string `json:"dependencies"`
 	}{
 		Name: info.Name, Title: info.Title, Summary: info.Summary, Author: info.Owner,
-		Category: api.CategoryFor(info.Category).Name, License: license, FactorioVersion: factorioVersion,
+		Category: category.Name, License: license, FactorioVersion: factorioVersion,
 		DownloadsCount: info.DownloadsCount, Status: jsonLocalStatus(status),
 		LatestVersion: latestVersion, InstalledVersion: installedVersion, UpdateAvailable: updateAvailable,
 		Dependencies: dependencies,

--- a/internal/cli/mod_show.go
+++ b/internal/cli/mod_show.go
@@ -1,0 +1,352 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"strings"
+
+	"github.com/fatih/color"
+	"github.com/spf13/cobra"
+
+	"github.com/sakuro/factorix/internal/api"
+	"github.com/sakuro/factorix/internal/app"
+	"github.com/sakuro/factorix/internal/mod"
+)
+
+func newMODShowCommand(c *cli) *cobra.Command {
+	var jsonOutput bool
+
+	cmd := &cobra.Command{
+		Use:   "show <mod-name>",
+		Short: "Show MOD details from Factorio MOD Portal",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			target := mod.MOD{Name: args[0]}
+			if target.IsBase() {
+				return fmt.Errorf("Cannot show base MOD")
+			}
+			if target.IsExpansion() {
+				return fmt.Errorf("Cannot show expansion MOD: %s", target.Name)
+			}
+
+			application, err := c.App()
+			if err != nil {
+				return err
+			}
+			portalAPI, err := application.PortalAPI()
+			if err != nil {
+				return err
+			}
+			info, err := portalAPI.GetMODFull(cmd.Context(), target.Name)
+			if err != nil {
+				return err
+			}
+			localStatus, err := fetchLocalStatus(application, target)
+			if err != nil {
+				return err
+			}
+
+			p := c.printer(cmd)
+			if jsonOutput {
+				return outputShowJSON(p, info, localStatus)
+			}
+			displayShow(p, info, localStatus)
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSON format")
+	return cmd
+}
+
+type localMODStatus struct {
+	Installed    bool
+	Enabled      bool
+	LocalVersion *mod.MODVersion
+}
+
+func fetchLocalStatus(application *app.App, target mod.MOD) (localMODStatus, error) {
+	modListPath, err := application.Runtime.MODListPath()
+	if err != nil {
+		return localMODStatus{}, err
+	}
+	modList, err := mod.LoadMODList(modListPath)
+	if err != nil {
+		return localMODStatus{}, err
+	}
+
+	var status localMODStatus
+	status.Enabled = modList.Contains(target) && func() bool { e, _ := modList.Enabled(target); return e }()
+
+	modDir, err := application.Runtime.MODDir()
+	if err != nil {
+		return localMODStatus{}, err
+	}
+	dataDir, err := application.Runtime.DataDir()
+	if err != nil {
+		return localMODStatus{}, err
+	}
+	installed, err := mod.ScanInstalled(modDir, dataDir, application.Logger, nil)
+	if err != nil {
+		return localMODStatus{}, err
+	}
+	for _, im := range installed {
+		if im.MOD == target {
+			status.Installed = true
+			v := im.Version
+			status.LocalVersion = &v
+			break
+		}
+	}
+	return status, nil
+}
+
+func latestReleaseOf(info *api.MODInfo) *api.Release {
+	if info.LatestRelease != nil {
+		return info.LatestRelease
+	}
+	return latestByVersion(info.Releases)
+}
+
+func latestByVersion(releases []api.Release) *api.Release {
+	if len(releases) == 0 {
+		return nil
+	}
+	latest := &releases[0]
+	for i := 1; i < len(releases); i++ {
+		if latest.Version.Less(releases[i].Version) {
+			latest = &releases[i]
+		}
+	}
+	return latest
+}
+
+func displayShow(p *printer, info *api.MODInfo, status localMODStatus) {
+	title := color.New(color.Bold, color.Underline)
+	header := color.New(color.Bold)
+	incompatible := color.New(color.FgRed)
+	if !colorEnabled() {
+		title.DisableColor()
+		header.DisableColor()
+		incompatible.DisableColor()
+	}
+
+	p.Println(title.Sprint(info.Title))
+	p.Println()
+	if info.Summary != "" {
+		p.Println(info.Summary)
+	}
+	p.Println()
+
+	displayBasicInfo(p, info, status)
+
+	p.Println(header.Sprint("Links"))
+	p.Println("  MOD Portal: https://mods.factorio.com/mod/" + info.Name)
+	if info.SourceURL != "" {
+		p.Println("  Source: " + info.SourceURL)
+	}
+	if info.Homepage != "" {
+		p.Println("  Homepage: " + info.Homepage)
+	}
+	p.Println()
+
+	latest := latestReleaseOf(info)
+	if latest == nil {
+		return
+	}
+	required, optional, incompatibleDeps := classifyDependencies(latest.InfoJSON.Dependencies)
+
+	if len(required) > 0 {
+		p.Println(header.Sprint("Dependencies"))
+		for _, d := range required {
+			p.Println("  " + d)
+		}
+		p.Println()
+	}
+	if len(optional) > 0 {
+		p.Println(header.Sprint("Optional Dependencies"))
+		for _, d := range optional {
+			p.Println("  " + d)
+		}
+		p.Println()
+	}
+	if len(incompatibleDeps) > 0 {
+		p.Println(header.Sprint("Incompatibilities"))
+		for _, d := range incompatibleDeps {
+			p.Println("  " + incompatible.Sprint(d))
+		}
+		p.Println()
+	}
+}
+
+func displayBasicInfo(p *printer, info *api.MODInfo, status localMODStatus) {
+	latest := latestReleaseOf(info)
+	factorioVersion := "N/A"
+	if latest != nil && latest.InfoJSON.FactorioVersion != "" {
+		factorioVersion = latest.InfoJSON.FactorioVersion
+	}
+
+	type row struct{ label, value string }
+	rows := []row{{"Status", formatLocalStatus(status)}}
+	if latest != nil {
+		rows = append(rows, row{"Latest Version", latest.Version.String()})
+	} else {
+		rows = append(rows, row{"Latest Version", "N/A"})
+	}
+	if status.Installed && status.LocalVersion != nil {
+		note := ""
+		if latest != nil && *status.LocalVersion != latest.Version {
+			note = " (update available)"
+		}
+		rows = append(rows, row{"Installed Version", status.LocalVersion.String() + note})
+	}
+	rows = append(rows,
+		row{"Author", info.Owner},
+		row{"Category", api.CategoryFor(info.Category).Name},
+		row{"License", formatLicense(info)},
+		row{"Factorio Version", factorioVersion},
+		row{"Downloads", fmt.Sprintf("%d", info.DownloadsCount)},
+	)
+
+	width := 0
+	for _, r := range rows {
+		width = max(width, len(r.label))
+	}
+	for _, r := range rows {
+		p.Printf("%-*s  %s\n", width, r.label, r.value)
+	}
+	p.Println()
+}
+
+func formatLocalStatus(status localMODStatus) string {
+	if !status.Installed {
+		return "Not installed"
+	}
+	if status.Enabled {
+		return "Enabled"
+	}
+	return "Disabled"
+}
+
+func formatLicense(info *api.MODInfo) string {
+	if info.License == nil {
+		return "N/A"
+	}
+	return info.License.Title
+}
+
+// classifyDependencies splits raw dependency strings by prefix, matching
+// Ruby's own regex-based classification in mod/show.rb (not
+// internal/dependency.Parse's Type, so a malformed entry here is simply
+// treated as required rather than rejected — this command only displays
+// dependencies, it never resolves them).
+func classifyDependencies(raw []string) (required, optional, incompatible []string) {
+	for _, dep := range raw {
+		trimmed := strings.TrimSpace(dep)
+		switch {
+		case strings.HasPrefix(trimmed, "!"):
+			incompatible = append(incompatible, strings.TrimSpace(strings.TrimPrefix(trimmed, "!")))
+		case strings.HasPrefix(trimmed, "(?)"):
+			optional = append(optional, strings.TrimSpace(strings.TrimPrefix(trimmed, "(?)")))
+		case strings.HasPrefix(trimmed, "?"):
+			optional = append(optional, strings.TrimSpace(strings.TrimPrefix(trimmed, "?")))
+		case strings.HasPrefix(trimmed, "~"):
+			// load-neutral: Ruby's parse_dependency tags it but show.rb never
+			// displays this bucket, so it's parsed and discarded here too.
+		default:
+			required = append(required, trimmed)
+		}
+	}
+	return required, optional, incompatible
+}
+
+func outputShowJSON(p *printer, info *api.MODInfo, status localMODStatus) error {
+	latest := latestReleaseOf(info)
+	factorioVersion := ""
+	var latestVersion *string
+	var dependencies []string
+	if latest != nil {
+		factorioVersion = latest.InfoJSON.FactorioVersion
+		v := latest.Version.String()
+		latestVersion = &v
+		dependencies = latest.InfoJSON.Dependencies
+	}
+	if dependencies == nil {
+		dependencies = []string{}
+	}
+
+	var installedVersion *string
+	var updateAvailable *bool
+	if status.Installed {
+		if status.LocalVersion != nil {
+			v := status.LocalVersion.String()
+			installedVersion = &v
+			if latestVersion != nil {
+				u := v != *latestVersion
+				updateAvailable = &u
+			}
+		}
+	}
+
+	var license *string
+	if info.License != nil {
+		license = &info.License.Title
+	}
+	var sourceURL, homepage *string
+	if info.SourceURL != "" {
+		sourceURL = &info.SourceURL
+	}
+	if info.Homepage != "" {
+		homepage = &info.Homepage
+	}
+
+	doc := struct {
+		Name             string  `json:"name"`
+		Title            string  `json:"title"`
+		Summary          string  `json:"summary"`
+		Author           string  `json:"author"`
+		Category         string  `json:"category"`
+		License          *string `json:"license"`
+		FactorioVersion  string  `json:"factorio_version"`
+		DownloadsCount   int     `json:"downloads_count"`
+		Status           string  `json:"status"`
+		LatestVersion    *string `json:"latest_version"`
+		InstalledVersion *string `json:"installed_version"`
+		UpdateAvailable  *bool   `json:"update_available"`
+		Links            struct {
+			ModPortal string  `json:"mod_portal"`
+			Source    *string `json:"source"`
+			Homepage  *string `json:"homepage"`
+		} `json:"links"`
+		Dependencies []string `json:"dependencies"`
+	}{
+		Name: info.Name, Title: info.Title, Summary: info.Summary, Author: info.Owner,
+		Category: api.CategoryFor(info.Category).Name, License: license, FactorioVersion: factorioVersion,
+		DownloadsCount: info.DownloadsCount, Status: jsonLocalStatus(status),
+		LatestVersion: latestVersion, InstalledVersion: installedVersion, UpdateAvailable: updateAvailable,
+		Dependencies: dependencies,
+	}
+	doc.Links.ModPortal = "https://mods.factorio.com/mod/" + info.Name
+	doc.Links.Source = sourceURL
+	doc.Links.Homepage = homepage
+
+	var buf bytes.Buffer
+	encoder := json.NewEncoder(&buf)
+	encoder.SetEscapeHTML(false)
+	encoder.SetIndent("", "  ")
+	if err := encoder.Encode(doc); err != nil {
+		return err
+	}
+	p.Printf("%s", buf.String())
+	return nil
+}
+
+func jsonLocalStatus(status localMODStatus) string {
+	if !status.Installed {
+		return "not_installed"
+	}
+	if status.Enabled {
+		return "enabled"
+	}
+	return "disabled"
+}

--- a/internal/cli/mod_show_test.go
+++ b/internal/cli/mod_show_test.go
@@ -1,0 +1,102 @@
+package cli
+
+import (
+	"bytes"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sakuro/factorix/internal/api"
+	"github.com/sakuro/factorix/internal/mod"
+)
+
+func sampleShowMODInfo() *api.MODInfo {
+	v, _ := mod.ParseMODVersion("2.0.0")
+	return &api.MODInfo{
+		Name: "some-mod", Title: "Some MOD", Summary: "A test MOD", Owner: "alice",
+		Category: "content", DownloadsCount: 42,
+		License:   &api.License{Title: "MIT License"},
+		SourceURL: "https://example.com/src", Homepage: "https://example.com",
+		LatestRelease: &api.Release{
+			Version: v,
+			InfoJSON: api.ReleaseInfoJSON{
+				FactorioVersion: "2.0",
+				Dependencies:    []string{"base", "lib >= 1.0", "? optional-lib", "! bad-mod", "~ neutral-mod"},
+			},
+		},
+	}
+}
+
+func TestClassifyDependencies(t *testing.T) {
+	required, optional, incompatible := classifyDependencies([]string{
+		"base", "lib >= 1.0", "? optional-lib", "(?) hidden-lib", "! bad-mod", "~ neutral-mod",
+	})
+	assert.Equal(t, []string{"base", "lib >= 1.0"}, required)
+	assert.Equal(t, []string{"optional-lib", "hidden-lib"}, optional)
+	assert.Equal(t, []string{"bad-mod"}, incompatible)
+}
+
+func TestFormatLocalStatus(t *testing.T) {
+	assert.Equal(t, "Not installed", formatLocalStatus(localMODStatus{}))
+	assert.Equal(t, "Disabled", formatLocalStatus(localMODStatus{Installed: true}))
+	assert.Equal(t, "Enabled", formatLocalStatus(localMODStatus{Installed: true, Enabled: true}))
+}
+
+func TestJSONLocalStatus(t *testing.T) {
+	assert.Equal(t, "not_installed", jsonLocalStatus(localMODStatus{}))
+	assert.Equal(t, "disabled", jsonLocalStatus(localMODStatus{Installed: true}))
+	assert.Equal(t, "enabled", jsonLocalStatus(localMODStatus{Installed: true, Enabled: true}))
+}
+
+func TestDisplayShow(t *testing.T) {
+	t.Setenv("NO_COLOR", "1")
+	var buf bytes.Buffer
+	p := &printer{out: &buf}
+
+	displayShow(p, sampleShowMODInfo(), localMODStatus{})
+
+	out := buf.String()
+	assert.Contains(t, out, "Some MOD")
+	assert.Contains(t, out, "A test MOD")
+	assert.Contains(t, out, "Status")
+	assert.Contains(t, out, "Not installed")
+	assert.Contains(t, out, "Content") // category display name
+	assert.Contains(t, out, "MIT License")
+	assert.Contains(t, out, "Source: https://example.com/src")
+	assert.Contains(t, out, "Dependencies")
+	assert.Contains(t, out, "  base")
+	assert.Contains(t, out, "Optional Dependencies")
+	assert.Contains(t, out, "optional-lib")
+	assert.Contains(t, out, "Incompatibilities")
+	assert.Contains(t, out, "bad-mod")
+	assert.NotContains(t, out, "neutral-mod") // load-neutral is parsed and discarded
+}
+
+func TestDisplayShowUpdateAvailable(t *testing.T) {
+	t.Setenv("NO_COLOR", "1")
+	var buf bytes.Buffer
+	p := &printer{out: &buf}
+
+	local := mod.MODVersion{Major: 1}
+	displayShow(p, sampleShowMODInfo(), localMODStatus{Installed: true, Enabled: true, LocalVersion: &local})
+
+	out := buf.String()
+	assert.Contains(t, out, "Enabled")
+	assert.Contains(t, out, "Installed Version")
+	assert.Contains(t, out, "1.0.0 (update available)")
+}
+
+func TestOutputShowJSON(t *testing.T) {
+	var buf bytes.Buffer
+	p := &printer{out: &buf}
+
+	require.NoError(t, outputShowJSON(p, sampleShowMODInfo(), localMODStatus{}))
+
+	out := buf.String()
+	assert.Contains(t, out, `"status": "not_installed"`)
+	assert.Contains(t, out, `"category": "Content"`) // JSON uses .name, unlike search's .value
+	assert.Contains(t, out, `"latest_version": "2.0.0"`)
+	assert.Contains(t, out, `"installed_version": null`)
+	assert.Contains(t, out, `"mod_portal": "https://mods.factorio.com/mod/some-mod"`)
+}

--- a/internal/cli/mod_show_test.go
+++ b/internal/cli/mod_show_test.go
@@ -54,7 +54,7 @@ func TestDisplayShow(t *testing.T) {
 	var buf bytes.Buffer
 	p := &printer{out: &buf}
 
-	displayShow(p, sampleShowMODInfo(), localMODStatus{})
+	require.NoError(t, displayShow(p, sampleShowMODInfo(), localMODStatus{}))
 
 	out := buf.String()
 	assert.Contains(t, out, "Some MOD")
@@ -79,12 +79,35 @@ func TestDisplayShowUpdateAvailable(t *testing.T) {
 	p := &printer{out: &buf}
 
 	local := mod.MODVersion{Major: 1}
-	displayShow(p, sampleShowMODInfo(), localMODStatus{Installed: true, Enabled: true, LocalVersion: &local})
+	require.NoError(t, displayShow(p, sampleShowMODInfo(), localMODStatus{Installed: true, Enabled: true, LocalVersion: &local}))
 
 	out := buf.String()
 	assert.Contains(t, out, "Enabled")
 	assert.Contains(t, out, "Installed Version")
 	assert.Contains(t, out, "1.0.0 (update available)")
+}
+
+func TestDisplayShowUnknownCategory(t *testing.T) {
+	t.Setenv("NO_COLOR", "1")
+	var buf bytes.Buffer
+	p := &printer{out: &buf}
+
+	info := sampleShowMODInfo()
+	info.Category = "not-a-real-category"
+
+	err := displayShow(p, info, localMODStatus{})
+	require.ErrorIs(t, err, api.ErrInvalidResponse)
+}
+
+func TestOutputShowJSONUnknownCategory(t *testing.T) {
+	var buf bytes.Buffer
+	p := &printer{out: &buf}
+
+	info := sampleShowMODInfo()
+	info.Category = "not-a-real-category"
+
+	err := outputShowJSON(p, info, localMODStatus{})
+	require.ErrorIs(t, err, api.ErrInvalidResponse)
 }
 
 func TestOutputShowJSON(t *testing.T) {

--- a/internal/cli/stubs.go
+++ b/internal/cli/stubs.go
@@ -49,8 +49,11 @@ func newMODCommand(c *cli) *cobra.Command {
 		newMODSettingsCommand(c),
 		newMODEnableCommand(c),
 		newMODDisableCommand(c),
+		newMODSearchCommand(c),
+		newMODShowCommand(c),
+		newMODDownloadCommand(c),
 	)
-	for _, use := range []string{"show", "search", "install", "uninstall", "update", "download", "upload", "edit", "sync"} {
+	for _, use := range []string{"install", "uninstall", "update", "upload", "edit", "sync"} {
 		mod.AddCommand(&cobra.Command{Use: use, Short: "MOD " + use, RunE: notImplemented})
 	}
 


### PR DESCRIPTION
## Summary
Third slice of Phase 10 (CLI commands): `mod search`, `mod show`, and `mod download`, plus the download-planning machinery they share with `install`/`update`/`sync` later.

## Changes
- `internal/api/category.go`: the Category display catalog deferred from Phase 7 (needed now for `mod search`'s table CATEGORY column and `mod show`'s Category row). An unrecognized value errors, matching Ruby's `Category.for` (which raises `KeyError`) — categories change rarely, so an unknown one means this catalog is stale and needs a code change, not a value to paper over
- `internal/cli/download_support.go`: MOD spec parsing (`name`/`name@version`/`name@latest`), release resolution, target building, and bounded-concurrency parallel fetch/download — shared logic mirroring Ruby's `DownloadSupport` mixin, reused by `mod download` now and `install`/`update`/`sync` later
- `internal/app` gains `Downloader()` and `MODDownloadAPI()` (wired as Client → Retry, no cache decorator, matching Ruby's `download_http_client`), plus `FACTORIX_MODS_PORTAL_URL` as an optional endpoint override (portal mirrors; also how the CLI test suite points at an httptest server)
- `mod search`: table/JSON output; `--version` defaults to the installed base MOD's major.minor when omitted
- `mod show`: local install/enabled status, license/category/dependency display, classifying raw dependency strings by prefix for the Dependencies/Optional/Incompatibilities sections
- `mod download`: `--recursive` pulls in required dependencies (BFS, builtin MODs skipped); an unresolvable dependency is skipped with a warning rather than failing the whole download
- `mod sync` was reconsidered mid-phase and reprioritized after these three: despite living under "Local MOD Management" in the roadmap, it needs this same Portal/download machinery to install MODs present in a save but missing locally (roadmap updated with a note)

## Bug fixed (found by running the real binary against the live Portal)
`MODInfo.LastHighlightedAt` broke `mod show`/`mod download` for MODs like Krastorio2 with `invalid API response: parsing time "2026-05-18" as "2006-01-02T15:04:05Z07:00": cannot parse "" as "T"`. The Portal returns this field as either a full RFC3339 timestamp or a bare date — both valid ISO 8601, but `time.Time`'s own `UnmarshalJSON` only accepts the RFC3339 form. Fixed with a custom `MODInfo.UnmarshalJSON` that parses `last_highlighted_at` against both forms; `created_at`/`updated_at` are always full timestamps in the responses actually observed and were left on standard `time.Time` decoding.

## Known CLI difference from Ruby
A MOD name starting with `--` (some exist on the Portal, e.g. `----early-bird----`, apparently for in-game sort-order tricks) needs the standard `--` separator (`mod show -- ----early-bird----`) since cobra/pflag treat a leading `--` as a flag token. dry-cli didn't require this. Confirmed working with `--` in manual testing; not treated as a bug to fix, since `--` is the standard POSIX/GNU convention for this exact situation.

## Test Plan
- `go build ./... && go vet ./... && go test ./...` pass locally (`mise run default`)
- Unit tests cover the download-planning pure functions (spec parsing, release/compatible-release resolution, filename validation, target building, dependency collection) and the search/show formatting functions (table/JSON shape, category display name vs raw value, dependency classification, update-available detection) directly, without a live server
- CLI-level tests cover the argument-validation paths that don't need network (builtin MOD rejection, missing/same-as-MOD-dir download directory) and the local-only helpers (`defaultFactorioVersion`, `fetchLocalStatus`) against sandbox fixtures
- Manually ran the built binary against the real Factorio Mod Portal: `mod search` (real results, correct category names), `mod show` on a real MOD including one whose name starts with `--`, `mod show`/`mod download` on Krastorio2 confirming the date-parsing fix, and `mod download`'s credential-error path with no credentials configured

