### PR TITLE
:sparkles: Implement mod install/uninstall/update commands (Phase 10d)

### DIFF
--- a/doc/go-migration-roadmap.md
+++ b/doc/go-migration-roadmap.md
@@ -436,7 +436,11 @@ than one pass over the full list below.
       (deferred from Phase 7); an unrecognized category value errors, matching
       Ruby's `Category.for` (`KeyError`) — categories change rarely, so an
       unknown one means the catalog is stale and needs a code change
-- [ ] `mod install` / `mod uninstall` / `mod update`
+- [x] `mod install` / `mod uninstall` / `mod update` — graph extension for
+      Portal-fetched MODs (`Graph.AddUninstalledMOD`) and install planning
+      (`MarkDisabledDependenciesForEnable`, `ValidateInstallGraph`) live in
+      `internal/dependency`; uninstall refuses to break enabled dependents
+      unless remaining installed versions still satisfy them
 - [x] `mod download` — download without installing; shared download-planning
       logic lives in `internal/cli/download_support.go` (parse spec, resolve
       release, build targets, parallel fetch) for reuse by install/update/sync.

--- a/internal/cli/mod_download.go
+++ b/internal/cli/mod_download.go
@@ -109,8 +109,11 @@ func planDownload(ctx context.Context, application *app.App, specs []modSpec, do
 		return nil, err
 	}
 
