### PR TITLE
:recycle: Modernize sort/map-collection/index-loop idioms

### DIFF
--- a/internal/api/management.go
+++ b/internal/api/management.go
@@ -7,6 +7,7 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"maps"
 	"net/http"
 	"net/url"
 	"slices"
@@ -243,9 +244,5 @@ func validateMetadataKeys(keys, allowed []string, context string) error {
 }
 
 func keysOf(m map[string]string) []string {
-	keys := make([]string, 0, len(m))
-	for key := range m {
-		keys = append(keys, key)
-	}
-	return keys
+	return slices.Collect(maps.Keys(m))
 }

--- a/internal/cli/mod_download.go
+++ b/internal/cli/mod_download.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"errors"
 	"fmt"
+	"maps"
 	"os"
 	"path/filepath"
 	"slices"
@@ -201,11 +202,7 @@ func resolveDownloadDependencies(ctx context.Context, application *app.App, init
 		}
 	}
 
-	all := make([]fetchedMODInfo, 0, len(known))
-	for _, info := range known {
-		all = append(all, info)
-	}
-	return all, nil
+	return slices.Collect(maps.Values(known)), nil
 }
 
 // warnAndSkip logs and returns nil so the caller treats the dependency as

--- a/internal/cli/mod_list.go
+++ b/internal/cli/mod_list.go
@@ -2,11 +2,12 @@ package cli
 
 import (
 	"bytes"
+	"cmp"
 	"context"
 	"encoding/json"
 	"errors"
 	"fmt"
-	"sort"
+	"slices"
 	"strings"
 	"sync"
 
@@ -282,12 +283,11 @@ func sortListedMODs(mods []*listedMOD) {
 			return 2
 		}
 	}
-	sort.SliceStable(mods, func(i, j int) bool {
-		ri, rj := rank(mods[i]), rank(mods[j])
-		if ri != rj {
-			return ri < rj
+	slices.SortStableFunc(mods, func(a, b *listedMOD) int {
+		if c := cmp.Compare(rank(a), rank(b)); c != 0 {
+			return c
 		}
-		return mods[i].Name < mods[j].Name
+		return cmp.Compare(a.Name, b.Name)
 	})
 }
 

--- a/internal/dependency/parser.go
+++ b/internal/dependency/parser.go
@@ -149,7 +149,7 @@ func isVersionFormat(s string) bool {
 		if part == "" {
 			return false
 		}
-		for i := 0; i < len(part); i++ {
+		for i := range len(part) {
 			if part[i] < '0' || part[i] > '9' {
 				return false
 			}

--- a/internal/transfer/uploader.go
+++ b/internal/transfer/uploader.go
@@ -5,13 +5,14 @@ import (
 	"fmt"
 	"io"
 	"log/slog"
+	"maps"
 	"mime/multipart"
 	"net/http"
 	"net/textproto"
 	"net/url"
 	"os"
 	"path/filepath"
-	"sort"
+	"slices"
 	"strings"
 
 	"github.com/sakuro/factorix/internal/httpx"
@@ -107,12 +108,7 @@ func (u *Uploader) buildMultipartFile(filePath string, fields map[string]string,
 	writer := multipart.NewWriter(tmp)
 
 	// Deterministic field order keeps requests reproducible.
-	names := make([]string, 0, len(fields))
-	for name := range fields {
-		names = append(names, name)
-	}
-	sort.Strings(names)
-	for _, name := range names {
+	for _, name := range slices.Sorted(maps.Keys(fields)) {
 		if err := writer.WriteField(name, fields[name]); err != nil {
 			cleanup()
 			return nil, 0, err


### PR DESCRIPTION
## Summary
A sweep for outdated Go idioms across `internal/`, prompted by a question about whether the `sync` usage looked dated (that part landed separately in #115). go.mod targets 1.25, so this replaces a few pre-generics/pre-iterator patterns with their current stdlib equivalents.

## Changes
- `sort.Strings`/`sort.SliceStable` → `slices.Sort`/`slices.SortStableFunc` (Go 1.21) in `uploader.go` and `mod_list.go`; the latter's comparator moves from a hand-rolled less-than closure to `cmp.Compare`
- Manual "collect map keys/values into a slice" loops → `maps.Keys`/`maps.Values` + `slices.Collect`/`slices.Sorted` (Go 1.23) in `management.go`, `uploader.go` (this one collects and sorts in one call), and `mod_download.go`
- `for i := 0; i < len(x); i++` over a plain byte index with no custom step → `for i := range len(x)` (Go 1.22) in the dependency parser's version-format check

## What I looked at and left alone
- `scanner.go`'s `sync.Mutex` guards a slice append, a counter, and a progress-listener call together as one critical section — not a single memoizable value or a plain counter, so neither `sync.OnceValues` nor `atomic.Int64` would actually replace it
- The byte-scanning loops in `internal/dependency/parser.go`'s `scanName` have custom, non-sequential control flow (variable-length jumps, early returns with substrings), so `for i := range n` doesn't apply there
- No `io/ioutil`, `math/rand` (v1), `interface{}`, or `errors.New(fmt.Sprintf(...))` found anywhere in `internal/`

## Test Plan
- `go build ./... && go vet ./... && go test ./...` pass locally (`mise run default`)
- No behavior change intended; existing tests cover every touched function
