### PR TITLE
:sparkles: Add --backup-extension option to file-modifying commands

### DIFF
--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -291,6 +291,22 @@ func TestMODSettingsRestoreBacksUpExisting(t *testing.T) {
 	assert.FileExists(t, settingsPath+".bak")
 }
 
+func TestMODSettingsRestoreCustomBackupExtension(t *testing.T) {
+	s := newSandbox(t)
+	s.copyFile(t, e2eFile("mod-settings", "dump", "files", "mod-settings.dat"), "cwd/mod-settings.dat")
+	settingsPath := filepath.Join(s.root, "cwd", "mod-settings.dat")
+
+	dump, err := runCLI(t, "mod", "settings", "dump", settingsPath)
+	require.NoError(t, err)
+	inputPath := filepath.Join(s.root, "cwd", "settings.json")
+	require.NoError(t, os.WriteFile(inputPath, []byte(dump), 0o644))
+
+	_, err = runCLI(t, "mod", "settings", "restore", settingsPath, "-i", inputPath, "--backup-extension", ".orig")
+	require.NoError(t, err)
+	assert.FileExists(t, settingsPath+".orig")
+	assert.NoFileExists(t, settingsPath+".bak")
+}
+
 func TestMODSettingsRestoreRequiresGameStopped(t *testing.T) {
 	s := newSandbox(t)
 	require.NoError(t, os.WriteFile(filepath.Join(s.root, "factorio", ".lock"), nil, 0o644))

--- a/internal/cli/mod_disable.go
+++ b/internal/cli/mod_disable.go
@@ -11,6 +11,7 @@ import (
 
 func newMODDisableCommand(c *cli) *cobra.Command {
 	var yes, all bool
+	var backupExtension string
 
 	cmd := &cobra.Command{
 		Use:   "disable [mod-name]...",
@@ -73,10 +74,11 @@ func newMODDisableCommand(c *cli) *cobra.Command {
 				return nil
 			}
 
-			return applyMODListChange(cmd, c, application, state, planned, "Disabled", (*mod.MODList).Disable)
+			return applyMODListChange(cmd, c, application, state, planned, "Disabled", (*mod.MODList).Disable, backupExtension)
 		},
 	}
 	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "Skip confirmation prompts")
 	cmd.Flags().BoolVar(&all, "all", false, "Disable all MOD(s) (except base)")
+	cmd.Flags().StringVar(&backupExtension, "backup-extension", defaultBackupExtension, "Backup file extension")
 	return cmd
 }

--- a/internal/cli/mod_enable.go
+++ b/internal/cli/mod_enable.go
@@ -12,6 +12,7 @@ import (
 
 func newMODEnableCommand(c *cli) *cobra.Command {
 	var yes bool
+	var backupExtension string
 
 	cmd := &cobra.Command{
 		Use:   "enable <mod-name>...",
@@ -69,17 +70,18 @@ func newMODEnableCommand(c *cli) *cobra.Command {
 				return nil
 			}
 
-			return applyMODListChange(cmd, c, application, state, planned, "Enabled", (*mod.MODList).Enable)
+			return applyMODListChange(cmd, c, application, state, planned, "Enabled", (*mod.MODList).Enable, backupExtension)
 		},
 	}
 	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "Skip confirmation prompts")
+	cmd.Flags().StringVar(&backupExtension, "backup-extension", defaultBackupExtension, "Backup file extension")
 	return cmd
 }
 
 // applyMODListChange applies fn (MODList.Enable or MODList.Disable) to each
 // MOD in planned, reporting success per MOD, then backs up and saves
 // mod-list.json. This is the shared tail of the enable and disable commands.