+	// The full endpoint is required here: only /full includes each
+	// release's dependencies in info_json, and recursive resolution reads
+	// them (with the short endpoint they silently come back empty).
 	initial, err := fetchMODInfoConcurrently(ctx, jobs, specs, func(ctx context.Context, spec modSpec) (fetchedMODInfo, error) {
-		info, err := portalAPI.GetMOD(ctx, spec.MOD.Name)
+		info, err := portalAPI.GetMODFull(ctx, spec.MOD.Name)
 		if err != nil {
 			return fetchedMODInfo{}, err
 		}
@@ -178,7 +181,7 @@ func resolveDownloadDependencies(ctx context.Context, application *app.App, init
 			specs[i] = modSpec{MOD: mod.MOD{Name: dep.name}}
 		}
 		results, err := fetchMODInfoConcurrently(ctx, jobs, specs, func(ctx context.Context, spec modSpec) (fetchedMODInfo, error) {
-			info, err := portalAPI.GetMOD(ctx, spec.MOD.Name)
+			info, err := portalAPI.GetMODFull(ctx, spec.MOD.Name)
 			if err != nil {
 				return fetchedMODInfo{}, warnAndSkip(application, spec.MOD.Name, err)
 			}

--- a/internal/cli/mod_install.go
+++ b/internal/cli/mod_install.go
@@ -1,0 +1,331 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"github.com/sakuro/factorix/internal/api"
+	"github.com/sakuro/factorix/internal/app"
+	"github.com/sakuro/factorix/internal/dependency"
+	"github.com/sakuro/factorix/internal/mod"
+)
+
+// installTarget is one planned action: download-and-enable a new MOD, or
+// re-enable an installed-but-disabled dependency.
+type installTarget struct {
+	MOD       mod.MOD
+	Operation dependency.Operation // OpInstall or OpEnable
+	Release   api.Release          // meaningful only for OpInstall
+}
+
+func newMODInstallCommand(c *cli) *cobra.Command {
+	var jobs int
+	var yes bool
+
+	cmd := &cobra.Command{
+		Use:   "install <mod-spec>...",
+		Short: "Install MOD(s) from Factorio MOD Portal (downloads to MOD directory and enables)",
+		Args:  cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			application, err := c.App()
+			if err != nil {
+				return err
+			}
+			if err := application.RequireGameStopped(); err != nil {
+				return err
+			}
+
+			state, err := loadMODState(application)
+			if err != nil {
+				return err
+			}
+			modDir, err := application.Runtime.MODDir()
+			if err != nil {
+				return err
+			}
+			if info, err := os.Stat(modDir); err != nil || !info.IsDir() {
+				return fmt.Errorf("MOD directory does not exist: %s", modDir)
+			}
+
+			specs := make([]modSpec, len(args))
+			for i, arg := range args {
+				spec, err := parseMODSpec(arg)
+				if err != nil {
+					return err
+				}
+				specs[i] = spec
+			}
+
+			targets, err := planInstall(cmd.Context(), application, state.graph, specs, jobs)
+			if err != nil {
+				return err
+			}
+
+			p := c.printer(cmd)
+			if len(targets) == 0 {
+				p.Info("All specified MOD(s) are already installed and enabled")
+				return nil
+			}
+
+			installs, enables := splitInstallTargets(targets)
+			if len(installs) > 0 {
+				p.Info(fmt.Sprintf("Planning to install %d MOD(s):", len(installs)))
+				for _, target := range installs {
+					p.Say(fmt.Sprintf("  - %s@%s", target.MOD, target.Release.Version))
+				}
+			}
+			if len(enables) > 0 {
+				p.Info(fmt.Sprintf("Planning to enable %d disabled dependency MOD(s):", len(enables)))
+				for _, target := range enables {
+					p.Say("  - " + target.MOD.String())
+				}
+			}
+
+			confirmed, err := confirm(cmd, c.quiet, yes, "Do you want to proceed?")
+			if err != nil {
+				return err
+			}
+			if !confirmed {
+				return nil
+			}
+
+			if err := executeInstall(cmd.Context(), c, cmd, application, state.modList, modDir, installs, enables, jobs); err != nil {
+				return err
+			}
+
+			modListPath, err := application.Runtime.MODListPath()
+			if err != nil {
+				return err
+			}
+			if err := backupIfExists(modListPath); err != nil {
+				return err
+			}
+			if err := state.modList.Save(modListPath); err != nil {
+				return err
+			}
+
+			if len(installs) > 0 {
+				p.Success(fmt.Sprintf("Installed %d MOD(s)", len(installs)))
+			}
+			if len(enables) > 0 {
+				p.Success(fmt.Sprintf("Enabled %d disabled dependency MOD(s)", len(enables)))
+			}
+			p.Success("Saved mod-list.json")
+			return nil
+		},
+	}
+	cmd.Flags().IntVarP(&jobs, "jobs", "j", 4, "Number of parallel downloads")
+	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "Skip confirmation prompts")
+	return cmd
+}
+
+func splitInstallTargets(targets []installTarget) (installs, enables []installTarget) {
+	for _, target := range targets {
+		if target.Operation == dependency.OpInstall {
+			installs = append(installs, target)
+		} else {
+			enables = append(enables, target)
+		}
+	}
+	return installs, enables
+}
+
+// planInstall fetches the requested MODs from the Portal, extends the graph
+// with them and their required dependencies (recursively), marks disabled
+// installed dependencies for enabling, validates the result, and extracts
+// the actions to perform.
+func planInstall(ctx context.Context, application *app.App, graph *dependency.Graph, specs []modSpec, jobs int) ([]installTarget, error) {
+	portalAPI, err := application.PortalAPI()
+	if err != nil {
+		return nil, err
+	}
+
+	// The full endpoint is required: only /full includes each release's
+	// dependencies, which drive the recursive resolution below.
+	initial, err := fetchMODInfoConcurrently(ctx, jobs, specs, func(ctx context.Context, spec modSpec) (fetchedMODInfo, error) {
+		info, err := portalAPI.GetMODFull(ctx, spec.MOD.Name)
+		if err != nil {
+			return fetchedMODInfo{}, err
+		}
+		release := findRelease(info, spec)
+		if release == nil {
+			return fetchedMODInfo{}, fmt.Errorf("Release not found for %s@%s", spec.MOD.Name, specVersionLabel(spec))
+		}
+		return fetchedMODInfo{MOD: spec.MOD, MODInfo: info, Release: *release}, nil
+	})
+	if err != nil {
+		return nil, err
+	}
+
+	releases := map[mod.MOD]api.Release{}
+	frontier := make([]mod.MOD, 0, len(initial))
+	for _, info := range initial {
+		if err := graph.AddUninstalledMOD(info.MOD, info.Release.Version, info.Release.InfoJSON.Dependencies); err != nil {
+			return nil, err
+		}
+		releases[info.MOD] = info.Release
+		frontier = append(frontier, info.MOD)
+	}
+
+	if err := resolveInstallDependencies(ctx, application, graph, releases, frontier, jobs); err != nil {
+		return nil, err
+	}
+
+	dependency.MarkDisabledDependenciesForEnable(graph)
+	if err := dependency.ValidateInstallGraph(graph); err != nil {
+		return nil, err
+	}
+
+	var targets []installTarget
+	for _, node := range graph.Nodes() {
+		switch node.Operation {
+		case dependency.OpInstall:
+			release, ok := releases[node.MOD]
+			if !ok {
+				application.Logger.Warn("No release info for MOD, skipping", "mod", node.MOD.Name)
+				continue
+			}
+			targets = append(targets, installTarget{MOD: node.MOD, Operation: dependency.OpInstall, Release: release})
+		case dependency.OpEnable:
+			targets = append(targets, installTarget{MOD: node.MOD, Operation: dependency.OpEnable})
+		}
+	}
+	return targets, nil
+}
+
+// resolveInstallDependencies walks the required edges of newly-added graph
+// nodes and fetches MODs not yet in the graph, extending it recursively.
+// A dependency that cannot be fetched or has no compatible release is
+// skipped with a warning rather than failing the install.
+func resolveInstallDependencies(ctx context.Context, application *app.App, graph *dependency.Graph, releases map[mod.MOD]api.Release, frontier []mod.MOD, jobs int) error {
+	portalAPI, err := application.PortalAPI()
+	if err != nil {
+		return err
+	}
+
+	processed := map[mod.MOD]bool{}
+	for len(frontier) > 0 {
+		type missingDep struct {
+			mod         mod.MOD
+			requirement *dependency.VersionRequirement
+			requiredBy  mod.MOD
+		}
+		var missing []missingDep
+		for _, m := range frontier {
+			if processed[m] {
+				continue
+			}
+			processed[m] = true
+			for _, edge := range graph.EdgesFrom(m) {
+				if edge.Type != dependency.TypeRequired || graph.Contains(edge.To) {
+					continue
+				}
+				missing = append(missing, missingDep{mod: edge.To, requirement: edge.Requirement, requiredBy: m})
+			}
+		}
+		frontier = nil
+		if len(missing) == 0 {
+			continue
+		}
+
+		specs := make([]modSpec, len(missing))
+		for i, dep := range missing {
+			specs[i] = modSpec{MOD: dep.mod}
+		}
+		results, err := fetchMODInfoConcurrently(ctx, jobs, specs, func(ctx context.Context, spec modSpec) (fetchedMODInfo, error) {
+			var requirement *dependency.VersionRequirement
+			var requiredBy mod.MOD
+			for _, dep := range missing {
+				if dep.mod == spec.MOD {
+					requirement = dep.requirement
+					requiredBy = dep.requiredBy
+					break
+				}
+			}
+			info, err := portalAPI.GetMODFull(ctx, spec.MOD.Name)
+			if err != nil {
+				application.Logger.Warn("Skipping dependency", "mod", spec.MOD.Name, "required_by", requiredBy.Name, "reason", err)
+				return fetchedMODInfo{}, nil
+			}
+			release := findCompatibleRelease(info, requirement)
+			if release == nil {
+				application.Logger.Warn("Skipping dependency", "mod", spec.MOD.Name, "required_by", requiredBy.Name, "reason", "no compatible release found")
+				return fetchedMODInfo{}, nil
+			}
+			return fetchedMODInfo{MOD: spec.MOD, MODInfo: info, Release: *release}, nil
+		})
+		if err != nil {
+			return err
+		}
+
+		for _, r := range results {
+			if r.MODInfo == nil {
+				continue // skipped above
+			}
+			if err := graph.AddUninstalledMOD(r.MOD, r.Release.Version, r.Release.InfoJSON.Dependencies); err != nil {
+				return err
+			}
+			releases[r.MOD] = r.Release
+			frontier = append(frontier, r.MOD)
+		}
+	}
+	return nil
+}
+
+func executeInstall(ctx context.Context, c *cli, cmd *cobra.Command, application *app.App, modList *mod.MODList, modDir string, installs, enables []installTarget, jobs int) error {
+	p := c.printer(cmd)
+
+	if len(installs) > 0 {
+		downloads := make([]downloadTarget, 0, len(installs))
+		for _, target := range installs {
+			if err := validateFilename(target.Release.FileName); err != nil {
+				return err
+			}
+			downloads = append(downloads, downloadTarget{
+				MOD:        target.MOD,
+				Release:    target.Release,
+				OutputPath: filepath.Join(modDir, target.Release.FileName),
+			})
+		}
+		if err := downloadTargets(ctx, application, downloads, jobs); err != nil {
+			return err
+		}
+	}
+
+	for _, target := range installs {
+		if modList.Contains(target.MOD) {
+			enabled, err := modList.Enabled(target.MOD)
+			if err != nil {
+				return err
+			}
+			if !enabled {
+				if err := modList.Enable(target.MOD); err != nil {
+					return err
+				}
+				p.Success(fmt.Sprintf("Enabled %s in mod-list.json", target.MOD))
+			}
+		} else {
+			if err := modList.Add(target.MOD, mod.MODState{Enabled: true}); err != nil {
+				return err
+			}
+			p.Success(fmt.Sprintf("Added %s to mod-list.json", target.MOD))
+		}
+	}
+	for _, target := range enables {
+		if err := modList.Enable(target.MOD); err != nil {
+			// An enable target discovered via the graph should always be in
+			// the list; a missing entry means local state changed under us.
+			if errors.Is(err, mod.ErrMODNotInList) {
+				return fmt.Errorf("cannot enable dependency %s: %w", target.MOD, err)
+			}
+			return err
+		}
+		p.Success(fmt.Sprintf("Enabled dependency %s in mod-list.json", target.MOD))
+	}
+	return nil
+}

--- a/internal/cli/mod_install_update_test.go
+++ b/internal/cli/mod_install_update_test.go
@@ -1,0 +1,108 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sakuro/factorix/internal/dependency"
+	"github.com/sakuro/factorix/internal/mod"
+)
+
+func TestMODInstallRequiresGameStopped(t *testing.T) {
+	s := baseSandbox(t)
+	require.NoError(t, os.WriteFile(filepath.Join(s.root, "factorio", ".lock"), nil, 0o644))
+
+	_, err := runCLI(t, "mod", "install", "some-mod", "-y")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "running")
+}
+
+// A missing MOD directory (which also means a missing mod-list.json, since
+// the file lives inside it) must fail locally, before any Portal request.
+func TestMODInstallFailsWithoutMODDir(t *testing.T) {
+	s := baseSandbox(t)
+	require.NoError(t, os.RemoveAll(filepath.Join(s.root, "factorio", "mods")))
+
+	_, err := runCLI(t, "mod", "install", "some-mod", "-y")
+	require.Error(t, err)
+	require.ErrorIs(t, err, os.ErrNotExist)
+}
+
+func TestSplitInstallTargets(t *testing.T) {
+	targets := []installTarget{
+		{MOD: mod.MOD{Name: "a"}, Operation: dependency.OpInstall},
+		{MOD: mod.MOD{Name: "b"}, Operation: dependency.OpEnable},
+		{MOD: mod.MOD{Name: "c"}, Operation: dependency.OpInstall},
+	}
+	installs, enables := splitInstallTargets(targets)
+	require.Len(t, installs, 2)
+	require.Len(t, enables, 1)
+	assert.Equal(t, "b", enables[0].MOD.Name)
+}
+
+func TestMODUpdateRejectsBaseAndExpansion(t *testing.T) {
+	s := baseSandbox(t)
+	s.writeMODList(t, modListEntry{name: "base", enabled: true})
+
+	_, err := runCLI(t, "mod", "update", "base", "-y")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Cannot update base MOD")
+
+	_, err = runCLI(t, "mod", "update", "quality", "-y")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Cannot update expansion MOD: quality")
+}
+
+func TestMODUpdateNothingInstalled(t *testing.T) {
+	s := baseSandbox(t)
+	s.writeMODList(t, modListEntry{name: "base", enabled: true})
+
+	// Only base is installed; with no names given there is nothing to check.
+	out, err := runCLI(t, "mod", "update", "-y")
+	require.NoError(t, err)
+	assert.Contains(t, out, "No MOD(s) to update")
+}
+
+func TestMODUpdateRequiresGameStopped(t *testing.T) {
+	s := baseSandbox(t)
+	require.NoError(t, os.WriteFile(filepath.Join(s.root, "factorio", ".lock"), nil, 0o644))
+
+	_, err := runCLI(t, "mod", "update", "-y")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "running")
+}
+
+func TestUpdateTargetMODs(t *testing.T) {
+	installed := []mod.InstalledMOD{
+		{MOD: mod.MOD{Name: "base"}, Version: mod.MODVersion{Major: 2}},
+		{MOD: mod.MOD{Name: "space-age"}, Version: mod.MODVersion{Major: 2}},
+		{MOD: mod.MOD{Name: "some-mod"}, Version: mod.MODVersion{Major: 1}},
+		{MOD: mod.MOD{Name: "some-mod"}, Version: mod.MODVersion{Major: 2}}, // duplicate version entry
+	}
+
+	targets, err := updateTargetMODs(nil, installed)
+	require.NoError(t, err)
+	assert.Equal(t, []mod.MOD{{Name: "some-mod"}}, targets)
+
+	targets, err = updateTargetMODs([]string{"another-mod"}, installed)
+	require.NoError(t, err)
+	assert.Equal(t, []mod.MOD{{Name: "another-mod"}}, targets)
+}
+
+func TestNewestInstalledVersion(t *testing.T) {
+	installed := []mod.InstalledMOD{
+		{MOD: mod.MOD{Name: "m"}, Version: mod.MODVersion{Major: 1}},
+		{MOD: mod.MOD{Name: "m"}, Version: mod.MODVersion{Major: 3}},
+		{MOD: mod.MOD{Name: "m"}, Version: mod.MODVersion{Major: 2}},
+	}
+	version, found := newestInstalledVersion(installed, mod.MOD{Name: "m"})
+	require.True(t, found)
+	assert.Equal(t, mod.MODVersion{Major: 3}, version)
+
+	_, found = newestInstalledVersion(installed, mod.MOD{Name: "absent"})
+	assert.False(t, found)
+}

