### PR TITLE
:sparkles: Implement blueprint encode/decode commands (Phase 10e)

### DIFF
--- a/doc/go-migration-roadmap.md
+++ b/doc/go-migration-roadmap.md
@@ -429,7 +429,7 @@ than one pass over the full list below.
 
 #### MOD Author Tools
 - [ ] `mod changelog add` / `check` / `extract` / `release`
-- [ ] `blueprint encode` / `decode`
+- [x] `blueprint encode` / `decode`
 
 #### Portal-dependent
 - [x] `mod search` / `mod show` — `api.Category` display catalog added here

--- a/e2e/cases/blueprint/encode/case.yaml
+++ b/e2e/cases/blueprint/encode/case.yaml
@@ -4,4 +4,4 @@ stdin: |
 expect:
   status: 0
   stdout:
-    match: "\\A0[A-Za-z0-9+/=]+\\z"
+    match: "\\A0[A-Za-z0-9+/=]+\\n\\z"

--- a/internal/cli/blueprint.go
+++ b/internal/cli/blueprint.go
@@ -1,0 +1,94 @@
+package cli
+
+import (
+	"io"
+	"os"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/sakuro/factorix/internal/blueprint"
+)
+
+func newBlueprintCommand(c *cli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "blueprint",
+		Short: "Encode and decode blueprint strings",
+	}
+	cmd.AddCommand(newBlueprintEncodeCommand(c), newBlueprintDecodeCommand(c))
+	return cmd
+}
+
+func newBlueprintEncodeCommand(c *cli) *cobra.Command {
+	var output string
+
+	cmd := &cobra.Command{
+		Use:   "encode [file]",
+		Short: "Encode JSON to a Factorio blueprint string",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			data, err := readFileOrStdin(cmd, args)
+			if err != nil {
+				return err
+			}
+			bp, err := blueprint.FromJSON(data)
+			if err != nil {
+				return err
+			}
+			encoded, err := bp.Encode()
+			if err != nil {
+				return err
+			}
+
+			if output != "" {
+				return os.WriteFile(output, []byte(encoded), 0o644)
+			}
+			// No trailing newline, matching Ruby's out.print.
+			c.printer(cmd).Printf("%s", encoded)
+			return nil
+		},
+	}
+	cmd.Flags().StringVarP(&output, "output", "o", "", "Output file path (default: stdout)")
+	return cmd
+}
+
+func newBlueprintDecodeCommand(c *cli) *cobra.Command {
+	var output string
+
+	cmd := &cobra.Command{
+		Use:   "decode [file]",
+		Short: "Decode a Factorio blueprint string to JSON",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			data, err := readFileOrStdin(cmd, args)
+			if err != nil {
+				return err
+			}
+			bp, err := blueprint.Decode(strings.TrimSpace(string(data)))
+			if err != nil {
+				return err
+			}
+			jsonData, err := bp.JSON()
+			if err != nil {
+				return err
+			}
+
+			if output != "" {
+				return os.WriteFile(output, jsonData, 0o644)
+			}
+			c.printer(cmd).Println(string(jsonData))
+			return nil
+		},
+	}
+	cmd.Flags().StringVarP(&output, "output", "o", "", "Output file path (default: stdout)")
+	return cmd
+}
+
+// readFileOrStdin returns the contents of the file named by the optional
+// positional argument, or all of stdin when the argument is absent.
+func readFileOrStdin(cmd *cobra.Command, args []string) ([]byte, error) {
+	if len(args) > 0 {
+		return os.ReadFile(args[0])
+	}
+	return io.ReadAll(cmd.InOrStdin())
+}

--- a/internal/cli/blueprint.go
+++ b/internal/cli/blueprint.go
@@ -41,10 +41,9 @@ func newBlueprintEncodeCommand(c *cli) *cobra.Command {
 			}
 
 			if output != "" {
-				return os.WriteFile(output, []byte(encoded), 0o644)
+				return os.WriteFile(output, []byte(encoded+"\n"), 0o644)
 			}
-			// No trailing newline, matching Ruby's out.print.
-			c.printer(cmd).Printf("%s", encoded)
+			c.printer(cmd).Println(encoded)
 			return nil
 		},
 	}
@@ -74,7 +73,7 @@ func newBlueprintDecodeCommand(c *cli) *cobra.Command {
 			}
 
 			if output != "" {
-				return os.WriteFile(output, jsonData, 0o644)
+				return os.WriteFile(output, append(jsonData, '\n'), 0o644)
 			}
 			c.printer(cmd).Println(string(jsonData))
 			return nil