-func applyMODListChange(cmd *cobra.Command, c *cli, application *app.App, state *modState, planned []mod.MOD, verb string, fn func(*mod.MODList, mod.MOD) error) error {
+func applyMODListChange(cmd *cobra.Command, c *cli, application *app.App, state *modState, planned []mod.MOD, verb string, fn func(*mod.MODList, mod.MOD) error, backupExtension string) error {
 	p := c.printer(cmd)
 	for _, m := range planned {
 		if err := fn(state.modList, m); err != nil {
@@ -92,7 +94,7 @@ func applyMODListChange(cmd *cobra.Command, c *cli, application *app.App, state 
 	if err != nil {
 		return err
 	}
-	if err := backupIfExists(modListPath); err != nil {
+	if err := backupIfExists(modListPath, backupExtension); err != nil {
 		return err
 	}
 	if err := state.modList.Save(modListPath); err != nil {

--- a/internal/cli/mod_enable_disable_test.go
+++ b/internal/cli/mod_enable_disable_test.go
@@ -43,6 +43,17 @@ func TestMODEnableSimple(t *testing.T) {
 	assert.True(t, states["lib"])
 }
 
+func TestMODEnableCustomBackupExtension(t *testing.T) {
+	s := baseSandbox(t)
+	s.writeInstalledMOD(t, "app", "1.0.0", nil)
+	s.writeMODList(t, modListEntry{name: "base", enabled: true}, modListEntry{name: "app", enabled: false})
+
+	_, err := runCLI(t, "mod", "enable", "app", "-y", "--backup-extension", ".orig")
+	require.NoError(t, err)
+	assert.FileExists(t, filepath.Join(s.root, "factorio", "mods", "mod-list.json.orig"))
+	assert.NoFileExists(t, filepath.Join(s.root, "factorio", "mods", "mod-list.json.bak"))
+}
+
 func TestMODEnableAlreadyEnabled(t *testing.T) {
 	s := baseSandbox(t)
 	s.writeInstalledMOD(t, "app", "1.0.0", nil)

--- a/internal/cli/mod_install.go
+++ b/internal/cli/mod_install.go
@@ -26,6 +26,7 @@ type installTarget struct {
 func newMODInstallCommand(c *cli) *cobra.Command {
 	var jobs int
 	var yes bool
+	var backupExtension string
 
 	cmd := &cobra.Command{
 		Use:   "install <mod-spec>...",
@@ -102,7 +103,7 @@ func newMODInstallCommand(c *cli) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if err := backupIfExists(modListPath); err != nil {
+			if err := backupIfExists(modListPath, backupExtension); err != nil {
 				return err
 			}
 			if err := state.modList.Save(modListPath); err != nil {
@@ -121,6 +122,7 @@ func newMODInstallCommand(c *cli) *cobra.Command {
 	}
 	cmd.Flags().IntVarP(&jobs, "jobs", "j", 4, "Number of parallel downloads")
 	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "Skip confirmation prompts")
+	cmd.Flags().StringVar(&backupExtension, "backup-extension", defaultBackupExtension, "Backup file extension")
 	return cmd
 }
 

--- a/internal/cli/mod_settings.go
+++ b/internal/cli/mod_settings.go
@@ -9,7 +9,7 @@ import (
 	"github.com/sakuro/factorix/internal/settings"
 )
 
-const backupExtension = ".bak"
+const defaultBackupExtension = ".bak"
 
 func newMODSettingsCommand(c *cli) *cobra.Command {
 	cmd := &cobra.Command{
@@ -54,6 +54,7 @@ func newMODSettingsDumpCommand(c *cli) *cobra.Command {
 
 func newMODSettingsRestoreCommand(c *cli) *cobra.Command {
 	var input string
+	var backupExtension string
 
 	cmd := &cobra.Command{
 		Use:   "restore [settings_file]",
@@ -87,13 +88,14 @@ func newMODSettingsRestoreCommand(c *cli) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if err := backupIfExists(settingsPath); err != nil {
+			if err := backupIfExists(settingsPath, backupExtension); err != nil {
 				return err
 			}
 			return modSettings.SaveFile(settingsPath)
 		},
 	}
 	cmd.Flags().StringVarP(&input, "input", "i", "", "Input file path")
+	cmd.Flags().StringVar(&backupExtension, "backup-extension", defaultBackupExtension, "Backup file extension")
 	return cmd
 }
 
@@ -108,13 +110,14 @@ func settingsPathFromArgs(c *cli, args []string) (string, error) {
 	return application.Runtime.MODSettingsPath()
 }
 
-// backupIfExists renames an existing file to <path>.bak before overwriting.
-func backupIfExists(path string) error {
+// backupIfExists renames an existing file to <path><extension> before
+// overwriting.
+func backupIfExists(path, extension string) error {
 	if _, err := os.Stat(path); err != nil {
 		if os.IsNotExist(err) {
 			return nil
 		}
 		return err
 	}
-	return os.Rename(path, path+backupExtension)
+	return os.Rename(path, path+extension)
 }

--- a/internal/cli/mod_uninstall.go
+++ b/internal/cli/mod_uninstall.go
@@ -27,6 +27,7 @@ func (t uninstallTarget) String() string {
 
 func newMODUninstallCommand(c *cli) *cobra.Command {
 	var all, yes bool
+	var backupExtension string
 
 	cmd := &cobra.Command{
 		Use:   "uninstall [mod-spec]...",
@@ -117,7 +118,7 @@ func newMODUninstallCommand(c *cli) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if err := backupIfExists(modListPath); err != nil {
+			if err := backupIfExists(modListPath, backupExtension); err != nil {
 				return err
 			}
 			if err := state.modList.Save(modListPath); err != nil {
@@ -130,6 +131,7 @@ func newMODUninstallCommand(c *cli) *cobra.Command {
 	}
 	cmd.Flags().BoolVar(&all, "all", false, "Uninstall all MOD(s) (base remains enabled, expansions disabled, others removed)")
 	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "Skip confirmation prompts")
+	cmd.Flags().StringVar(&backupExtension, "backup-extension", defaultBackupExtension, "Backup file extension")
 	return cmd
 }
 

--- a/internal/cli/mod_update.go
+++ b/internal/cli/mod_update.go
@@ -24,6 +24,7 @@ type updateTarget struct {
 func newMODUpdateCommand(c *cli) *cobra.Command {
 	var jobs int
 	var yes bool
+	var backupExtension string
 
 	cmd := &cobra.Command{
 		Use:   "update [mod-name]...",
@@ -84,7 +85,7 @@ func newMODUpdateCommand(c *cli) *cobra.Command {
 			if err != nil {
 				return err
 			}
-			if err := backupIfExists(modListPath); err != nil {
+			if err := backupIfExists(modListPath, backupExtension); err != nil {
 				return err
 			}
 			if err := state.modList.Save(modListPath); err != nil {
@@ -97,6 +98,7 @@ func newMODUpdateCommand(c *cli) *cobra.Command {
 	}
 	cmd.Flags().IntVarP(&jobs, "jobs", "j", 4, "Number of parallel downloads")
 	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "Skip confirmation prompts")
+	cmd.Flags().StringVar(&backupExtension, "backup-extension", defaultBackupExtension, "Backup file extension")
 	return cmd
 }
 


### PR DESCRIPTION
## Summary
Add the `--backup-extension` option (default `".bak"`) to the Go commands that back up files before overwriting, matching Ruby's `BackupSupport` mixin.

## Changes
- Add `--backup-extension` to `mod enable`, `mod disable`, `mod install`, `mod uninstall`, `mod update`, and `mod settings restore`
- Thread the extension through `backupIfExists` and `applyMODListChange` instead of the hardcoded `.bak`
- Add tests covering a custom extension for both `mod-list.json` and `mod-settings.dat` backups

## Test Plan
- `mise run default` (test + vet + fmt-check) passes
- `factorix mod enable --help` shows the option with its default

Closes #118
