### PR TITLE
:sparkles: Implement mod upload/edit/image commands (Phase 10g)

### DIFF
--- a/doc/go-migration-roadmap.md
+++ b/doc/go-migration-roadmap.md
@@ -447,7 +447,7 @@ than one pass over the full list below.
       `internal/app` gained `Downloader()`/`MODDownloadAPI()` (Client → Retry,
       no cache decorator, matching Ruby) and `FACTORIX_MODS_PORTAL_URL` as an
       optional endpoint override (mirrors/tests)
-- [ ] `mod upload` / `mod edit` / `mod image list/add/edit`
+- [x] `mod upload` / `mod edit` / `mod image list/add/edit`
 - [ ] `download` — download the game itself
 
 #### Cache

--- a/internal/api/license.go
+++ b/internal/api/license.go
@@ -1,0 +1,33 @@
+package api
+
+import (
+	"regexp"
+	"slices"
+)
+
+// licenseIdentifiers are the standard license identifiers accepted by the
+// portal's edit_details API.
+//
+// See https://wiki.factorio.com/Mod_details_API#License
+var licenseIdentifiers = []string{
+	"default_mit",
+	"default_gnugplv3",
+	"default_gnulgplv3",
+	"default_mozilla2",
+	"default_apache2",
+	"default_unlicense",
+}
+
+// Custom license identifiers are "custom_" + 24 lowercase hex chars.
+var customLicensePattern = regexp.MustCompile(`\Acustom_[0-9a-f]{24}\z`)
+
+// LicenseIdentifiers returns the standard license identifiers.
+func LicenseIdentifiers() []string {
+	return slices.Clone(licenseIdentifiers)
+}
+
+// ValidLicenseIdentifier reports whether the value is a standard or custom
+// license identifier.
+func ValidLicenseIdentifier(value string) bool {
+	return slices.Contains(licenseIdentifiers, value) || customLicensePattern.MatchString(value)
+}

--- a/internal/api/license_test.go
+++ b/internal/api/license_test.go
@@ -1,0 +1,20 @@
+package api
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+)
+
+func TestValidLicenseIdentifier(t *testing.T) {
+	for _, id := range LicenseIdentifiers() {
+		assert.True(t, ValidLicenseIdentifier(id), id)
+	}
+	assert.True(t, ValidLicenseIdentifier("custom_0123456789abcdef01234567"))
+
+	assert.False(t, ValidLicenseIdentifier("MIT"))
+	assert.False(t, ValidLicenseIdentifier("default_wtfpl"))
+	assert.False(t, ValidLicenseIdentifier("custom_0123456789ABCDEF01234567")) // uppercase hex
+	assert.False(t, ValidLicenseIdentifier("custom_0123"))                     // too short
+	assert.False(t, ValidLicenseIdentifier("custom_0123456789abcdef012345678"))
+}

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -3,6 +3,7 @@
 package app
 
 import (
+	"context"
 	"fmt"
 	"io"
 	"log/slog"
@@ -47,6 +48,12 @@ type App struct {
 	// commands that never actually download never require
 	// FACTORIO_USERNAME/FACTORIO_TOKEN or player-data.json.
 	MODDownloadAPI func() (*api.MODDownloadAPI, error)
+
+	// ManagementAPI returns the client for API-key operations (upload,
+	// edit, images), wired as Client → Retry with no cache. The API key
+	// resolves lazily on first use, so commands only require
+	// FACTORIO_API_KEY when a management operation actually runs.
+	ManagementAPI func() (*api.MODManagementAPI, error)
 }
 
 // Options select the configuration and log level.
@@ -98,6 +105,7 @@ func New(opts Options) (*App, error) {
 	a.PortalAPI = sync.OnceValues(a.buildPortalAPI)
 	a.Downloader = sync.OnceValues(a.buildDownloader)
 	a.MODDownloadAPI = sync.OnceValues(a.buildMODDownloadAPI)
+	a.ManagementAPI = sync.OnceValues(a.buildManagementAPI)
 	return a, nil
 }
 
@@ -212,6 +220,36 @@ func (a *App) buildMODDownloadAPI() (*api.MODDownloadAPI, error) {
 	})
 	modDownload.BaseURL = modsPortalBaseURL()
 	return modDownload, nil