--- a/internal/cli/mod_uninstall.go
+++ b/internal/cli/mod_uninstall.go
@@ -1,0 +1,308 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/sakuro/factorix/internal/dependency"
+	"github.com/sakuro/factorix/internal/mod"
+)
+
+// uninstallTarget is a MOD to uninstall; a nil Version means every
+// installed version.
+type uninstallTarget struct {
+	MOD     mod.MOD
+	Version *mod.MODVersion
+}
+
+func (t uninstallTarget) String() string {
+	if t.Version != nil {
+		return fmt.Sprintf("%s@%s", t.MOD, t.Version)
+	}
+	return t.MOD.String()
+}
+
+func newMODUninstallCommand(c *cli) *cobra.Command {
+	var all, yes bool
+
+	cmd := &cobra.Command{
+		Use:   "uninstall [mod-spec]...",
+		Short: "Uninstall MOD(s) from MOD directory",
+		Args:  cobra.ArbitraryArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			if all && len(args) > 0 {
+				return fmt.Errorf("Cannot specify MOD names with --all option")
+			}
+			if !all && len(args) == 0 {
+				return fmt.Errorf("Must specify MOD names or use --all option")
+			}
+
+			application, err := c.App()
+			if err != nil {
+				return err
+			}
+			if err := application.RequireGameStopped(); err != nil {
+				return err
+			}
+
+			state, err := loadMODState(application)
+			if err != nil {
+				return err
+			}
+
+			p := c.printer(cmd)
+			var requested []uninstallTarget
+			if all {
+				requested = planUninstallAll(state.graph)
+			} else {
+				requested, err = parseUninstallSpecs(args)
+				if err != nil {
+					return err
+				}
+			}
+
+			targets, err := validateUninstallTargets(p, requested, state, all)
+			if err != nil {
+				return err
+			}
+
+			var expansionsToDisable []mod.MOD
+			if all {
+				expansionsToDisable = enabledExpansions(state)
+			}
+			if len(targets) == 0 && len(expansionsToDisable) == 0 {
+				if all {
+					p.Info("No MOD(s) to uninstall or disable")
+				} else {
+					p.Info("No MOD(s) to uninstall")
+				}
+				return nil
+			}
+
+			p.Info(fmt.Sprintf("Planning to uninstall %d MOD(s):", len(targets)))
+			for _, target := range targets {
+				p.Say("  - " + target.String())
+			}
+			if all && len(expansionsToDisable) > 0 {
+				p.Info("Expansion MOD(s) to be disabled:")
+				for _, m := range expansionsToDisable {
+					p.Say("  - " + m.String())
+				}
+			}
+
+			confirmed, err := confirm(cmd, c.quiet, yes, "Do you want to uninstall these MOD(s)?")
+			if err != nil {
+				return err
+			}
+			if !confirmed {
+				return nil
+			}
+
+			if err := executeUninstall(p, targets, state); err != nil {
+				return err
+			}
+			if all {
+				for _, m := range expansionsToDisable {
+					if err := state.modList.Disable(m); err != nil {
+						return err
+					}
+					p.Success("Disabled expansion MOD: " + m.String())
+				}
+			}
+
+			modListPath, err := application.Runtime.MODListPath()
+			if err != nil {
+				return err
+			}
+			if err := backupIfExists(modListPath); err != nil {
+				return err
+			}
+			if err := state.modList.Save(modListPath); err != nil {
+				return err
+			}
+			p.Success(fmt.Sprintf("Uninstalled %d MOD(s)", len(targets)))
+			p.Success("Saved mod-list.json")
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&all, "all", false, "Uninstall all MOD(s) (base remains enabled, expansions disabled, others removed)")
+	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "Skip confirmation prompts")
+	return cmd
+}
+
+// parseUninstallSpecs parses "name" or "name@version" specs. Unlike
+// download/install specs, "@latest" is not meaningful for uninstalling and
+// the version, when present, must be exact.
+func parseUninstallSpecs(args []string) ([]uninstallTarget, error) {
+	targets := make([]uninstallTarget, len(args))
+	for i, arg := range args {
+		name, versionStr, hasVersion := strings.Cut(arg, "@")
+		target := uninstallTarget{MOD: mod.MOD{Name: name}}
+		if hasVersion {
+			version, err := mod.ParseMODVersion(versionStr)
+			if err != nil {
+				return nil, err
+			}
+			target.Version = &version
+		}
+		targets[i] = target
+	}
+	return targets, nil
+}
+
+func planUninstallAll(graph *dependency.Graph) []uninstallTarget {
+	var targets []uninstallTarget
+	for _, node := range graph.Nodes() {
+		if node.MOD.IsBase() || node.MOD.IsExpansion() {
+			continue
+		}
+		targets = append(targets, uninstallTarget{MOD: node.MOD})
+	}
+	return targets
+}
+
+// validateUninstallTargets rejects base/expansion MODs, warns about and
+// drops targets that are not installed, and (except under --all, where
+// everything goes at once) refuses to break enabled dependents.
+func validateUninstallTargets(p *printer, requested []uninstallTarget, state *modState, all bool) ([]uninstallTarget, error) {
+	var targets []uninstallTarget
+	for _, target := range requested {
+		if target.MOD.IsBase() {
+			return nil, fmt.Errorf("Cannot uninstall base MOD")
+		}
+		if target.MOD.IsExpansion() {
+			return nil, fmt.Errorf("Cannot uninstall expansion MOD: %s", target.MOD)
+		}
+		if !state.graph.Contains(target.MOD) {
+			p.Warn("MOD not installed: " + target.MOD.String())
+			continue
+		}
+		if target.Version != nil && !versionInstalled(state.installedMODs, target.MOD, *target.Version) {
+			p.Warn("MOD version not installed: " + target.String())
+			continue
+		}
+		if !all {
+			if err := checkDependents(target, state); err != nil {
+				return nil, err
+			}
+		}
+		targets = append(targets, target)
+	}
+	return targets, nil
+}
+
+func versionInstalled(installed []mod.InstalledMOD, m mod.MOD, version mod.MODVersion) bool {
+	for _, im := range installed {
+		if im.MOD == m && im.Version == version {
+			return true
+		}
+	}
+	return false
+}
+
+// checkDependents refuses the uninstall when an enabled MOD's required
+// dependency on the target could no longer be satisfied by the versions
+// that would remain installed.
+func checkDependents(target uninstallTarget, state *modState) error {
+	dependents := state.graph.FindEnabledDependents(target.MOD)
+	if len(dependents) == 0 {
+		return nil
+	}
+
+	var remaining []mod.InstalledMOD
+	if target.Version != nil {
+		for _, im := range state.installedMODs {
+			if im.MOD == target.MOD && im.Version != *target.Version {
+				remaining = append(remaining, im)
+			}
+		}
+	}
+
+	var unsatisfied []string
+	seen := map[mod.MOD]bool{}
+	for _, dependent := range dependents {
+		for _, edge := range state.graph.EdgesFrom(dependent) {
+			if edge.To != target.MOD || edge.Type != dependency.TypeRequired {
+				continue
+			}
+			satisfiable := false
+			for _, im := range remaining {
+				if edge.SatisfiedBy(im.Version) {
+					satisfiable = true
+					break
+				}
+			}
+			if !satisfiable && !seen[dependent] {
+				seen[dependent] = true
+				unsatisfied = append(unsatisfied, dependent.Name)
+			}
+		}
+	}
+	if len(unsatisfied) > 0 {
+		return fmt.Errorf("Cannot uninstall %s: the following enabled MOD(s) depend on it: %s",
+			target, strings.Join(unsatisfied, ", "))
+	}
+	return nil
+}
+
+func enabledExpansions(state *modState) []mod.MOD {
+	var expansions []mod.MOD
+	for _, node := range state.graph.Nodes() {
+		if !node.MOD.IsExpansion() || !state.modList.Contains(node.MOD) {
+			continue
+		}
+		if enabled, err := state.modList.Enabled(node.MOD); err == nil && enabled {
+			expansions = append(expansions, node.MOD)
+		}
+	}
+	return expansions
+}
+
+func executeUninstall(p *printer, targets []uninstallTarget, state *modState) error {
+	for _, target := range targets {
+		var toRemove []mod.InstalledMOD
+		for _, im := range state.installedMODs {
+			if im.MOD != target.MOD {
+				continue
+			}
+			if target.Version == nil || im.Version == *target.Version {
+				toRemove = append(toRemove, im)
+			}
+		}
+
+		for _, im := range toRemove {
+			var err error
+			if im.Form == mod.FormDirectory {
+				err = os.RemoveAll(im.Path)
+			} else {
+				err = os.Remove(im.Path)
+			}
+			if err != nil {
+				return err
+			}
+		}
+
+		removeFromList := target.Version == nil ||
+			len(toRemove) == countInstalledVersions(state.installedMODs, target.MOD)
+		if removeFromList && state.modList.Contains(target.MOD) {
+			if err := state.modList.Remove(target.MOD); err != nil {
+				return err
+			}
+			p.Success(fmt.Sprintf("Removed %s from mod-list.json", target.MOD))
+		}
+	}
+	return nil
+}
+
+func countInstalledVersions(installed []mod.InstalledMOD, m mod.MOD) int {
+	count := 0
+	for _, im := range installed {
+		if im.MOD == m {
+			count++
+		}
+	}
+	return count
+}

