### PR TITLE
:sparkles: Implement mod changelog commands (Phase 10f)

### DIFF
--- a/doc/go-migration-roadmap.md
+++ b/doc/go-migration-roadmap.md
@@ -428,7 +428,7 @@ than one pass over the full list below.
 - [x] `mod settings dump` / `restore` — export/import `mod-settings.dat` (JSON)
 
 #### MOD Author Tools
-- [ ] `mod changelog add` / `check` / `extract` / `release`
+- [x] `mod changelog add` / `check` / `extract` / `release`
 - [x] `blueprint encode` / `decode`
 
 #### Portal-dependent

--- a/internal/changelog/changelog.go
+++ b/internal/changelog/changelog.go
@@ -136,13 +136,15 @@ func (c *Changelog) String() string {
 			b.WriteString("\n")
 		}
 		b.WriteString(Separator + "\n")
-		b.WriteString(formatSection(section))
+		b.WriteString(FormatSection(section))
 	}
 	b.WriteString("\n")
 	return b.String()
 }
 
-func formatSection(section *Section) string {
+// FormatSection renders one section in the changelog.txt format, without
+// the separator line or a trailing newline.
+func FormatSection(section *Section) string {
 	var lines []string
 	lines = append(lines, "Version: "+section.VersionLabel())
 	if section.Date != "" {

--- a/internal/cli/mod_changelog.go
+++ b/internal/cli/mod_changelog.go
@@ -1,0 +1,328 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/sakuro/factorix/internal/changelog"
+	"github.com/sakuro/factorix/internal/mod"
+)
+
+func newMODChangelogCommand(c *cli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "changelog",
+		Short: "Manage MOD changelogs",
+	}
+	cmd.AddCommand(
+		newMODChangelogAddCommand(c),
+		newMODChangelogCheckCommand(c),
+		newMODChangelogExtractCommand(c),
+		newMODChangelogReleaseCommand(c),
+	)
+	return cmd
+}
+
+func newMODChangelogAddCommand(c *cli) *cobra.Command {
+	var version, category, changelogPath string
+
+	cmd := &cobra.Command{
+		Use:   "add <entry>...",
+		Short: "Add an entry to MOD changelog",
+		Args:  cobra.MinimumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			target, err := parseChangelogVersion(version)
+			if err != nil {
+				return err
+			}
+			log, err := changelog.Load(changelogPath)
+			if err != nil {
+				return err
+			}
+			if err := log.AddEntry(target, category, strings.Join(args, " ")); err != nil {
+				return err
+			}
+			if err := log.Save(changelogPath); err != nil {
+				return err
+			}
+			c.printer(cmd).Success(fmt.Sprintf("Added entry to %s [%s]", changelogVersionLabel(target), category))
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&version, "version", changelog.Unreleased, "Version (X.Y.Z or Unreleased)")
+	cmd.Flags().StringVar(&category, "category", "", "Category (e.g., Features, Bugfixes)")
+	cmd.Flags().StringVar(&changelogPath, "changelog", "changelog.txt", "Path to changelog file")
+	_ = cmd.MarkFlagRequired("category")
+	return cmd
+}
+
+func newMODChangelogCheckCommand(c *cli) *cobra.Command {
+	var release bool
+	var changelogPath, infoJSONPath string
+
+	cmd := &cobra.Command{
+		Use:   "check",
+		Short: "Validate MOD changelog structure",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			var validationErrors []string
+
+			log, err := changelog.Load(changelogPath)
+			switch {
+			case errors.Is(err, changelog.ErrParse):
+				validationErrors = append(validationErrors, "Failed to parse changelog: "+err.Error())
+			case err != nil:
+				return err
+			default:
+				validationErrors = append(validationErrors, validateUnreleasedPosition(log)...)
+				validationErrors = append(validationErrors, validateVersionOrder(log)...)
+				if release {
+					releaseErrors, err := validateReleaseMode(log, infoJSONPath)
+					if err != nil {
+						return err
+					}
+					validationErrors = append(validationErrors, releaseErrors...)
+				}
+			}
+
+			p := c.printer(cmd)
+			if len(validationErrors) == 0 {
+				p.Success("Changelog is valid")
+				return nil
+			}
+			p.Error("Changelog validation failed:")
+			for _, msg := range validationErrors {
+				p.Say("  - " + msg)
+			}
+			return errors.New("Changelog validation failed")
+		},
+	}
+	cmd.Flags().BoolVar(&release, "release", false, "Disallow Unreleased section")
+	cmd.Flags().StringVar(&changelogPath, "changelog", "changelog.txt", "Path to changelog file")
+	cmd.Flags().StringVar(&infoJSONPath, "info-json", "info.json", "Path to info.json file")
+	return cmd
+}
+
+func validateUnreleasedPosition(log *changelog.Changelog) []string {
+	for i, section := range log.Sections() {
+		if section.Version == nil && i != 0 {
+			return []string{"Unreleased section must be the first section"}
+		}
+	}
+	return nil
+}
+
+func validateVersionOrder(log *changelog.Changelog) []string {
+	var errs []string
+	var previous *mod.MODVersion
+	for _, section := range log.Sections() {
+		if section.Version == nil {
+			continue
+		}
+		if previous != nil && previous.Compare(*section.Version) <= 0 {
+			errs = append(errs, fmt.Sprintf("Versions are not in descending order: %s should be greater than %s", previous, section.Version))
+		}
+		previous = section.Version
+	}
+	return errs
+}
+
+// validateReleaseMode returns validation errors for release mode; a missing
+// info.json is a validation error, but an unreadable or malformed one is a
+// hard error, as in Ruby.
+func validateReleaseMode(log *changelog.Changelog, infoJSONPath string) ([]string, error) {
+	var errs []string
+	if _, ok := log.FindSection(nil); ok {
+		errs = append(errs, "Unreleased section is not allowed in release mode")
+	}
+
+	data, err := os.ReadFile(infoJSONPath)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return append(errs, "info.json not found: "+infoJSONPath), nil
+		}
+		return nil, err
+	}
+	info, err := mod.ParseInfoJSON(data)
+	if err != nil {
+		return nil, err
+	}
+
+	for _, section := range log.Sections() {
+		if section.Version == nil {
+			continue
+		}
+		if info.Version != *section.Version {
+			errs = append(errs, fmt.Sprintf("info.json version (%s) does not match first changelog version (%s)", info.Version, section.Version))
+		}
+		break
+	}
+	return errs, nil
+}
+
+func newMODChangelogExtractCommand(c *cli) *cobra.Command {
+	var version, changelogPath string
+	var jsonOutput bool
+
+	cmd := &cobra.Command{
+		Use:   "extract",
+		Short: "Extract a changelog section for a specific version",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			target, err := parseChangelogVersion(version)
+			if err != nil {
+				return err
+			}
+			log, err := changelog.Load(changelogPath)
+			if err != nil {
+				return err
+			}
+			section, ok := log.FindSection(target)
+			if !ok {
+				return fmt.Errorf("version not found: %s", changelogVersionLabel(target))
+			}
+
+			p := c.printer(cmd)
+			if jsonOutput {
+				data, err := extractSectionJSON(section)
+				if err != nil {
+					return err
+				}
+				p.Println(string(data))
+				return nil
+			}
+			p.Println(changelog.FormatSection(section))
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&version, "version", "", "Version (X.Y.Z or Unreleased)")
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSON format")
+	cmd.Flags().StringVar(&changelogPath, "changelog", "changelog.txt", "Path to changelog file")
+	_ = cmd.MarkFlagRequired("version")
+	return cmd
+}
+
+// extractSectionJSON renders a section as pretty JSON with the same key
+// and category order as Ruby's JSON.pretty_generate (encoding/json maps
+// would sort category names, so the object is assembled by hand).
+func extractSectionJSON(section *changelog.Section) ([]byte, error) {
+	var compact bytes.Buffer
+	compact.WriteString(`{"version":`)
+	if err := appendJSON(&compact, section.VersionLabel()); err != nil {
+		return nil, err
+	}
+	compact.WriteString(`,"date":`)
+	if section.Date == "" {
+		compact.WriteString("null")
+	} else if err := appendJSON(&compact, section.Date); err != nil {
+		return nil, err
+	}
+	compact.WriteString(`,"entries":{`)
+	for i, category := range section.Categories {
+		if i > 0 {
+			compact.WriteString(",")
+		}
+		if err := appendJSON(&compact, category.Name); err != nil {
+			return nil, err
+		}
+		compact.WriteString(":")
+		if err := appendJSON(&compact, category.Entries); err != nil {
+			return nil, err
+		}
+	}
+	compact.WriteString("}}")
+
+	var pretty bytes.Buffer
+	if err := json.Indent(&pretty, compact.Bytes(), "", "  "); err != nil {
+		return nil, err
+	}
+	return pretty.Bytes(), nil
+}
+
+func appendJSON(b *bytes.Buffer, v any) error {
+	data, err := json.Marshal(v)
+	if err != nil {
+		return err
+	}
+	b.Write(data)
+	return nil
+}
+
+func newMODChangelogReleaseCommand(c *cli) *cobra.Command {
+	var version, date, changelogPath, infoJSONPath string
+
+	cmd := &cobra.Command{
+		Use:   "release",
+		Short: "Convert Unreleased changelog section to a versioned section",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			target, err := resolveReleaseVersion(version, infoJSONPath)
+			if err != nil {
+				return err
+			}
+			releaseDate := date
+			if releaseDate == "" {
+				releaseDate = time.Now().UTC().Format("2006-01-02")
+			}
+
+			log, err := changelog.Load(changelogPath)
+			if err != nil {
+				return err
+			}
+			if err := log.ReleaseSection(target, releaseDate); err != nil {
+				return err
+			}
+			if err := log.Save(changelogPath); err != nil {
+				return err
+			}
+			c.printer(cmd).Success(fmt.Sprintf("Converted Unreleased to %s (%s)", target, releaseDate))
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&version, "version", "", "Version (X.Y.Z, default: from info.json)")
+	cmd.Flags().StringVar(&date, "date", "", "Release date (YYYY-MM-DD, default: today UTC)")
+	cmd.Flags().StringVar(&changelogPath, "changelog", "changelog.txt", "Path to changelog file")
+	cmd.Flags().StringVar(&infoJSONPath, "info-json", "info.json", "Path to info.json file")
+	return cmd
+}
+
+func resolveReleaseVersion(version, infoJSONPath string) (mod.MODVersion, error) {
+	if version != "" {
+		return mod.ParseMODVersion(version)
+	}
+	data, err := os.ReadFile(infoJSONPath)
+	if err != nil {
+		return mod.MODVersion{}, err
+	}
+	info, err := mod.ParseInfoJSON(data)
+	if err != nil {
+		return mod.MODVersion{}, err
+	}
+	return info.Version, nil
+}
+
+// parseChangelogVersion maps a --version value to a section version:
+// nil for Unreleased (case-insensitive), a parsed MODVersion otherwise.
+func parseChangelogVersion(s string) (*mod.MODVersion, error) {
+	if strings.EqualFold(s, changelog.Unreleased) {
+		return nil, nil
+	}
+	v, err := mod.ParseMODVersion(s)
+	if err != nil {
+		return nil, err
+	}
+	return &v, nil
+}
+
+func changelogVersionLabel(version *mod.MODVersion) string {
+	if version == nil {
+		return changelog.Unreleased
+	}
+	return version.String()
+}