+}
+
+func (a *App) buildManagementAPI() (*api.MODManagementAPI, error) {
+	transport := httpx.NewRetryTransport(
+		httpx.NewBaseTransport(
+			time.Duration(a.Config.HTTP.ConnectTimeout)*time.Second,
+			time.Duration(a.Config.HTTP.ReadTimeout)*time.Second,
+		),
+		httpx.RetryOptions{Logger: a.Logger},
+	)
+	client := httpx.NewClient(httpx.Options{
+		Transport:    transport,
+		MaskedParams: maskedQueryParams,
+		Logger:       a.Logger,
+	})
+	management := api.NewMODManagementAPI(client, transfer.NewUploader(client, a.Logger), api.LoadAPICredential, a.Logger)
+	management.BaseURL = modsPortalBaseURL()
+	// Invalidate the portal cache after any changing operation, replacing
+	// Ruby's dry-events subscription.
+	management.OnMODChanged = func(ctx context.Context, name string) {
+		portal, err := a.PortalAPI()
+		if err != nil {
+			a.Logger.Warn("Skipping MOD cache invalidation", "mod", name, "error", err)
+			return
+		}
+		if err := portal.InvalidateMODCache(ctx, name); err != nil {
+			a.Logger.Warn("Failed to invalidate MOD cache", "mod", name, "error", err)
+		}
+	}
+	return management, nil
 }
 
 // RequireGameStopped fails when Factorio is running; commands that modify

--- a/internal/cli/mod_edit.go
+++ b/internal/cli/mod_edit.go
@@ -1,0 +1,70 @@
+package cli
+
+import (
+	"errors"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/sakuro/factorix/internal/api"
+)
+
+func newMODEditCommand(c *cli) *cobra.Command {
+	var metadata api.EditMetadata
+	var deprecated bool
+
+	cmd := &cobra.Command{
+		Use:   "edit <mod-name>",
+		Short: "Edit MOD metadata on Factorio MOD Portal",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			p := c.printer(cmd)
+			if metadata.License != "" && !api.ValidLicenseIdentifier(metadata.License) {
+				p.Error("Invalid license identifier: " + metadata.License)
+				p.Say("Valid identifiers: " + strings.Join(api.LicenseIdentifiers(), ", "))
+				p.Say("Custom licenses: custom_<24 hex chars> (e.g., custom_0123456789abcdef01234567)")
+				return errors.New("Invalid license identifier")
+			}
+
+			if cmd.Flags().Changed("deprecated") {
+				metadata.Deprecated = &deprecated
+			}
+			if isEmptyEditMetadata(metadata) {
+				p.Error("At least one metadata option must be provided")
+				p.Say("Available options: --description, --summary, --title, --category, --tags, --license, --homepage, --source-url, --faq, --deprecated")
+				return errors.New("No metadata options provided")
+			}
+
+			application, err := c.App()
+			if err != nil {
+				return err
+			}
+			management, err := application.ManagementAPI()
+			if err != nil {
+				return err
+			}
+			if err := management.EditDetails(cmd.Context(), args[0], metadata); err != nil {
+				return err
+			}
+			p.Success("Metadata updated successfully!")
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&metadata.Description, "description", "", "Markdown description")
+	cmd.Flags().StringVar(&metadata.Summary, "summary", "", "Brief description")
+	cmd.Flags().StringVar(&metadata.Title, "title", "", "MOD title")
+	cmd.Flags().StringVar(&metadata.Category, "category", "", "MOD category")
+	cmd.Flags().StringSliceVar(&metadata.Tags, "tags", nil, "Array of tags")
+	cmd.Flags().StringVar(&metadata.License, "license", "", "License identifier")
+	cmd.Flags().StringVar(&metadata.Homepage, "homepage", "", "Homepage URL")
+	cmd.Flags().StringVar(&metadata.SourceURL, "source-url", "", "Repository URL")
+	cmd.Flags().StringVar(&metadata.FAQ, "faq", "", "FAQ text")
+	cmd.Flags().BoolVar(&deprecated, "deprecated", false, "Deprecation flag")
+	return cmd
+}
+
+func isEmptyEditMetadata(m api.EditMetadata) bool {
+	return m.Description == "" && m.Summary == "" && m.Title == "" && m.Category == "" &&
+		len(m.Tags) == 0 && m.License == "" && m.Homepage == "" && m.SourceURL == "" &&
+		m.FAQ == "" && m.Deprecated == nil
+}