--- a/internal/cli/blueprint_test.go
+++ b/internal/cli/blueprint_test.go
@@ -4,7 +4,6 @@ import (
 	"os"
 	"path/filepath"
 	"regexp"
-	"strings"
 	"testing"
 
 	"github.com/stretchr/testify/assert"
@@ -17,7 +16,8 @@ const (
 	e2eBlueprintJSON   = `{"blueprint": {"item": "blueprint", "label": "e2e", "version": 281479275675648}}`
 )
 
-var blueprintStringPattern = regexp.MustCompile(`\A0[A-Za-z0-9+/=]+\z`)
+// The e2e contract: a blueprint string followed by a trailing newline.
+var blueprintStringPattern = regexp.MustCompile(`\A0[A-Za-z0-9+/=]+\n\z`)
 
 func TestBlueprintDecodeStdin(t *testing.T) {
 	out, err := runCLIWithStdin(t, e2eBlueprintString, "blueprint", "decode")
@@ -28,7 +28,6 @@ func TestBlueprintDecodeStdin(t *testing.T) {
 func TestBlueprintEncodeStdin(t *testing.T) {
 	out, err := runCLIWithStdin(t, e2eBlueprintJSON+"\n", "blueprint", "encode")
 	require.NoError(t, err)
-	// No trailing newline, matching Ruby's out.print.
 	assert.Regexp(t, blueprintStringPattern, out)
 
 	// The produced string decodes back to the same JSON.
@@ -50,9 +49,8 @@ func TestBlueprintDecodeFileToFile(t *testing.T) {
 
 	data, err := os.ReadFile(outPath)
 	require.NoError(t, err)
-	// The file gets the JSON without the newline that puts adds on stdout.
-	expected := strings.TrimSuffix(expectedStdout(t, "blueprint", "decode", "expected_stdout.txt"), "\n")
-	assert.Equal(t, expected, string(data))
+	// The file gets the same newline-terminated JSON as stdout.
+	assert.Equal(t, expectedStdout(t, "blueprint", "decode", "expected_stdout.txt"), string(data))
 }
 
 func TestBlueprintEncodeFileToFile(t *testing.T) {

--- a/internal/cli/blueprint_test.go
+++ b/internal/cli/blueprint_test.go
@@ -1,0 +1,83 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"regexp"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// The blueprint string and JSON from the e2e cases (e2e/cases/blueprint).
+const (
+	e2eBlueprintString = "0eNqrVkrKKU0tKMrMK1GyqlbKLEnNVbJCEtNRyklMSs0BiqUapQJ5ZalFxZn5eUpWRhaGJuaWRuamZkBkYlFbCwCnbBdF"
+	e2eBlueprintJSON   = `{"blueprint": {"item": "blueprint", "label": "e2e", "version": 281479275675648}}`
+)
+
+var blueprintStringPattern = regexp.MustCompile(`\A0[A-Za-z0-9+/=]+\z`)
+
+func TestBlueprintDecodeStdin(t *testing.T) {
+	out, err := runCLIWithStdin(t, e2eBlueprintString, "blueprint", "decode")
+	require.NoError(t, err)
+	assert.Equal(t, expectedStdout(t, "blueprint", "decode", "expected_stdout.txt"), out)
+}
+
+func TestBlueprintEncodeStdin(t *testing.T) {
+	out, err := runCLIWithStdin(t, e2eBlueprintJSON+"\n", "blueprint", "encode")
+	require.NoError(t, err)
+	// No trailing newline, matching Ruby's out.print.
+	assert.Regexp(t, blueprintStringPattern, out)
+
+	// The produced string decodes back to the same JSON.
+	decoded, err := runCLIWithStdin(t, out, "blueprint", "decode")
+	require.NoError(t, err)
+	assert.Equal(t, expectedStdout(t, "blueprint", "decode", "expected_stdout.txt"), decoded)
+}
+
+func TestBlueprintDecodeFileToFile(t *testing.T) {
+	dir := t.TempDir()
+	inPath := filepath.Join(dir, "blueprint.txt")
+	outPath := filepath.Join(dir, "decoded.json")
+	// A trailing newline in the input file is stripped, as in Ruby.
+	require.NoError(t, os.WriteFile(inPath, []byte(e2eBlueprintString+"\n"), 0o644))
+
+	out, err := runCLI(t, "blueprint", "decode", inPath, "-o", outPath)
+	require.NoError(t, err)
+	assert.Empty(t, out)
+
+	data, err := os.ReadFile(outPath)
+	require.NoError(t, err)
+	// The file gets the JSON without the newline that puts adds on stdout.
+	expected := strings.TrimSuffix(expectedStdout(t, "blueprint", "decode", "expected_stdout.txt"), "\n")
+	assert.Equal(t, expected, string(data))
+}
+
+func TestBlueprintEncodeFileToFile(t *testing.T) {
+	dir := t.TempDir()
+	inPath := filepath.Join(dir, "decoded.json")
+	outPath := filepath.Join(dir, "blueprint.txt")
+	require.NoError(t, os.WriteFile(inPath, []byte(e2eBlueprintJSON), 0o644))
+
+	out, err := runCLI(t, "blueprint", "encode", inPath, "-o", outPath)
+	require.NoError(t, err)
+	assert.Empty(t, out)
+
+	data, err := os.ReadFile(outPath)
+	require.NoError(t, err)
+	assert.Regexp(t, blueprintStringPattern, string(data))
+}
+
+func TestBlueprintDecodeInvalidInput(t *testing.T) {
+	_, err := runCLIWithStdin(t, "1nonsense", "blueprint", "decode")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "unsupported blueprint version")
+}
+
+func TestBlueprintEncodeInvalidJSON(t *testing.T) {
+	_, err := runCLIWithStdin(t, "{not json", "blueprint", "encode")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "invalid JSON")
+}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -91,7 +91,7 @@ func NewRootCommand() (root *cobra.Command, reportError func(error)) {
 		newManCommand(),
 		newMODCommand(c),
 		newCacheCommand(),
-		newBlueprintCommand(),
+		newBlueprintCommand(c),
 		newRConCommand(),
 	)
 

--- a/internal/cli/stubs.go
+++ b/internal/cli/stubs.go
@@ -87,18 +87,6 @@ func newCacheCommand() *cobra.Command {
 	return cache
 }
 
-func newBlueprintCommand() *cobra.Command {
-	blueprint := &cobra.Command{
-		Use:   "blueprint",
-		Short: "Encode and decode blueprint strings",
-	}
-	blueprint.AddCommand(
-		&cobra.Command{Use: "encode", Short: "Encode JSON to a blueprint string", RunE: notImplemented},
-		&cobra.Command{Use: "decode", Short: "Decode a blueprint string to JSON", RunE: notImplemented},
-	)
-	return blueprint
-}
-
 func newRConCommand() *cobra.Command {
 	rcon := &cobra.Command{
 		Use:   "rcon",

--- a/lib/factorix/cli/commands/blueprint/decode.rb
+++ b/lib/factorix/cli/commands/blueprint/decode.rb
@@ -28,7 +28,7 @@ module Factorix
             json_string = blueprint.to_json
 
             if output
-              Pathname(output).write(json_string)
+              Pathname(output).write("#{json_string}\n")
             else
               out.puts json_string
             end

--- a/lib/factorix/cli/commands/blueprint/encode.rb
+++ b/lib/factorix/cli/commands/blueprint/encode.rb
@@ -30,9 +30,9 @@ module Factorix
             blueprint_string = blueprint.encode
 
             if output
-              Pathname(output).write(blueprint_string)
+              Pathname(output).write("#{blueprint_string}\n")
             else
-              out.print blueprint_string
+              out.puts blueprint_string
             end
           end
         end

--- a/spec/factorix/cli/commands/blueprint/encode_spec.rb
+++ b/spec/factorix/cli/commands/blueprint/encode_spec.rb
@@ -69,7 +69,7 @@ RSpec.describe Factorix::CLI::Commands::Blueprint::Encode do
 
       it "produces a blueprint string that decodes back to the original data" do
         result = run_command(command, [input_file.path])
-        blueprint = Factorix::Blueprint.decode(result.stdout)
+        blueprint = Factorix::Blueprint.decode(result.stdout.chomp)
         expect(blueprint.data).to eq(data)
       end
     end


### PR DESCRIPTION
## Summary
Implement `blueprint encode` and `blueprint decode` by wiring the existing `internal/blueprint` package to the CLI (Phase 10e, MOD Author Tools).

## Changes
- `blueprint decode [file]` — blueprint string from positional file or stdin, pretty JSON to `-o` or stdout
- `blueprint encode [file]` — JSON from positional file or stdin, blueprint string to `-o` or stdout
- All output (stdout and `-o` files, both commands) is newline-terminated. The Ruby implementation's `puts`/`print` split turned out to be incidental, so Ruby was unified to the same rule and the e2e encode contract now requires the trailing newline
- Remove the blueprint stubs; check off the roadmap item

## Test Plan
- `mise run default` and Ruby specs (blueprint + e2e) pass
- Verified against the real binaries: decode output matches `expected_stdout.txt`; all output paths end with `\n` (od-checked); cross-checked Go↔Ruby in both directions (encoded bytes differ due to zlib settings — the e2e encode case matches by pattern, so this is within contract)