--- a/internal/cli/mod_changelog_test.go
+++ b/internal/cli/mod_changelog_test.go
@@ -1,0 +1,183 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func changelogFixture(name string) string {
+	return filepath.Join("..", "..", "spec", "fixtures", "changelog", name)
+}
+
+func TestMODChangelogCheckValid(t *testing.T) {
+	newSandbox(t)
+	out, err := runCLI(t, "mod", "changelog", "check", "--changelog", changelogFixture("basic.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, expectedStdout(t, "changelog", "check-valid", "expected_stdout.txt"), out)
+}
+
+func TestMODChangelogCheckWrongOrder(t *testing.T) {
+	newSandbox(t)
+	out, err := runCLI(t, "mod", "changelog", "check", "--changelog", changelogFixture("wrong_order.txt"))
+	require.Error(t, err)
+	assert.Equal(t, "Changelog validation failed", err.Error())
+	assert.Equal(t, expectedStdout(t, "changelog", "check-invalid", "expected_stdout.txt"), out)
+}
+
+func TestMODChangelogCheckParseFailure(t *testing.T) {
+	s := newSandbox(t)
+	path := filepath.Join(s.root, "broken.txt")
+	require.NoError(t, os.WriteFile(path, []byte("not a changelog\n"), 0o644))
+
+	out, err := runCLI(t, "mod", "changelog", "check", "--changelog", path)
+	require.Error(t, err)
+	assert.Contains(t, out, "  - Failed to parse changelog:")
+}
+
+func TestMODChangelogCheckReleaseMode(t *testing.T) {
+	s := newSandbox(t)
+	path := filepath.Join(s.root, "changelog.txt")
+	_, err := runCLI(t, "mod", "changelog", "add", "--changelog", path, "--category", "Features", "New", "thing")
+	require.NoError(t, err)
+
+	// Unreleased section present and info.json missing.
+	out, err := runCLI(t, "mod", "changelog", "check", "--release",
+		"--changelog", path, "--info-json", filepath.Join(s.root, "info.json"))
+	require.Error(t, err)
+	assert.Contains(t, out, "  - Unreleased section is not allowed in release mode\n")
+	assert.Contains(t, out, "  - info.json not found: ")
+
+	// Released changelog whose version does not match info.json.
+	_, err = runCLI(t, "mod", "changelog", "release", "--changelog", path, "--version", "1.0.0", "--date", "2026-07-10")
+	require.NoError(t, err)
+	infoPath := filepath.Join(s.root, "info.json")
+	info := `{"name": "m", "version": "2.0.0", "title": "m", "author": "a", "factorio_version": "2.0"}`
+	require.NoError(t, os.WriteFile(infoPath, []byte(info), 0o644))
+
+	out, err = runCLI(t, "mod", "changelog", "check", "--release", "--changelog", path, "--info-json", infoPath)
+	require.Error(t, err)
+	assert.Contains(t, out, "  - info.json version (2.0.0) does not match first changelog version (1.0.0)\n")
+}
+
+func TestMODChangelogExtractText(t *testing.T) {
+	newSandbox(t)
+	out, err := runCLI(t, "mod", "changelog", "extract", "--version", "1.1.0", "--changelog", changelogFixture("basic.txt"))
+	require.NoError(t, err)
+	assert.Equal(t, expectedStdout(t, "changelog", "extract", "expected_stdout.txt"), out)
+}
+
+func TestMODChangelogExtractJSON(t *testing.T) {
+	newSandbox(t)
+	out, err := runCLI(t, "mod", "changelog", "extract", "--version", "1.1.0", "--json", "--changelog", changelogFixture("basic.txt"))
+	require.NoError(t, err)
+	// Category order follows the file, date is null when absent (as in
+	// Ruby's JSON.pretty_generate).
+	assert.Equal(t, `{
+  "version": "1.1.0",
+  "date": null,
+  "entries": {
+    "Features": [
+      "Added new feature A",
+      "Added new feature B"
+    ],
+    "Bugfixes": [
+      "Fixed crash on startup"
+    ]
+  }
+}
+`, out)
+}
+
+func TestMODChangelogExtractVersionNotFound(t *testing.T) {
+	newSandbox(t)
+	_, err := runCLI(t, "mod", "changelog", "extract", "--version", "9.9.9", "--changelog", changelogFixture("basic.txt"))
+	require.Error(t, err)
+	assert.Equal(t, "version not found: 9.9.9", err.Error())
+}
+
+func TestMODChangelogAddCreatesUnreleased(t *testing.T) {
+	s := newSandbox(t)
+	path := filepath.Join(s.root, "changelog.txt")
+
+	out, err := runCLI(t, "mod", "changelog", "add", "--changelog", path, "--category", "Features", "Added", "something", "new")
+	require.NoError(t, err)
+	assert.Equal(t, "✓ Added entry to Unreleased [Features]\n", out)
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "Version: Unreleased\n  Features:\n    - Added something new\n")
+}
+
+func TestMODChangelogAddToExistingVersion(t *testing.T) {
+	s := newSandbox(t)
+	path := filepath.Join(s.root, "changelog.txt")
+	fixture, err := os.ReadFile(changelogFixture("basic.txt"))
+	require.NoError(t, err)
+	require.NoError(t, os.WriteFile(path, fixture, 0o644))
+
+	out, err := runCLI(t, "mod", "changelog", "add", "--changelog", path, "--version", "1.0.0", "--category", "Features", "Another", "one")
+	require.NoError(t, err)
+	assert.Equal(t, "✓ Added entry to 1.0.0 [Features]\n", out)
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "    - Initial release\n    - Another one\n")
+}
+
+func TestMODChangelogAddDuplicateEntry(t *testing.T) {
+	s := newSandbox(t)
+	path := filepath.Join(s.root, "changelog.txt")
+
+	_, err := runCLI(t, "mod", "changelog", "add", "--changelog", path, "--category", "Features", "Same")
+	require.NoError(t, err)
+	_, err = runCLI(t, "mod", "changelog", "add", "--changelog", path, "--category", "Features", "Same")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "duplicate entry: Same")
+}
+
+func TestMODChangelogAddRequiresCategory(t *testing.T) {
+	newSandbox(t)
+	_, err := runCLI(t, "mod", "changelog", "add", "Entry")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "category")
+}
+
+func TestMODChangelogRelease(t *testing.T) {
+	s := newSandbox(t)
+	path := filepath.Join(s.root, "changelog.txt")
+	_, err := runCLI(t, "mod", "changelog", "add", "--changelog", path, "--category", "Features", "New", "thing")
+	require.NoError(t, err)
+
+	out, err := runCLI(t, "mod", "changelog", "release", "--changelog", path, "--version", "1.2.0", "--date", "2026-07-10")
+	require.NoError(t, err)
+	assert.Equal(t, "✓ Converted Unreleased to 1.2.0 (2026-07-10)\n", out)
+
+	data, err := os.ReadFile(path)
+	require.NoError(t, err)
+	assert.Contains(t, string(data), "Version: 1.2.0\nDate: 2026-07-10\n")
+}
+
+func TestMODChangelogReleaseVersionFromInfoJSON(t *testing.T) {
+	s := newSandbox(t)
+	path := filepath.Join(s.root, "changelog.txt")
+	infoPath := filepath.Join(s.root, "info.json")
+	_, err := runCLI(t, "mod", "changelog", "add", "--changelog", path, "--category", "Features", "New", "thing")
+	require.NoError(t, err)
+	info := `{"name": "m", "version": "3.4.5", "title": "m", "author": "a", "factorio_version": "2.0"}`
+	require.NoError(t, os.WriteFile(infoPath, []byte(info), 0o644))
+
+	out, err := runCLI(t, "mod", "changelog", "release", "--changelog", path, "--info-json", infoPath, "--date", "2026-07-10")
+	require.NoError(t, err)
+	assert.Equal(t, "✓ Converted Unreleased to 3.4.5 (2026-07-10)\n", out)
+}
+
+func TestMODChangelogReleaseWithoutUnreleased(t *testing.T) {
+	newSandbox(t)
+	_, err := runCLI(t, "mod", "changelog", "release", "--changelog", changelogFixture("basic.txt"), "--version", "9.9.9")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "first section is not Unreleased")
+}