--- a/internal/cli/mod_uninstall_test.go
+++ b/internal/cli/mod_uninstall_test.go
@@ -1,0 +1,246 @@
+package cli
+
+import (
+	"archive/zip"
+	"io/fs"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// zipDirectory packs srcDir's files into zipPath under the topLevel
+// directory, the layout InstalledMODFromZIP expects.
+func zipDirectory(t *testing.T, srcDir, topLevel, zipPath string) error {
+	t.Helper()
+	f, err := os.Create(zipPath)
+	if err != nil {
+		return err
+	}
+	defer f.Close()
+
+	zw := zip.NewWriter(f)
+	err = filepath.WalkDir(srcDir, func(path string, d fs.DirEntry, err error) error {
+		if err != nil || d.IsDir() {
+			return err
+		}
+		rel, err := filepath.Rel(srcDir, path)
+		if err != nil {
+			return err
+		}
+		w, err := zw.Create(topLevel + "/" + filepath.ToSlash(rel))
+		if err != nil {
+			return err
+		}
+		data, err := os.ReadFile(path)
+		if err != nil {
+			return err
+		}
+		_, err = w.Write(data)
+		return err
+	})
+	if err != nil {
+		return err
+	}
+	return zw.Close()
+}
+
+// writeInstalledMODZip creates a ZIP-form installed MOD, so uninstall can
+// exercise both removal paths (os.Remove for ZIPs, os.RemoveAll for dirs).
+func (s *sandbox) writeInstalledMODZip(t *testing.T, name, version string) {
+	t.Helper()
+	src := t.TempDir()
+	modDir := filepath.Join(src, name)
+	require.NoError(t, os.MkdirAll(modDir, 0o755))
+	info := `{"name": "` + name + `", "version": "` + version + `", "title": "` + name + `", "author": "test"}`
+	require.NoError(t, os.WriteFile(filepath.Join(modDir, "info.json"), []byte(info), 0o644))
+
+	zipPath := filepath.Join(s.root, "factorio", "mods", name+"_"+version+".zip")
+	require.NoError(t, zipDirectory(t, modDir, name+"_"+version, zipPath))
+}
+
+func TestMODUninstallSimple(t *testing.T) {
+	s := baseSandbox(t)
+	s.writeInstalledMOD(t, "doomed", "1.0.0", nil)
+	s.writeMODList(t, modListEntry{name: "base", enabled: true}, modListEntry{name: "doomed", enabled: true})
+
+	out, err := runCLI(t, "mod", "uninstall", "doomed", "-y")
+	require.NoError(t, err)
+	assert.Contains(t, out, "Planning to uninstall 1 MOD(s):")
+	assert.Contains(t, out, "  - doomed")
+	assert.Contains(t, out, "Removed doomed from mod-list.json")
+	assert.Contains(t, out, "Uninstalled 1 MOD(s)")
+
+	assert.NoDirExists(t, filepath.Join(s.root, "factorio", "mods", "doomed"))
+	_, ok := s.readMODList(t)["doomed"]
+	assert.False(t, ok, "doomed must be gone from mod-list.json")
+	assert.FileExists(t, filepath.Join(s.root, "factorio", "mods", "mod-list.json.bak"))
+}
+
+func TestMODUninstallZIPForm(t *testing.T) {
+	s := baseSandbox(t)
+	s.writeInstalledMODZip(t, "zipped", "1.0.0")
+	s.writeMODList(t, modListEntry{name: "base", enabled: true}, modListEntry{name: "zipped", enabled: true})
+
+	_, err := runCLI(t, "mod", "uninstall", "zipped", "-y")
+	require.NoError(t, err)
+	assert.NoFileExists(t, filepath.Join(s.root, "factorio", "mods", "zipped_1.0.0.zip"))
+}
+
+func TestMODUninstallSpecificVersionKeepsOthers(t *testing.T) {
+	s := baseSandbox(t)
+	s.writeInstalledMODZip(t, "multi", "1.0.0")
+	s.writeInstalledMODZip(t, "multi", "2.0.0")
+	s.writeMODList(t, modListEntry{name: "base", enabled: true}, modListEntry{name: "multi", enabled: true})
+
+	out, err := runCLI(t, "mod", "uninstall", "multi@1.0.0", "-y")
+	require.NoError(t, err)
+	assert.Contains(t, out, "  - multi@1.0.0")
+
+	assert.NoFileExists(t, filepath.Join(s.root, "factorio", "mods", "multi_1.0.0.zip"))
+	assert.FileExists(t, filepath.Join(s.root, "factorio", "mods", "multi_2.0.0.zip"))
+	// A version remains installed, so the list entry stays.
+	assert.NotContains(t, out, "Removed multi from mod-list.json")
+	_, ok := s.readMODList(t)["multi"]
+	assert.True(t, ok)
+}
+
+func TestMODUninstallRejectsBaseAndExpansion(t *testing.T) {
+	s := baseSandbox(t)
+	s.writeMODList(t, modListEntry{name: "base", enabled: true})
+
+	_, err := runCLI(t, "mod", "uninstall", "base", "-y")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Cannot uninstall base MOD")
+
+	_, err = runCLI(t, "mod", "uninstall", "space-age", "-y")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Cannot uninstall expansion MOD: space-age")
+}
+
+func TestMODUninstallNotInstalledWarns(t *testing.T) {
+	s := baseSandbox(t)
+	s.writeMODList(t, modListEntry{name: "base", enabled: true})
+
+	out, err := runCLI(t, "mod", "uninstall", "ghost", "-y")
+	require.NoError(t, err)
+	assert.Contains(t, out, "⚠︎ MOD not installed: ghost")
+	assert.Contains(t, out, "No MOD(s) to uninstall")
+}
+
+func TestMODUninstallVersionNotInstalledWarns(t *testing.T) {
+	s := baseSandbox(t)
+	s.writeInstalledMOD(t, "some-mod", "1.0.0", nil)
+	s.writeMODList(t, modListEntry{name: "base", enabled: true}, modListEntry{name: "some-mod", enabled: true})
+
+	out, err := runCLI(t, "mod", "uninstall", "some-mod@9.9.9", "-y")
+	require.NoError(t, err)
+	assert.Contains(t, out, "⚠︎ MOD version not installed: some-mod@9.9.9")
+	assert.Contains(t, out, "No MOD(s) to uninstall")
+}
+
+func TestMODUninstallBlockedByDependents(t *testing.T) {
+	s := baseSandbox(t)
+	s.writeInstalledMOD(t, "app", "1.0.0", []string{"lib"})
+	s.writeInstalledMOD(t, "lib", "1.0.0", nil)
+	s.writeMODList(t,
+		modListEntry{name: "base", enabled: true},
+		modListEntry{name: "app", enabled: true},
+		modListEntry{name: "lib", enabled: true},
+	)
+
+	_, err := runCLI(t, "mod", "uninstall", "lib", "-y")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Cannot uninstall lib: the following enabled MOD(s) depend on it: app")
+
+	assert.DirExists(t, filepath.Join(s.root, "factorio", "mods", "lib"))
+}
+
+func TestMODUninstallVersionedKeepSatisfiesDependent(t *testing.T) {
+	s := baseSandbox(t)
+	s.writeInstalledMOD(t, "app", "1.0.0", []string{"lib >= 2.0"})
+	s.writeInstalledMODZip(t, "lib", "1.0.0")
+	s.writeInstalledMODZip(t, "lib", "2.0.0")
+	s.writeMODList(t,
+		modListEntry{name: "base", enabled: true},
+		modListEntry{name: "app", enabled: true},
+		modListEntry{name: "lib", enabled: true},
+	)
+
+	// Removing 1.0.0 leaves 2.0.0, which still satisfies app's requirement.
+	_, err := runCLI(t, "mod", "uninstall", "lib@1.0.0", "-y")
+	require.NoError(t, err)
+	assert.NoFileExists(t, filepath.Join(s.root, "factorio", "mods", "lib_1.0.0.zip"))
+	assert.FileExists(t, filepath.Join(s.root, "factorio", "mods", "lib_2.0.0.zip"))
+
+	// Removing 2.0.0 would leave only 1.0.0, which does not satisfy >= 2.0.
+	_, err = runCLI(t, "mod", "uninstall", "lib@2.0.0", "-y")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "the following enabled MOD(s) depend on it: app")
+}
+
+func TestMODUninstallAll(t *testing.T) {
+	s := baseSandbox(t)
+	spaceAgeInfo := `{"name": "space-age", "version": "1.1.110", "title": "Space Age", "author": "Wube"}`
+	spaceAgeDir := filepath.Join(s.root, "factorio", "data", "space-age")
+	require.NoError(t, os.MkdirAll(spaceAgeDir, 0o755))
+	require.NoError(t, os.WriteFile(filepath.Join(spaceAgeDir, "info.json"), []byte(spaceAgeInfo), 0o644))
+	s.writeInstalledMOD(t, "mod-a", "1.0.0", nil)
+	s.writeInstalledMOD(t, "mod-b", "1.0.0", nil)
+	s.writeMODList(t,
+		modListEntry{name: "base", enabled: true},
+		modListEntry{name: "space-age", enabled: true},
+		modListEntry{name: "mod-a", enabled: true},
+		modListEntry{name: "mod-b", enabled: false},
+	)
+
+	out, err := runCLI(t, "mod", "uninstall", "--all", "-y")
+	require.NoError(t, err)
+	assert.Contains(t, out, "Planning to uninstall 2 MOD(s):")
+	assert.Contains(t, out, "Expansion MOD(s) to be disabled:")
+	assert.Contains(t, out, "Disabled expansion MOD: space-age")
+	assert.Contains(t, out, "Uninstalled 2 MOD(s)")
+
+	states := s.readMODList(t)
+	assert.True(t, states["base"], "base stays enabled")
+	assert.False(t, states["space-age"], "expansion disabled, not removed")
+	_, hasA := states["mod-a"]
+	assert.False(t, hasA)
+}
+
+func TestMODUninstallArgumentValidation(t *testing.T) {
+	baseSandbox(t)
+
+	_, err := runCLI(t, "mod", "uninstall")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Must specify MOD names or use --all option")
+
+	_, err = runCLI(t, "mod", "uninstall", "some-mod", "--all")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Cannot specify MOD names with --all option")
+
+	// @latest is not meaningful for uninstall; the version must be exact.
+	_, err = runCLI(t, "mod", "uninstall", "some-mod@latest")
+	require.Error(t, err)
+}
+
+func TestMODUninstallPromptDecline(t *testing.T) {
+	s := baseSandbox(t)
+	s.writeInstalledMOD(t, "doomed", "1.0.0", nil)
+	s.writeMODList(t, modListEntry{name: "base", enabled: true}, modListEntry{name: "doomed", enabled: true})
+
+	_, err := runCLIWithStdin(t, "n\n", "mod", "uninstall", "doomed")
+	require.NoError(t, err)
+	assert.DirExists(t, filepath.Join(s.root, "factorio", "mods", "doomed"))
+}
+
+func TestMODUninstallRequiresGameStopped(t *testing.T) {
+	s := baseSandbox(t)
+	require.NoError(t, os.WriteFile(filepath.Join(s.root, "factorio", ".lock"), nil, 0o644))
+
+	_, err := runCLI(t, "mod", "uninstall", "anything", "-y")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "running")
+}