--- a/internal/cli/mod_image.go
+++ b/internal/cli/mod_image.go
@@ -1,0 +1,163 @@
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"fmt"
+	"os"
+
+	"github.com/spf13/cobra"
+
+	"github.com/sakuro/factorix/internal/api"
+)
+
+func newMODImageCommand(c *cli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "image",
+		Short: "Manage MOD images",
+	}
+	cmd.AddCommand(
+		newMODImageListCommand(c),
+		newMODImageAddCommand(c),
+		newMODImageEditCommand(c),
+	)
+	return cmd
+}
+
+func newMODImageListCommand(c *cli) *cobra.Command {
+	var jsonOutput bool
+
+	cmd := &cobra.Command{
+		Use:   "list <mod-name>",
+		Short: "List images for a MOD",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			application, err := c.App()
+			if err != nil {
+				return err
+			}
+			portal, err := application.PortalAPI()
+			if err != nil {
+				return err
+			}
+			info, err := portal.GetMODFull(cmd.Context(), args[0])
+			if err != nil {
+				return err
+			}
+
+			p := c.printer(cmd)
+			if jsonOutput {
+				return outputImageJSON(p, info.Images)
+			}
+			outputImageTable(p, info.Images)
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSON format")
+	return cmd
+}
+
+func outputImageTable(p *printer, images []api.Image) {
+	if len(images) == 0 {
+		p.Info("No images found")
+		return
+	}
+
+	idWidth, thumbWidth := len("ID"), len("THUMBNAIL")
+	for _, image := range images {
+		idWidth = max(idWidth, len(image.ID))
+		thumbWidth = max(thumbWidth, len(image.Thumbnail))
+	}
+	p.Printf("%-*s  %-*s  %s\n", idWidth, "ID", thumbWidth, "THUMBNAIL", "URL")
+	for _, image := range images {
+		p.Printf("%-*s  %-*s  %s\n", idWidth, image.ID, thumbWidth, image.Thumbnail, image.URL)
+	}
+}
+
+func outputImageJSON(p *printer, images []api.Image) error {
+	type imageEntry struct {
+		ID        string `json:"id"`
+		Thumbnail string `json:"thumbnail"`
+		URL       string `json:"url"`
+	}
+	entries := make([]imageEntry, 0, len(images))
+	for _, image := range images {
+		entries = append(entries, imageEntry{ID: image.ID, Thumbnail: image.Thumbnail, URL: image.URL})
+	}
+	data, err := json.MarshalIndent(entries, "", "  ")
+	if err != nil {
+		return err
+	}
+	p.Println(string(data))
+	return nil
+}
+
+func newMODImageAddCommand(c *cli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "add <mod-name> <image-file>",
+		Short: "Add an image to a MOD",
+		Args:  cobra.ExactArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			name, imageFile := args[0], args[1]
+			if _, err := os.Stat(imageFile); errors.Is(err, os.ErrNotExist) {
+				return fmt.Errorf("Image file not found: %s", imageFile)
+			} else if err != nil {
+				return err
+			}
+
+			application, err := c.App()
+			if err != nil {
+				return err
+			}
+			management, err := application.ManagementAPI()
+			if err != nil {
+				return err
+			}
+			uploadURL, err := management.InitImageUpload(cmd.Context(), name)
+			if err != nil {
+				return err
+			}
+			image, err := management.FinishImageUpload(cmd.Context(), name, uploadURL, imageFile)
+			if err != nil {
+				return err
+			}
+
+			p := c.printer(cmd)
+			p.Success("Image added successfully!")
+			p.Say("  ID: " + image.ID)
+			p.Say("  Thumbnail: " + image.Thumbnail)
+			p.Say("  Full URL: " + image.URL)
+			return nil
+		},
+	}
+	return cmd
+}
+
+func newMODImageEditCommand(c *cli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "edit <mod-name> <image-id>...",
+		Short: "Edit MOD's image list (reorder/remove images)",
+		Args:  cobra.MinimumNArgs(2),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			name, imageIDs := args[0], args[1:]
+
+			application, err := c.App()
+			if err != nil {
+				return err
+			}
+			management, err := application.ManagementAPI()
+			if err != nil {
+				return err
+			}
+			if err := management.EditImages(cmd.Context(), name, imageIDs); err != nil {
+				return err
+			}
+
+			p := c.printer(cmd)
+			p.Success("Image list updated successfully!")
+			p.Info(fmt.Sprintf("Total images: %d", len(imageIDs)))
+			return nil
+		},
+	}
+	return cmd
+}