--- a/internal/cli/stubs.go
+++ b/internal/cli/stubs.go
@@ -60,11 +60,7 @@ func newMODCommand(c *cli) *cobra.Command {
 		mod.AddCommand(&cobra.Command{Use: use, Short: "MOD " + use, RunE: notImplemented})
 	}
 
-	changelog := &cobra.Command{Use: "changelog", Short: "Manage MOD changelogs"}
-	for _, use := range []string{"add", "check", "extract", "release"} {
-		changelog.AddCommand(&cobra.Command{Use: use, Short: "Changelog " + use, RunE: notImplemented})
-	}
-	mod.AddCommand(changelog)
+	mod.AddCommand(newMODChangelogCommand(c))
 
 	image := &cobra.Command{Use: "image", Short: "Manage MOD images"}
 	for _, use := range []string{"list", "add", "edit"} {


### PR DESCRIPTION
## Summary
Implement `mod changelog add` / `check` / `extract` / `release` by wiring the existing `internal/changelog` package to the CLI (Phase 10f, MOD Author Tools).

## Changes
- `add` — appends an entry (variadic words joined with spaces) to a category, creating the Unreleased section on demand; `--version` targets an existing section
- `check` — validates parseability, Unreleased-first position, and descending version order; `--release` additionally forbids Unreleased and cross-checks the first version against info.json
- `extract` — renders one section as text or `--json` (pretty, category order preserved by hand-assembling the JSON object since `encoding/json` maps sort keys)
- `release` — stamps the Unreleased section with a version (from `--version` or info.json) and date (`--date` or today UTC)
- Export `changelog.FormatSection`; remove the stubs; check off the roadmap item

## Test Plan
- `mise run default` passes; CLI tests cover the three e2e cases plus add/release round-trips and error paths
- Verified with the real binary: ran the same operation sequence (3 adds → release → add → extract → check) through both Go and Ruby CLIs — resulting changelog.txt, `extract --json` output, and `check` output are byte-identical