--- a/internal/cli/mod_update.go
+++ b/internal/cli/mod_update.go
@@ -1,0 +1,242 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+	"golang.org/x/sync/errgroup"
+
+	"github.com/sakuro/factorix/internal/api"
+	"github.com/sakuro/factorix/internal/app"
+	"github.com/sakuro/factorix/internal/mod"
+)
+
+// updateTarget is one MOD with a newer release available.
+type updateTarget struct {
+	MOD            mod.MOD
+	CurrentVersion mod.MODVersion
+	Release        api.Release
+}
+
+func newMODUpdateCommand(c *cli) *cobra.Command {
+	var jobs int
+	var yes bool
+
+	cmd := &cobra.Command{
+		Use:   "update [mod-name]...",
+		Short: "Update MOD(s) to their latest versions",
+		Args:  cobra.ArbitraryArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			application, err := c.App()
+			if err != nil {
+				return err
+			}
+			if err := application.RequireGameStopped(); err != nil {
+				return err
+			}
+
+			state, err := loadMODState(application)
+			if err != nil {
+				return err
+			}
+
+			targetMODs, err := updateTargetMODs(args, state.installedMODs)
+			if err != nil {
+				return err
+			}
+
+			p := c.printer(cmd)
+			if len(targetMODs) == 0 {
+				p.Info("No MOD(s) to update")
+				return nil
+			}
+
+			targets, err := findUpdateTargets(cmd.Context(), application, targetMODs, state.installedMODs, jobs)
+			if err != nil {
+				return err
+			}
+			if len(targets) == 0 {
+				p.Info("All MOD(s) are up to date")
+				return nil
+			}
+
+			p.Info(fmt.Sprintf("Planning to update %d MOD(s):", len(targets)))
+			for _, target := range targets {
+				p.Say(fmt.Sprintf("  - %s: %s -> %s", target.MOD, target.CurrentVersion, target.Release.Version))
+			}
+
+			confirmed, err := confirm(cmd, c.quiet, yes, "Do you want to update these MOD(s)?")
+			if err != nil {
+				return err
+			}
+			if !confirmed {
+				return nil
+			}
+
+			if err := executeUpdates(cmd.Context(), c, cmd, application, state.modList, targets, jobs); err != nil {
+				return err
+			}
+
+			modListPath, err := application.Runtime.MODListPath()
+			if err != nil {
+				return err
+			}
+			if err := backupIfExists(modListPath); err != nil {
+				return err
+			}
+			if err := state.modList.Save(modListPath); err != nil {
+				return err
+			}
+			p.Success(fmt.Sprintf("Updated %d MOD(s)", len(targets)))
+			p.Success("Saved mod-list.json")
+			return nil
+		},
+	}
+	cmd.Flags().IntVarP(&jobs, "jobs", "j", 4, "Number of parallel downloads")
+	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "Skip confirmation prompts")
+	return cmd
+}
+
+// updateTargetMODs resolves the MODs to check: the named ones (base and
+// expansion MODs rejected), or every installed MOD except base/expansions
+// when no names are given.
+func updateTargetMODs(args []string, installed []mod.InstalledMOD) ([]mod.MOD, error) {
+	if len(args) > 0 {
+		targets := make([]mod.MOD, len(args))
+		for i, name := range args {
+			m := mod.MOD{Name: name}
+			if m.IsBase() {
+				return nil, fmt.Errorf("Cannot update base MOD")
+			}
+			if m.IsExpansion() {
+				return nil, fmt.Errorf("Cannot update expansion MOD: %s", m)
+			}
+			targets[i] = m
+		}
+		return targets, nil
+	}
+
+	seen := map[mod.MOD]bool{}
+	var targets []mod.MOD
+	for _, im := range installed {
+		if seen[im.MOD] || im.MOD.IsBase() || im.MOD.IsExpansion() {
+			continue
+		}
+		seen[im.MOD] = true
+		targets = append(targets, im.MOD)
+	}
+	return targets, nil
+}
+
+// findUpdateTargets asks the Portal for each MOD's latest release and keeps
+// those newer than the newest installed version. MODs not installed or not
+// on the Portal are silently skipped, matching Ruby.
+func findUpdateTargets(ctx context.Context, application *app.App, targetMODs []mod.MOD, installed []mod.InstalledMOD, jobs int) ([]updateTarget, error) {
+	portalAPI, err := application.PortalAPI()
+	if err != nil {
+		return nil, err
+	}
+
+	// Each goroutine writes only its own index, so no lock is needed.
+	results := make([]*updateTarget, len(targetMODs))
+	group, ctx := errgroup.WithContext(ctx)
+	group.SetLimit(jobs)
+	for i, m := range targetMODs {
+		current, ok := newestInstalledVersion(installed, m)
+		if !ok {
+			continue
+		}
+		group.Go(func() error {
+			info, err := portalAPI.GetMODFull(ctx, m.Name)
+			if err != nil {
+				if errors.Is(err, api.ErrMODNotOnPortal) {
+					application.Logger.Debug("MOD not found on portal", "mod", m.Name)
+					return nil
+				}
+				return err
+			}
+			latest := latestByReleaseDate(info.Releases)
+			if latest == nil || !current.Less(latest.Version) {
+				return nil
+			}
+			results[i] = &updateTarget{MOD: m, CurrentVersion: current, Release: *latest}
+			return nil
+		})
+	}
+	if err := group.Wait(); err != nil {
+		return nil, err
+	}
+
+	var targets []updateTarget
+	for _, r := range results {
+		if r != nil {
+			targets = append(targets, *r)
+		}
+	}
+	return targets, nil
+}
+
+func newestInstalledVersion(installed []mod.InstalledMOD, m mod.MOD) (mod.MODVersion, bool) {
+	var newest mod.MODVersion
+	found := false
+	for _, im := range installed {
+		if im.MOD != m {
+			continue
+		}
+		if !found || newest.Less(im.Version) {
+			newest = im.Version
+			found = true
+		}
+	}
+	return newest, found
+}
+
+func executeUpdates(ctx context.Context, c *cli, cmd *cobra.Command, application *app.App, modList *mod.MODList, targets []updateTarget, jobs int) error {
+	modDir, err := application.Runtime.MODDir()
+	if err != nil {
+		return err
+	}
+
+	downloads := make([]downloadTarget, 0, len(targets))
+	for _, target := range targets {
+		if err := validateFilename(target.Release.FileName); err != nil {
+			return err
+		}
+		downloads = append(downloads, downloadTarget{
+			MOD:        target.MOD,
+			Release:    target.Release,
+			OutputPath: filepath.Join(modDir, target.Release.FileName),
+		})
+	}
+	if err := downloadTargets(ctx, application, downloads, jobs); err != nil {
+		return err
+	}
+
+	p := c.printer(cmd)
+	for _, target := range targets {
+		if modList.Contains(target.MOD) {
+			enabled, err := modList.Enabled(target.MOD)
+			if err != nil {
+				return err
+			}
+			// Remove and re-add so a pinned version in mod-list.json is
+			// cleared and the newly downloaded release takes effect.
+			if err := modList.Remove(target.MOD); err != nil {
+				return err
+			}
+			if err := modList.Add(target.MOD, mod.MODState{Enabled: enabled}); err != nil {
+				return err
+			}
+			p.Success(fmt.Sprintf("Updated %s to %s", target.MOD, target.Release.Version))
+		} else {
+			if err := modList.Add(target.MOD, mod.MODState{Enabled: true}); err != nil {
+				return err
+			}
+			p.Success(fmt.Sprintf("Added %s to mod-list.json", target.MOD))
+		}
+	}
+	return nil
+}

