### PR TITLE
:recycle: Replace manual sync.Once+value+err with sync.OnceValues

### DIFF
--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -25,7 +25,7 @@ import (
 var maskedQueryParams = []string{"username", "token", "secure"}
 
 // App holds the application-wide object graph. Expensive components are
-// built lazily on first use.
+// built lazily on first use, memoized via sync.OnceValues.
 type App struct {
 	Config  config.Config
 	Runtime *platform.Runtime
@@ -33,17 +33,20 @@ type App struct {
 
 	logCloser io.Closer
 
-	portalOnce sync.Once
-	portal     *api.MODPortalAPI
-	portalErr  error
+	// PortalAPI returns the MOD Portal client, wired with the api cache and
+	// retry as Client → CacheTransport → Retry (retry outermost, as in Ruby).
+	PortalAPI func() (*api.MODPortalAPI, error)
 
-	downloaderOnce sync.Once
-	downloader     *transfer.Downloader
-	downloaderErr  error
+	// Downloader returns the MOD file downloader, wired as Client → Retry
+	// (no cache decorator: the downloader manages its own download-type
+	// cache directly, matching Ruby's download_http_client).
+	Downloader func() (*transfer.Downloader, error)
 
-	modDownloadOnce sync.Once
-	modDownload     *api.MODDownloadAPI
-	modDownloadErr  error
+	// MODDownloadAPI returns the client for building authenticated MOD
+	// download URLs. Credentials resolve lazily on first use, not here, so
+	// commands that never actually download never require
+	// FACTORIO_USERNAME/FACTORIO_TOKEN or player-data.json.
+	MODDownloadAPI func() (*api.MODDownloadAPI, error)
 }
 
 // Options select the configuration and log level.
@@ -91,7 +94,11 @@ func New(opts Options) (*App, error) {
 		return nil, err
 	}
 
-	return &App{Config: cfg, Runtime: runtime, Logger: logger, logCloser: closer}, nil
+	a := &App{Config: cfg, Runtime: runtime, Logger: logger, logCloser: closer}
+	a.PortalAPI = sync.OnceValues(a.buildPortalAPI)
+	a.Downloader = sync.OnceValues(a.buildDownloader)
+	a.MODDownloadAPI = sync.OnceValues(a.buildMODDownloadAPI)
+	return a, nil
 }
 
 func loadConfig(p platform.Platform, explicitPath string) (config.Config, error) {
@@ -123,32 +130,27 @@ func (a *App) Close() error {
 	return nil
 }
 
-// PortalAPI returns the MOD Portal client, wired with the api cache and
-// retry as Client → CacheTransport → Retry (retry outermost, as in Ruby).
-func (a *App) PortalAPI() (*api.MODPortalAPI, error) {
-	a.portalOnce.Do(func() {
-		apiCache, err := a.newCache("api", a.Config.Cache.API)
-		if err != nil {
-			a.portalErr = err
-			return
-		}
-		base := httpx.NewBaseTransport(
-			time.Duration(a.Config.HTTP.ConnectTimeout)*time.Second,
-			time.Duration(a.Config.HTTP.ReadTimeout)*time.Second,
-		)
-		transport := httpx.NewRetryTransport(
-			httpx.NewCacheTransport(base, apiCache, a.Logger),
-			httpx.RetryOptions{Logger: a.Logger},
-		)
-		client := httpx.NewClient(httpx.Options{
-			Transport:    transport,
-			MaskedParams: maskedQueryParams,
-			Logger:       a.Logger,
-		})
-		a.portal = api.NewMODPortalAPI(client, apiCache, a.Logger)
-		a.portal.BaseURL = modsPortalBaseURL()
+func (a *App) buildPortalAPI() (*api.MODPortalAPI, error) {
+	apiCache, err := a.newCache("api", a.Config.Cache.API)
+	if err != nil {
+		return nil, err
+	}
+	base := httpx.NewBaseTransport(
+		time.Duration(a.Config.HTTP.ConnectTimeout)*time.Second,
+		time.Duration(a.Config.HTTP.ReadTimeout)*time.Second,
+	)
+	transport := httpx.NewRetryTransport(
+		httpx.NewCacheTransport(base, apiCache, a.Logger),
+		httpx.RetryOptions{Logger: a.Logger},
+	)
+	client := httpx.NewClient(httpx.Options{
+		Transport:    transport,
+		MaskedParams: maskedQueryParams,
+		Logger:       a.Logger,
 	})
-	return a.portal, a.portalErr
+	portal := api.NewMODPortalAPI(client, apiCache, a.Logger)
+	portal.BaseURL = modsPortalBaseURL()
+	return portal, nil
 }
 
 // modsPortalBaseURL is api.DefaultPortalBaseURL, overridable via
@@ -180,50 +182,36 @@ func (a *App) newCache(name string, cfg config.CacheType) (cache.Cache, error) {
 	})
 }
 
-// Downloader returns the MOD file downloader, wired as Client → Retry (no
-// cache decorator: the downloader manages its own download-type cache
-// directly, matching Ruby's download_http_client).
-func (a *App) Downloader() (*transfer.Downloader, error) {
-	a.downloaderOnce.Do(func() {
-		downloadCache, err := a.newCache("download", a.Config.Cache.Download)
-		if err != nil {
-			a.downloaderErr = err
-			return
-		}
-		transport := httpx.NewRetryTransport(
-			httpx.NewBaseTransport(
-				time.Duration(a.Config.HTTP.ConnectTimeout)*time.Second,
-				time.Duration(a.Config.HTTP.ReadTimeout)*time.Second,
-			),
-			httpx.RetryOptions{Logger: a.Logger},
-		)
-		client := httpx.NewClient(httpx.Options{
-			Transport:    transport,
-			MaskedParams: maskedQueryParams,
-			Logger:       a.Logger,
-		})
-		a.downloader = transfer.NewDownloader(downloadCache, client, a.Logger)
+func (a *App) buildDownloader() (*transfer.Downloader, error) {
+	downloadCache, err := a.newCache("download", a.Config.Cache.Download)
+	if err != nil {
+		return nil, err
+	}
+	transport := httpx.NewRetryTransport(
+		httpx.NewBaseTransport(
+			time.Duration(a.Config.HTTP.ConnectTimeout)*time.Second,
+			time.Duration(a.Config.HTTP.ReadTimeout)*time.Second,
+		),
+		httpx.RetryOptions{Logger: a.Logger},
+	)
+	client := httpx.NewClient(httpx.Options{
+		Transport:    transport,
+		MaskedParams: maskedQueryParams,
+		Logger:       a.Logger,
 	})
-	return a.downloader, a.downloaderErr
+	return transfer.NewDownloader(downloadCache, client, a.Logger), nil
 }
 
-// MODDownloadAPI returns the client for building authenticated MOD download
-// URLs. Credentials resolve lazily on first use, not here, so commands that
-// never actually download never require FACTORIO_USERNAME/FACTORIO_TOKEN or
-// player-data.json.
-func (a *App) MODDownloadAPI() (*api.MODDownloadAPI, error) {
-	a.modDownloadOnce.Do(func() {
-		playerDataPath, err := a.Runtime.PlayerDataPath()
-		if err != nil {
-			a.modDownloadErr = err
-			return
-		}
-		a.modDownload = api.NewMODDownloadAPI(func() (api.ServiceCredential, error) {
-			return api.LoadServiceCredential(playerDataPath)
-		})
-		a.modDownload.BaseURL = modsPortalBaseURL()
+func (a *App) buildMODDownloadAPI() (*api.MODDownloadAPI, error) {
+	playerDataPath, err := a.Runtime.PlayerDataPath()
+	if err != nil {
+		return nil, err
+	}
+	modDownload := api.NewMODDownloadAPI(func() (api.ServiceCredential, error) {
+		return api.LoadServiceCredential(playerDataPath)
 	})
-	return a.modDownload, a.modDownloadErr
+	modDownload.BaseURL = modsPortalBaseURL()
+	return modDownload, nil
 }
 
 // RequireGameStopped fails when Factorio is running; commands that modify

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -18,23 +18,24 @@ type cli struct {
 	logLevel   string
 	quiet      bool
 
-	appOnce sync.Once
-	app     *app.App
-	appErr  error
-}
+	// App builds the application on first use, memoized via sync.OnceValues;
+	// commands like version never pay for config loading or log-file
+	// creation. Set in NewRootCommand — the wrapped closure reads
+	// configPath/logLevel at call time, by which point cobra has already
+	// parsed the flags that set them.
+	App func() (*app.App, error)
 
-// App builds the application on first use; commands like version never pay
-// for config loading or log-file creation.
-func (c *cli) App() (*app.App, error) {
-	c.appOnce.Do(func() {
-		c.app, c.appErr = app.New(app.Options{ConfigPath: c.configPath, LogLevel: c.logLevel})
-	})
-	return c.app, c.appErr
+	// builtApp is set as a side effect the first time App succeeds, purely
+	// so Close can tell "never built" from "built" without calling App
+	// itself — calling App from Close would force construction (and thus
+	// config loading, log-file creation) even for commands like version
+	// that never touch the application.
+	builtApp *app.App
 }
 
 func (c *cli) Close() {
-	if c.app != nil {
-		_ = c.app.Close()
+	if c.builtApp != nil {
+		_ = c.builtApp.Close()
 	}
 }
 
@@ -49,6 +50,13 @@ func (c *cli) printer(cmd *cobra.Command) *printer {
 // error.
 func NewRootCommand() (root *cobra.Command, reportError func(error)) {
 	c := &cli{}
+	c.App = sync.OnceValues(func() (*app.App, error) {
+		a, err := app.New(app.Options{ConfigPath: c.configPath, LogLevel: c.logLevel})
+		if err == nil {
+			c.builtApp = a
+		}
+		return a, err
+	})
 
 	root = &cobra.Command{
 		Use:           "factorix",

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -176,6 +176,20 @@ func TestVersionCommand(t *testing.T) {
 	assert.Equal(t, "dev\n", out)
 }
 
+// TestVersionCommandNeverBuildsApp guards against PersistentPostRun's
+// Close() forcing application construction (config load, log file
+// creation) for a command that never calls c.App() itself.
+func TestVersionCommandNeverBuildsApp(t *testing.T) {
+	s := newSandbox(t)
+
+	_, err := runCLI(t, "version")
+	require.NoError(t, err)
+
+	logPath := filepath.Join(s.root, "xdg-state", "factorix", "factorix.log")
+	_, statErr := os.Stat(logPath)
+	assert.ErrorIs(t, statErr, os.ErrNotExist, "version must not trigger app construction")
+}
+
 func TestPathCommand(t *testing.T) {
 	s := newSandbox(t)
 	out, err := runCLI(t, "path")

--- a/internal/cli/mod_portal_readonly_test.go
+++ b/internal/cli/mod_portal_readonly_test.go
@@ -7,6 +7,7 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
+	"github.com/sakuro/factorix/internal/app"
 	"github.com/sakuro/factorix/internal/mod"
 )
 
@@ -41,7 +42,7 @@ func TestMODDownloadRejectsMODDirAsTarget(t *testing.T) {
 func TestDefaultFactorioVersion(t *testing.T) {
 	baseSandbox(t)
 
-	application, err := (&cli{}).App()
+	application, err := app.New(app.Options{})
 	require.NoError(t, err)
 
 	version, err := defaultFactorioVersion(application)
@@ -53,7 +54,7 @@ func TestFetchLocalStatusNotInstalled(t *testing.T) {
 	s := baseSandbox(t)
 	s.writeMODList(t, modListEntry{name: "base", enabled: true})
 
-	application, err := (&cli{}).App()
+	application, err := app.New(app.Options{})
 	require.NoError(t, err)
 
 	status, err := fetchLocalStatus(application, mod.MOD{Name: "ghost"})
@@ -70,7 +71,7 @@ func TestFetchLocalStatusInstalledAndEnabled(t *testing.T) {
 		modListEntry{name: "some-mod", enabled: true},
 	)
 
-	application, err := (&cli{}).App()
+	application, err := app.New(app.Options{})
 	require.NoError(t, err)
 
 	status, err := fetchLocalStatus(application, mod.MOD{Name: "some-mod"})

--- a/internal/platform/detect.go
+++ b/internal/platform/detect.go
@@ -18,7 +18,7 @@ func Detect() (Platform, error) {
 		return Windows{}, nil
 	case "linux":
 		if isWSL() {
-			return &WSL{}, nil
+			return NewWSL(), nil
 		}
 		return Linux{}, nil
 	default:

--- a/internal/platform/wsl.go
+++ b/internal/platform/wsl.go
@@ -16,9 +16,13 @@ import (
 // converts the paths to their /mnt/<drive> equivalents. Factorix-side
 // directories (cache, config, state) live in the Linux home.
 type WSL struct {
-	once sync.Once
-	envs map[string]string
-	err  error
+	windowsEnvs func() (map[string]string, error)
+}
+
+// NewWSL returns a WSL platform. The PowerShell fetch behind windowsPath
+// runs at most once, memoized via sync.OnceValues.
+func NewWSL() *WSL {
+	return &WSL{windowsEnvs: sync.OnceValues(fetchWindowsEnvs)}
 }
 
 // The Windows environment variables fetched in one PowerShell invocation.
@@ -34,13 +38,11 @@ var wslPowerShellFallbackPaths = []string{
 }
 
 func (w *WSL) windowsPath(name string) (string, error) {
-	w.once.Do(func() {
-		w.envs, w.err = fetchWindowsEnvs()
-	})
-	if w.err != nil {
-		return "", w.err
+	envs, err := w.windowsEnvs()
+	if err != nil {
+		return "", err
 	}
-	value, ok := w.envs[name]
+	value, ok := envs[name]
 	if !ok || value == "" {
 		return "", fmt.Errorf("%w: %s", ErrMissingEnv, name)
 	}


### PR DESCRIPTION
## Summary
Modernize the manual `sync.Once` + cached-value + cached-error triple pattern (used in three places) to `sync.OnceValues` (Go 1.21+; go.mod is on 1.25), prompted by a review question about whether the sync usage looked dated.

## Changes
- `internal/app`: `PortalAPI`/`Downloader`/`MODDownloadAPI` become memoized func fields built once in `New` via `sync.OnceValues`, replacing a method plus a `XxxOnce sync.Once` + value + err field triple per resource. Call syntax at every existing call site is unchanged — a func-typed field and a method both invoke as `application.PortalAPI()`
- `internal/platform`: `WSL` gets a constructor (`NewWSL`) so the PowerShell-backed environment fetch can be wrapped in `sync.OnceValues` at construction time instead of the `once`/`envs`/`err` triple; `Detect` calls `NewWSL()` instead of `&WSL{}`
- `internal/cli`: `cli.App` becomes the same kind of memoized field, set in `NewRootCommand`

## Bug caught while refactoring
The first pass had `Close()` call `c.App()` to decide whether to close it — but calling `App` is exactly what forces application construction (config load, log file creation), so `version` and other commands that never call `App` themselves would have started paying for it anyway via `PersistentPostRun`. Fixed by tracking a `builtApp` field set as a side effect of a successful build, so `Close` can tell "never built" from "built" without triggering a build. Locked in with `TestVersionCommandNeverBuildsApp`, which asserts no log file appears after running `version`.

## Test Plan
- `go build ./... && go vet ./... && go test ./...` pass locally (`mise run default`)
- A few tests constructed a bare `&cli{}` to reach `App()` for local-only helpers (`defaultFactorioVersion`, `fetchLocalStatus`); since `App` is no longer auto-wired outside `NewRootCommand`, they now call `app.New` directly
- Manually built the binary and confirmed `version` creates no log file while `mod list` does (proving the lazy-build behavior survived the refactor)