--- a/internal/cli/mod_upload.go
+++ b/internal/cli/mod_upload.go
@@ -1,0 +1,127 @@
+package cli
+
+import (
+	"context"
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/sakuro/factorix/internal/api"
+	"github.com/sakuro/factorix/internal/app"
+	"github.com/sakuro/factorix/internal/mod"
+)
+
+func newMODUploadCommand(c *cli) *cobra.Command {
+	var description, category, license, sourceURL string
+
+	cmd := &cobra.Command{
+		Use:   "upload <file>",
+		Short: "Upload MOD to Factorio MOD Portal (handles both new and update)",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			file := args[0]
+			if err := validateUploadFile(file); err != nil {
+				return err
+			}
+			info, err := mod.InfoJSONFromZIP(file)
+			if err != nil {
+				return err
+			}
+
+			application, err := c.App()
+			if err != nil {
+				return err
+			}
+			metadata := map[string]string{}
+			for key, value := range map[string]string{
+				"description": description,
+				"category":    category,
+				"license":     license,
+				"source_url":  sourceURL,
+			} {
+				if value != "" {
+					metadata[key] = value
+				}
+			}
+
+			if err := uploadMOD(cmd.Context(), application, info.Name, file, metadata); err != nil {
+				return err
+			}
+			c.printer(cmd).Success("Upload completed successfully!")
+			return nil
+		},
+	}
+	cmd.Flags().StringVar(&description, "description", "", "Markdown description")
+	cmd.Flags().StringVar(&category, "category", "", "MOD category")
+	cmd.Flags().StringVar(&license, "license", "", "License identifier")
+	cmd.Flags().StringVar(&sourceURL, "source-url", "", "Repository URL")
+	return cmd
+}
+
+func validateUploadFile(file string) error {
+	stat, err := os.Stat(file)
+	if err != nil {
+		if errors.Is(err, os.ErrNotExist) {
+			return fmt.Errorf("File not found: %s", file)
+		}
+		return err
+	}
+	if stat.IsDir() {
+		return fmt.Errorf("Not a file: %s", file)
+	}
+	if !strings.EqualFold(filepath.Ext(file), ".zip") {
+		return fmt.Errorf("File must be a .zip file")
+	}
+	return nil
+}
+
+// uploadMOD mirrors Ruby's Portal#upload_mod: an existing MOD gets a
+// release upload followed by a separate metadata edit; a new MOD is
+// published with the metadata included in the upload itself.
+func uploadMOD(ctx context.Context, application *app.App, name, file string, metadata map[string]string) error {
+	portal, err := application.PortalAPI()
+	if err != nil {
+		return err
+	}
+	management, err := application.ManagementAPI()
+	if err != nil {
+		return err
+	}
+
+	exists := true
+	if _, err := portal.GetMOD(ctx, name); err != nil {
+		if !errors.Is(err, api.ErrMODNotOnPortal) {
+			return err
+		}
+		exists = false
+	}
+
+	if !exists {
+		uploadURL, err := management.InitPublish(ctx, name)
+		if err != nil {
+			return err
+		}
+		return management.FinishUpload(ctx, name, uploadURL, file, metadata)
+	}
+
+	uploadURL, err := management.InitUpload(ctx, name)
+	if err != nil {
+		return err
+	}
+	if err := management.FinishUpload(ctx, name, uploadURL, file, nil); err != nil {
+		return err
+	}
+	if len(metadata) == 0 {
+		return nil
+	}
+	return management.EditDetails(ctx, name, api.EditMetadata{
+		Description: metadata["description"],
+		Category:    metadata["category"],
+		License:     metadata["license"],
+		SourceURL:   metadata["source_url"],
+	})
+}