--- a/internal/cli/stubs.go
+++ b/internal/cli/stubs.go
@@ -52,8 +52,11 @@ func newMODCommand(c *cli) *cobra.Command {
 		newMODSearchCommand(c),
 		newMODShowCommand(c),
 		newMODDownloadCommand(c),
+		newMODInstallCommand(c),
+		newMODUninstallCommand(c),
+		newMODUpdateCommand(c),
 	)
-	for _, use := range []string{"install", "uninstall", "update", "upload", "edit", "sync"} {
+	for _, use := range []string{"upload", "edit", "sync"} {
 		mod.AddCommand(&cobra.Command{Use: use, Short: "MOD " + use, RunE: notImplemented})
 	}
 

--- a/internal/dependency/graph.go
+++ b/internal/dependency/graph.go
@@ -94,6 +94,39 @@ func (g *Graph) SetNodeOperation(m mod.MOD, op Operation) {
 	g.nodes[m] = node
 }
 
+// AddUninstalledMOD extends the graph with a MOD fetched from the Portal
+// (used by mod install to plan alongside the installed MODs). If the MOD is
+// already in the graph, an installed-but-disabled node is marked for
+// enabling and nothing else changes. Otherwise a node with operation
+// install is added, with edges parsed from the release's dependency
+// strings (edges to the always-available base MOD carry no information and
+// are skipped, as in the builder).
+func (g *Graph) AddUninstalledMOD(m mod.MOD, version mod.MODVersion, dependencyStrings []string) error {
+	if existing, ok := g.nodes[m]; ok {
+		if existing.Installed && !existing.Enabled {
+			g.SetNodeOperation(m, OpEnable)
+		}
+		return nil
+	}
+
+	if err := g.AddNode(Node{MOD: m, Version: version, Operation: OpInstall}); err != nil {
+		return err
+	}
+	for _, depString := range dependencyStrings {
+		entry, err := Parse(depString)
+		if err != nil {
+			return err
+		}
+		if entry.MOD.IsBase() {
+			continue
+		}
+		if err := g.AddEdge(Edge{From: m, To: entry.MOD, Type: entry.Type, Requirement: entry.Requirement}); err != nil {
+			return err
+		}
+	}
+	return nil
+}
+
 // AddEdge adds an edge; the origin node must exist.
 func (g *Graph) AddEdge(e Edge) error {
 	if _, ok := g.nodes[e.From]; !ok {

--- a/internal/dependency/plan.go
+++ b/internal/dependency/plan.go
@@ -94,6 +94,64 @@ func checkConflict(g *Graph, m, other mod.MOD, plannedSet map[mod.MOD]bool) erro
 	return nil
 }
 
+// MarkDisabledDependenciesForEnable walks the required dependencies of
+// every node planned for install or enable and marks installed-but-disabled
+// dependencies for enabling (recursively), so installing a MOD also turns
+// its already-present dependency chain back on.
+func MarkDisabledDependenciesForEnable(g *Graph) {
+	var queue []mod.MOD
+	for _, node := range g.Nodes() {
+		if node.Operation == OpInstall || node.Operation == OpEnable {
+			queue = append(queue, node.MOD)
+		}
+	}
+
+	processed := map[mod.MOD]bool{}
+	for len(queue) > 0 {
+		m := queue[0]
+		queue = queue[1:]
+		if processed[m] {
+			continue
+		}
+		processed[m] = true
+
+		for _, edge := range g.EdgesFrom(m) {
+			if edge.Type != TypeRequired {
+				continue
+			}
+			depNode, ok := g.Node(edge.To)
+			if !ok || depNode.Operation != OpNone || depNode.Enabled || !depNode.Installed {
+				continue
+			}
+			g.SetNodeOperation(edge.To, OpEnable)
+			queue = append(queue, edge.To)
+		}
+	}
+}
+
+// ValidateInstallGraph rejects an install plan whose graph has a
+// required-dependency cycle, or where a MOD marked for install conflicts
+// with a currently-enabled MOD.
+func ValidateInstallGraph(g *Graph) error {
+	if g.IsCyclic() {
+		return fmt.Errorf("%w: circular dependency detected in MOD(s) to install", ErrCircularDependency)
+	}
+	for _, node := range g.Nodes() {
+		if node.Operation != OpInstall {
+			continue
+		}
+		for _, edge := range g.EdgesFrom(node.MOD) {
+			if edge.Type != TypeIncompatible {
+				continue
+			}
+			if target, ok := g.Node(edge.To); ok && target.Enabled {
+				return fmt.Errorf("%w: cannot install %s: it conflicts with enabled MOD %s", ErrMODConflict, node.MOD, edge.To)
+			}
+		}
+	}
+	return nil
+}
+
 // PlanDisableAll returns every enabled MOD except base.
 func PlanDisableAll(g *Graph) []mod.MOD {
 	var mods []mod.MOD

--- a/internal/dependency/plan_test.go
+++ b/internal/dependency/plan_test.go
@@ -97,6 +97,104 @@ func TestValidateNoConflictsPasses(t *testing.T) {
 	require.NoError(t, err)
 }
 
+func TestAddUninstalledMOD(t *testing.T) {
+	g := NewGraph()
+	require.NoError(t, g.AddUninstalledMOD(testMOD("new-mod"), mod.MODVersion{Major: 2}, []string{"base", "lib >= 1.0", "? optional-lib"}))
+
+	node, ok := g.Node(testMOD("new-mod"))
+	require.True(t, ok)
+	assert.Equal(t, OpInstall, node.Operation)
+	assert.False(t, node.Installed)
+	assert.False(t, node.Enabled)
+
+	edges := g.EdgesFrom(testMOD("new-mod"))
+	require.Len(t, edges, 2) // base edge skipped
+	assert.Equal(t, testMOD("lib"), edges[0].To)
+	assert.Equal(t, TypeRequired, edges[0].Type)
+	assert.Equal(t, testMOD("optional-lib"), edges[1].To)
+	assert.Equal(t, TypeOptional, edges[1].Type)
+}
+
+func TestAddUninstalledMODExistingDisabled(t *testing.T) {
+	g := NewGraph()
+	disabledNode(t, g, "present-mod")
+
+	require.NoError(t, g.AddUninstalledMOD(testMOD("present-mod"), mod.MODVersion{Major: 9}, []string{"lib"}))
+
+	node, ok := g.Node(testMOD("present-mod"))
+	require.True(t, ok)
+	assert.Equal(t, OpEnable, node.Operation)
+	// The existing node is untouched otherwise: no new edges, version kept.
+	assert.Equal(t, mod.MODVersion{Major: 1}, node.Version)
+	assert.Empty(t, g.EdgesFrom(testMOD("present-mod")))
+}
+
+func TestAddUninstalledMODExistingEnabled(t *testing.T) {
+	g := NewGraph()
+	addNodes(t, g, "enabled-mod")
+
+	require.NoError(t, g.AddUninstalledMOD(testMOD("enabled-mod"), mod.MODVersion{Major: 9}, nil))
+
+	node, ok := g.Node(testMOD("enabled-mod"))
+	require.True(t, ok)
+	assert.Equal(t, OpNone, node.Operation)
+}
+
+func TestAddUninstalledMODInvalidDependency(t *testing.T) {
+	g := NewGraph()
+	err := g.AddUninstalledMOD(testMOD("broken"), mod.MODVersion{Major: 1}, []string{">= 1.0"})
+	var parseErr *ParseError
+	require.ErrorAs(t, err, &parseErr)
+}
+
+func TestMarkDisabledDependenciesForEnable(t *testing.T) {
+	g := NewGraph()
+	// new-mod (install) -> lib (installed, disabled) -> sublib (installed, disabled)
+	require.NoError(t, g.AddUninstalledMOD(testMOD("new-mod"), mod.MODVersion{Major: 1}, []string{"lib"}))
+	disabledNode(t, g, "lib")
+	disabledNode(t, g, "sublib")
+	requireEdge(t, g, "lib", "sublib", TypeRequired)
+	// An optional dependency stays untouched.
+	disabledNode(t, g, "optional-lib")
+	requireEdge(t, g, "new-mod", "optional-lib", TypeOptional)
+
+	MarkDisabledDependenciesForEnable(g)
+
+	lib, _ := g.Node(testMOD("lib"))
+	assert.Equal(t, OpEnable, lib.Operation)
+	sublib, _ := g.Node(testMOD("sublib"))
+	assert.Equal(t, OpEnable, sublib.Operation)
+	optional, _ := g.Node(testMOD("optional-lib"))
+	assert.Equal(t, OpNone, optional.Operation)
+}
+
+func TestValidateInstallGraphCycle(t *testing.T) {
+	g := NewGraph()
+	require.NoError(t, g.AddUninstalledMOD(testMOD("a"), mod.MODVersion{Major: 1}, []string{"b"}))
+	require.NoError(t, g.AddUninstalledMOD(testMOD("b"), mod.MODVersion{Major: 1}, []string{"a"}))
+
+	err := ValidateInstallGraph(g)
+	require.ErrorIs(t, err, ErrCircularDependency)
+}
+
+func TestValidateInstallGraphConflict(t *testing.T) {
+	g := NewGraph()
+	addNodes(t, g, "rival") // enabled
+	require.NoError(t, g.AddUninstalledMOD(testMOD("new-mod"), mod.MODVersion{Major: 1}, []string{"! rival"}))
+
+	err := ValidateInstallGraph(g)
+	require.ErrorIs(t, err, ErrMODConflict)
+	assert.Contains(t, err.Error(), "conflicts with enabled MOD rival")
+}
+
+func TestValidateInstallGraphOK(t *testing.T) {
+	g := NewGraph()
+	addNodes(t, g, "lib")
+	require.NoError(t, g.AddUninstalledMOD(testMOD("new-mod"), mod.MODVersion{Major: 1}, []string{"lib"}))
+
+	require.NoError(t, ValidateInstallGraph(g))
+}
+
 func TestPlanDisableAll(t *testing.T) {
 	g := NewGraph()
 	addNodes(t, g, "base", "app") // both enabled


### PR DESCRIPTION
## Summary
Fourth slice of Phase 10 (CLI commands): `mod install`, `mod uninstall`, and `mod update`, plus the graph-extension machinery install needs.

## Changes
- `internal/dependency`: `Graph.AddUninstalledMOD` extends the graph with a Portal-fetched MOD (an already-present installed-but-disabled node is marked for enabling instead, matching Ruby's `add_uninstalled_mod`); `MarkDisabledDependenciesForEnable` recursively turns installed-but-disabled dependency chains back on; `ValidateInstallGraph` rejects cycles and installs conflicting with enabled MODs
- `mod install <spec>...`: fetches targets via the full endpoint, resolves required dependencies recursively over the graph (unfetchable/incompatible dependencies are skipped with a warning), plans installs and enables separately, downloads into the MOD directory, and adds/enables mod-list.json entries
- `mod uninstall [spec]... [--all]`: `name` or exact `name@version` (`@latest` is rejected, as in Ruby, where `MODVersion.from_string("latest")` raises); refuses to remove a MOD whose enabled dependents' version requirements can't be satisfied by the versions that would remain; `--all` removes everything except base (stays enabled) and expansions (disabled, not removed); removes ZIP files and directory checkouts accordingly and drops the list entry when no version remains
- `mod update [name]...`: compares the newest installed version against the latest Portal release (by release date); re-adding the list entry on update clears a pinned version so the new download takes effect

## Bug fixed first (separate commit)
`mod download --recursive` silently resolved **zero** dependencies: Phase 10c used the short Portal endpoint, whose per-release `info_json` only contains `factorio_version` — `dependencies` exists only in `/full` (verified against the live API). Ruby always used `get_mod_full`. Both fetch sites now use `GetMODFull`, and `mod list --outdated` deliberately stays on the short endpoint (it only needs versions, matching Ruby's `get_mod` there).

## Test Plan
- `go build ./... && go vet ./... && go test ./...` pass locally (`mise run default`)
- `internal/dependency`: unit tests for `AddUninstalledMOD` (new node + edges, base skipped; existing enabled/disabled nodes; invalid dependency string), `MarkDisabledDependenciesForEnable` (recursive, optional edges untouched), and `ValidateInstallGraph` (cycle, conflict, ok)
- Uninstall is fully local and covered by sandbox tests: directory and ZIP package forms, version-specific removal keeping the list entry while other versions remain, dependent protection (including the version-aware case where removing 1.0 is fine but removing 2.0 breaks a `>= 2.0` requirement), `--all` with expansion disabling, argument validation, prompt decline, game-running guard
- Install/update planning verified against the live Portal with the real binary, declining at the prompt: `mod install Krastorio2` plans 3 installs (Krastorio2 + Krastorio2Assets + Krastorio2MenuSimulations) **and** plans the locally-installed-but-disabled flib as an enable rather than a download; `mod update` detects a stale flib 0.1.0 → 0.17.2. The download execution path itself is the Phase 8 downloader already covered by its own tests (actual portal downloads require service credentials)
