### PR TITLE
:bug: Validate --log-level value at parse time

### DIFF
--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -7,6 +7,7 @@ import (
 	"github.com/spf13/cobra"
 
 	"github.com/sakuro/factorix/internal/app"
+	"github.com/sakuro/factorix/internal/logging"
 )
 
 // Version is the factorix version, injected at build time by goreleaser.
@@ -63,6 +64,16 @@ func NewRootCommand() (root *cobra.Command, reportError func(error)) {
 		Short:         "Manage Factorio MODs, settings, and game control",
 		SilenceUsage:  true,
 		SilenceErrors: true,
+		// Ruby validates --log-level values at option-parse time for every
+		// command; checking only at app construction would let commands that
+		// never build the app (like version) accept invalid values silently.
+		PersistentPreRunE: func(*cobra.Command, []string) error {
+			if c.logLevel == "" {
+				return nil
+			}
+			_, err := logging.ParseLevel(c.logLevel)
+			return err
+		},
 		PersistentPostRun: func(*cobra.Command, []string) {
 			c.Close()
 		},

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -190,6 +190,18 @@ func TestVersionCommandNeverBuildsApp(t *testing.T) {
 	assert.ErrorIs(t, statErr, os.ErrNotExist, "version must not trigger app construction")
 }
 
+// Invalid --log-level values must fail at parse time on every command,
+// including ones like version that never build the application.
+func TestInvalidLogLevelRejectedAtParseTime(t *testing.T) {
+	_, err := runCLI(t, "version", "--log-level", "bogus")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid log level")
+
+	out, err := runCLI(t, "version", "--log-level", "debug")
+	require.NoError(t, err)
+	assert.Equal(t, "dev\n", out)
+}
+
 func TestPathCommand(t *testing.T) {
 	s := newSandbox(t)
 	out, err := runCLI(t, "path")


### PR DESCRIPTION
## Summary
Reject invalid `--log-level` values at option-parse time on every command, matching Ruby's behavior and the fail-loud policy.

## Changes
- Validate `--log-level` via `logging.ParseLevel` in the root command's `PersistentPreRunE`
- Previously only app construction validated it, so commands that never build the app (e.g. `version`) accepted invalid values silently

## Test Plan
- `mise run default` passes
- `factorix version --log-level bogus` now exits 1 with `invalid log level: "bogus"`; valid values unaffected

Closes #120