--- a/internal/cli/mod_upload_edit_image_test.go
+++ b/internal/cli/mod_upload_edit_image_test.go
@@ -1,0 +1,113 @@
+package cli
+
+import (
+	"bytes"
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sakuro/factorix/internal/api"
+)
+
+func TestMODUploadFileValidation(t *testing.T) {
+	s := newSandbox(t)
+
+	_, err := runCLI(t, "mod", "upload", filepath.Join(s.root, "missing.zip"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "File not found: ")
+
+	dir := filepath.Join(s.root, "a-directory.zip")
+	require.NoError(t, os.Mkdir(dir, 0o755))
+	_, err = runCLI(t, "mod", "upload", dir)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Not a file: ")
+
+	notZip := filepath.Join(s.root, "mod.tar")
+	require.NoError(t, os.WriteFile(notZip, []byte("x"), 0o644))
+	_, err = runCLI(t, "mod", "upload", notZip)
+	require.Error(t, err)
+	assert.Equal(t, "File must be a .zip file", err.Error())
+}
+
+func TestMODEditRejectsInvalidLicense(t *testing.T) {
+	newSandbox(t)
+	out, err := runCLI(t, "mod", "edit", "some-mod", "--license", "MIT")
+	require.Error(t, err)
+	assert.Equal(t, "Invalid license identifier", err.Error())
+	assert.Contains(t, out, "✗ Invalid license identifier: MIT\n")
+	assert.Contains(t, out, "Valid identifiers: default_mit, ")
+	assert.Contains(t, out, "Custom licenses: custom_<24 hex chars>")
+}
+
+func TestMODEditRequiresMetadata(t *testing.T) {
+	newSandbox(t)
+	out, err := runCLI(t, "mod", "edit", "some-mod")
+	require.Error(t, err)
+	assert.Equal(t, "No metadata options provided", err.Error())
+	assert.Contains(t, out, "✗ At least one metadata option must be provided\n")
+	assert.Contains(t, out, "Available options: --description, --summary, --title, --category, --tags, --license, --homepage, --source-url, --faq, --deprecated\n")
+}
+
+func TestMODImageAddMissingFile(t *testing.T) {
+	s := newSandbox(t)
+	_, err := runCLI(t, "mod", "image", "add", "some-mod", filepath.Join(s.root, "missing.png"))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Image file not found: ")
+}
+
+func sampleImages() []api.Image {
+	return []api.Image{
+		{ID: "abc123", Thumbnail: "https://assets.example/thumb/abc123.png", URL: "https://assets.example/full/abc123.png"},
+		{ID: "d4", Thumbnail: "https://a.example/t.png", URL: "https://a.example/f.png"},
+	}
+}
+
+func TestOutputImageTable(t *testing.T) {
+	var buf bytes.Buffer
+	p := &printer{out: &buf}
+	outputImageTable(p, sampleImages())
+
+	out := buf.String()
+	assert.Equal(t, "ID      THUMBNAIL                                URL\n"+
+		"abc123  https://assets.example/thumb/abc123.png  https://assets.example/full/abc123.png\n"+
+		"d4      https://a.example/t.png                  https://a.example/f.png\n", out)
+}
+
+func TestOutputImageTableEmpty(t *testing.T) {
+	t.Setenv("NO_COLOR", "1")
+	var buf bytes.Buffer
+	p := &printer{out: &buf}
+	outputImageTable(p, nil)
+	assert.Equal(t, "ℹ No images found\n", buf.String())
+}
+
+func TestOutputImageJSON(t *testing.T) {
+	var buf bytes.Buffer
+	p := &printer{out: &buf}
+	require.NoError(t, outputImageJSON(p, sampleImages()[1:]))
+	assert.Equal(t, `[
+  {
+    "id": "d4",
+    "thumbnail": "https://a.example/t.png",
+    "url": "https://a.example/f.png"
+  }
+]
+`, buf.String())
+}
+
+func TestOutputImageJSONEmpty(t *testing.T) {
+	var buf bytes.Buffer
+	p := &printer{out: &buf}
+	require.NoError(t, outputImageJSON(p, nil))
+	assert.Equal(t, "[]\n", buf.String())
+}
+
+func TestIsEmptyEditMetadata(t *testing.T) {
+	assert.True(t, isEmptyEditMetadata(api.EditMetadata{}))
+	assert.False(t, isEmptyEditMetadata(api.EditMetadata{Title: "t"}))
+	f := false
+	assert.False(t, isEmptyEditMetadata(api.EditMetadata{Deprecated: &f}))
+}

--- a/internal/cli/stubs.go
+++ b/internal/cli/stubs.go
@@ -56,17 +56,14 @@ func newMODCommand(c *cli) *cobra.Command {
 		newMODUninstallCommand(c),
 		newMODUpdateCommand(c),
 	)
-	for _, use := range []string{"upload", "edit", "sync"} {
-		mod.AddCommand(&cobra.Command{Use: use, Short: "MOD " + use, RunE: notImplemented})
-	}
+	mod.AddCommand(&cobra.Command{Use: "sync", Short: "MOD sync", RunE: notImplemented})
 
-	mod.AddCommand(newMODChangelogCommand(c))
-
-	image := &cobra.Command{Use: "image", Short: "Manage MOD images"}
-	for _, use := range []string{"list", "add", "edit"} {
-		image.AddCommand(&cobra.Command{Use: use, Short: "Image " + use, RunE: notImplemented})
-	}
-	mod.AddCommand(image)
+	mod.AddCommand(
+		newMODUploadCommand(c),
+		newMODEditCommand(c),
+		newMODChangelogCommand(c),
+		newMODImageCommand(c),
+	)
 
 	return mod
 }


### PR DESCRIPTION
## Summary
Implement `mod upload`, `mod edit`, and `mod image list/add/edit` (Phase 10g), completing the MOD Author Tools group.

## Changes
- `mod upload <file>` — validates the zip, reads the MOD name from info.json, then mirrors Ruby's `Portal#upload_mod`: existing MODs get `init_upload` + `finish_upload` followed by a separate `edit_details` for metadata; new MODs get `init_publish` with metadata included in the upload
- `mod edit <mod-name>` — local license-identifier validation (ported as `api.LicenseIdentifiers` / `ValidLicenseIdentifier` with the `custom_<24 hex>` pattern) and a required-metadata check, both with Ruby's exact messages; `--deprecated` uses Changed() so `--deprecated=false` counts as provided
- `mod image list` — gallery as table or `--json`; `add`/`edit` wire `InitImageUpload`/`FinishImageUpload`/`EditImages`
- App gains a memoized `ManagementAPI` (Client → Retry, no cache); its `OnMODChanged` callback invalidates the portal cache, replacing Ruby's dry-events subscription. `FACTORIO_API_KEY` resolves lazily on first management call

## Test Plan
- `mise run default` passes
- Live-verified `mod image list` (table and JSON) is byte-identical with the Ruby CLI against the real portal (FNEI, 5 images; also the empty case)
- Mutating paths verified up to credential resolution: without `FACTORIO_API_KEY`, upload (both new and existing MOD branches), edit, and image edit fail cleanly before anything reaches the portal
