### PR TITLE
:sparkles: Implement cache stat/evict commands (Phase 10i)

### DIFF
--- a/doc/go-migration-roadmap.md
+++ b/doc/go-migration-roadmap.md
@@ -451,7 +451,7 @@ than one pass over the full list below.
 - [ ] `download` — download the game itself
 
 #### Cache
-- [ ] `cache stat` / `cache evict`
+- [x] `cache stat` / `cache evict`
 
 #### Game
 - [ ] `launch` — launch Factorio (`os/exec`)

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -222,6 +222,37 @@ func (a *App) buildMODDownloadAPI() (*api.MODDownloadAPI, error) {
 	return modDownload, nil
 }
 
+// NamedCache pairs a configured cache with its name and TTL.
+type NamedCache struct {
+	Name  string
+	Cache cache.Cache
+	TTL   *int64 // seconds; nil = unlimited
+}
+
+// Caches returns the configured caches. The fixed order (download, api,
+// info_json — the Ruby config definition order) keeps output deterministic;
+// a map would randomize it per run. Instances are built fresh — cache state
+// lives on disk, so they can coexist with the ones inside the API clients.
+func (a *App) Caches() ([]NamedCache, error) {
+	named := []struct {
+		name string
+		cfg  config.CacheType
+	}{
+		{"download", a.Config.Cache.Download},
+		{"api", a.Config.Cache.API},
+		{"info_json", a.Config.Cache.InfoJSON},
+	}
+	result := make([]NamedCache, 0, len(named))
+	for _, n := range named {
+		c, err := a.newCache(n.name, n.cfg)
+		if err != nil {
+			return nil, err
+		}
+		result = append(result, NamedCache{Name: n.name, Cache: c, TTL: n.cfg.TTL})
+	}
+	return result, nil
+}
+
 func (a *App) buildManagementAPI() (*api.MODManagementAPI, error) {
 	transport := httpx.NewRetryTransport(
 		httpx.NewBaseTransport(

--- a/internal/cli/cache.go
+++ b/internal/cli/cache.go
@@ -1,0 +1,363 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/json"
+	"fmt"
+	"regexp"
+	"slices"
+	"strconv"
+	"strings"
+	"time"
+
+	"github.com/spf13/cobra"
+
+	"github.com/sakuro/factorix/internal/app"
+	"github.com/sakuro/factorix/internal/cache"
+)
+
+func newCacheCommand(c *cli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "cache",
+		Short: "Manage caches",
+	}
+	cmd.AddCommand(newCacheStatCommand(c), newCacheEvictCommand(c))
+	return cmd
+}
+
+func newCacheStatCommand(c *cli) *cobra.Command {
+	var jsonOutput bool
+
+	cmd := &cobra.Command{
+		Use:   "stat",
+		Short: "Display cache statistics",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			application, err := c.App()
+			if err != nil {
+				return err
+			}
+			caches, err := application.Caches()
+			if err != nil {
+				return err
+			}
+
+			stats := make([]namedCacheStats, 0, len(caches))
+			for _, named := range caches {
+				entries, err := named.Cache.Entries(cmd.Context())
+				if err != nil {
+					return err
+				}
+				stats = append(stats, namedCacheStats{
+					name:  named.Name,
+					stats: collectCacheStats(named.TTL, entries, named.Cache.Info()),
+				})
+			}
+
+			p := c.printer(cmd)
+			if jsonOutput {
+				return outputCacheStatsJSON(p, stats)
+			}
+			outputCacheStatsText(p, stats)
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSON format")
+	return cmd
+}
+
+// cacheStats mirrors the shape of Ruby's stat JSON; struct order fixes the
+// key order.
+type cacheStats struct {
+	TTL     *int64          `json:"ttl"`
+	Entries cacheEntryStats `json:"entries"`
+	Size    cacheSizeStats  `json:"size"`
+	Age     cacheAgeStats   `json:"age"`
+	Backend backendInfoJSON `json:"backend_info"`
+}
+
+type namedCacheStats struct {
+	name  string
+	stats cacheStats
+}
+
+type cacheEntryStats struct {
+	Total   int `json:"total"`
+	Valid   int `json:"valid"`
+	Expired int `json:"expired"`
+}
+
+type cacheSizeStats struct {
+	Total int64 `json:"total"`
+	Avg   int64 `json:"avg"`
+	Min   int64 `json:"min"`
+	Max   int64 `json:"max"`
+}
+
+// Ages are seconds; nil when the cache is empty.
+type cacheAgeStats struct {
+	Oldest *float64 `json:"oldest"`
+	Newest *float64 `json:"newest"`
+	Avg    *float64 `json:"avg"`
+}
+
+type backendInfoJSON struct {
+	Type                 string `json:"type"`
+	Directory            string `json:"directory"`
+	MaxFileSize          *int64 `json:"max_file_size"`
+	CompressionThreshold *int64 `json:"compression_threshold"`
+	StaleLocks           int    `json:"stale_locks"`
+}
+
+func collectCacheStats(ttl *int64, entries []cache.Entry, info cache.BackendInfo) cacheStats {
+	stats := cacheStats{
+		TTL: ttl,
+		Backend: backendInfoJSON{
+			Type:                 info.Type,
+			Directory:            info.Directory,
+			MaxFileSize:          info.MaxFileSize,
+			CompressionThreshold: info.CompressionThreshold,
+			StaleLocks:           info.StaleLocks,
+		},
+	}
+
+	stats.Entries.Total = len(entries)
+	for _, e := range entries {
+		if !e.Expired {
+			stats.Entries.Valid++
+		}
+	}
+	stats.Entries.Expired = stats.Entries.Total - stats.Entries.Valid
+
+	if len(entries) == 0 {
+		return stats
+	}
+
+	var totalAge time.Duration
+	stats.Size.Min = entries[0].Size
+	oldest, newest := entries[0].Age, entries[0].Age
+	for _, e := range entries {
+		stats.Size.Total += e.Size
+		stats.Size.Min = min(stats.Size.Min, e.Size)
+		stats.Size.Max = max(stats.Size.Max, e.Size)
+		totalAge += e.Age
+		oldest = max(oldest, e.Age)
+		newest = min(newest, e.Age)
+	}
+	stats.Size.Avg = stats.Size.Total / int64(len(entries))
+
+	oldestSec, newestSec := oldest.Seconds(), newest.Seconds()
+	avgSec := (totalAge / time.Duration(len(entries))).Seconds()
+	stats.Age = cacheAgeStats{Oldest: &oldestSec, Newest: &newestSec, Avg: &avgSec}
+	return stats
+}
+
+// outputCacheStatsJSON renders the stats as one JSON object whose keys keep
+// the canonical cache order (assembled by hand — a map would sort them).
+func outputCacheStatsJSON(p *printer, stats []namedCacheStats) error {
+	var compact bytes.Buffer
+	compact.WriteString("{")
+	for i, s := range stats {
+		if i > 0 {
+			compact.WriteString(",")
+		}
+		if err := appendJSON(&compact, s.name); err != nil {
+			return err
+		}
+		compact.WriteString(":")
+		if err := appendJSON(&compact, s.stats); err != nil {
+			return err
+		}
+	}
+	compact.WriteString("}")
+
+	var pretty bytes.Buffer
+	if err := json.Indent(&pretty, compact.Bytes(), "", "  "); err != nil {
+		return err
+	}
+	p.Println(pretty.String())
+	return nil
+}
+
+func outputCacheStatsText(p *printer, stats []namedCacheStats) {
+	for i, s := range stats {
+		if i > 0 {
+			p.Println()
+		}
+		p.Println(s.name + ":")
+		outputSingleCacheStats(p, s.stats)
+	}
+}
+
+func outputSingleCacheStats(p *printer, s cacheStats) {
+	ttl := "unlimited"
+	if s.TTL != nil {
+		ttl = formatDuration(*s.TTL)
+	}
+	p.Println("  TTL:            " + ttl)
+
+	validPct := 0.0
+	if s.Entries.Total > 0 {
+		validPct = float64(s.Entries.Valid) / float64(s.Entries.Total) * 100
+	}
+	p.Printf("  Entries:        %d / %d (%.1f%% valid)\n", s.Entries.Valid, s.Entries.Total, validPct)
+
+	p.Printf("  Size:           %s (avg %s)\n", formatSize(s.Size.Total), formatSize(s.Size.Avg))
+
+	if s.Age.Oldest != nil {
+		p.Printf("  Age:            %s - %s (avg %s)\n",
+			formatDuration(int64(*s.Age.Newest)), formatDuration(int64(*s.Age.Oldest)), formatDuration(int64(*s.Age.Avg)))
+	} else {
+		p.Println("  Age:            -")
+	}
+
+	p.Println("  Backend:")
+	backendLine := func(label, value string) {
+		p.Printf("    %-20s %s\n", label+":", value)
+	}
+	backendLine("Type", s.Backend.Type)
+	backendLine("Directory", s.Backend.Directory)
+	backendLine("Max file size", formatSizeLimit(s.Backend.MaxFileSize))
+	backendLine("Compression threshold", formatSizeLimit(s.Backend.CompressionThreshold))
+	backendLine("Stale locks", strconv.Itoa(s.Backend.StaleLocks))
+}
+
+var agePattern = regexp.MustCompile(`\A(\d+)([smhd])\z`)
+
+var ageUnits = map[string]time.Duration{
+	"s": time.Second,
+	"m": time.Minute,
+	"h": time.Hour,
+	"d": 24 * time.Hour,
+}
+
+// parseAge parses an age like "30s", "5m", "2h", or "7d".
+func parseAge(age string) (time.Duration, error) {
+	m := agePattern.FindStringSubmatch(age)
+	if m == nil {
+		return 0, fmt.Errorf("Invalid age format: %s. Use format like 30s, 5m, 2h, 7d", age)
+	}
+	value, err := strconv.ParseInt(m[1], 10, 64)
+	if err != nil {
+		return 0, err
+	}
+	return time.Duration(value) * ageUnits[m[2]], nil
+}
+
+func newCacheEvictCommand(c *cli) *cobra.Command {
+	var all, expired bool
+	var olderThan string
+
+	cmd := &cobra.Command{
+		Use:   "evict [cache-name]...",
+		Short: "Evict cache entries",
+		Args:  cobra.ArbitraryArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			optionCount := 0
+			for _, set := range []bool{all, expired, olderThan != ""} {
+				if set {
+					optionCount++
+				}
+			}
+			if optionCount == 0 {
+				return fmt.Errorf("One of --all, --expired, or --older-than must be specified")
+			}
+			if optionCount > 1 {
+				return fmt.Errorf("Only one of --all, --expired, or --older-than can be specified")
+			}
+
+			var olderThanAge time.Duration
+			if olderThan != "" {
+				var err error
+				olderThanAge, err = parseAge(olderThan)
+				if err != nil {
+					return err
+				}
+			}
+
+			application, err := c.App()
+			if err != nil {
+				return err
+			}
+			caches, err := application.Caches()
+			if err != nil {
+				return err
+			}
+			targets, err := resolveEvictTargets(caches, args)
+			if err != nil {
+				return err
+			}
+
+			shouldEvict := func(e cache.Entry) bool {
+				switch {
+				case all:
+					return true
+				case expired:
+					return e.Expired
+				default:
+					return e.Age > olderThanAge
+				}
+			}
+
+			p := c.printer(cmd)
+			nameWidth := 0
+			for _, named := range targets {
+				nameWidth = max(nameWidth, len(named.Name))
+			}
+			for _, named := range targets {
+				count, size, err := evictCacheEntries(cmd, named.Cache, shouldEvict)
+				if err != nil {
+					return err
+				}
+				p.Info(fmt.Sprintf("%-*s: %3d entries removed (%s)", nameWidth, named.Name, count, formatSize(size)))
+			}
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&all, "all", false, "Remove all entries")
+	cmd.Flags().BoolVar(&expired, "expired", false, "Remove expired entries only")
+	cmd.Flags().StringVar(&olderThan, "older-than", "", "Remove entries older than AGE (e.g., 30s, 5m, 2h, 7d)")
+	return cmd
+}
+
+// resolveEvictTargets maps cache-name arguments to caches; no arguments
+// means every cache.
+func resolveEvictTargets(caches []app.NamedCache, names []string) ([]app.NamedCache, error) {
+	if len(names) == 0 {
+		return caches, nil
+	}
+	var targets []app.NamedCache
+	for _, name := range names {
+		i := slices.IndexFunc(caches, func(n app.NamedCache) bool { return n.Name == name })
+		if i < 0 {
+			valid := make([]string, len(caches))
+			for j, n := range caches {
+				valid[j] = n.Name
+			}
+			return nil, fmt.Errorf("Unknown cache: %s. Valid caches: %s", name, strings.Join(valid, ", "))
+		}
+		targets = append(targets, caches[i])
+	}
+	return targets, nil
+}
+
+func evictCacheEntries(cmd *cobra.Command, target cache.Cache, shouldEvict func(cache.Entry) bool) (count int, size int64, err error) {
+	entries, err := target.Entries(cmd.Context())
+	if err != nil {
+		return 0, 0, err
+	}
+	for _, e := range entries {
+		if !shouldEvict(e) {
+			continue
+		}
+		deleted, err := target.Delete(cmd.Context(), e.Key)
+		if err != nil {
+			return count, size, err
+		}
+		if deleted {
+			count++
+			size += e.Size
+		}
+	}
+	return count, size, nil
+}

--- a/internal/cli/cache_test.go
+++ b/internal/cli/cache_test.go
@@ -1,0 +1,185 @@
+package cli
+
+import (
+	"context"
+	"encoding/json"
+	"os"
+	"path/filepath"
+	"strings"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sakuro/factorix/internal/cache"
+)
+
+func TestFormatSize(t *testing.T) {
+	assert.Equal(t, "0 B", formatSize(0))
+	assert.Equal(t, "1023 B", formatSize(1023))
+	assert.Equal(t, "1.0 KiB", formatSize(1024))
+	assert.Equal(t, "1.5 KiB", formatSize(1536))
+	assert.Equal(t, "1.0 MiB", formatSize(1024*1024))
+	assert.Equal(t, "unlimited", formatSizeLimit(nil))
+}
+
+func TestFormatDuration(t *testing.T) {
+	assert.Equal(t, "59s", formatDuration(59))
+	assert.Equal(t, "1m", formatDuration(60))
+	assert.Equal(t, "59m", formatDuration(3599))
+	assert.Equal(t, "1h 0m", formatDuration(3600))
+	assert.Equal(t, "1h 1m", formatDuration(3661))
+	assert.Equal(t, "1d 0h", formatDuration(86400))
+	assert.Equal(t, "7d 3h", formatDuration(7*86400+3*3600))
+}
+
+func TestParseAge(t *testing.T) {
+	for input, want := range map[string]time.Duration{
+		"30s": 30 * time.Second,
+		"5m":  5 * time.Minute,
+		"2h":  2 * time.Hour,
+		"7d":  7 * 24 * time.Hour,
+	} {
+		got, err := parseAge(input)
+		require.NoError(t, err, input)
+		assert.Equal(t, want, got, input)
+	}
+
+	_, err := parseAge("7w")
+	require.Error(t, err)
+	assert.Equal(t, "Invalid age format: 7w. Use format like 30s, 5m, 2h, 7d", err.Error())
+}
+
+func TestCacheStatEmpty(t *testing.T) {
+	newSandbox(t)
+	out, err := runCLI(t, "cache", "stat")
+	require.NoError(t, err)
+
+	// Canonical cache order.
+	download := strings.Index(out, "download:\n")
+	api := strings.Index(out, "api:\n")
+	infoJSON := strings.Index(out, "info_json:\n")
+	require.GreaterOrEqual(t, download, 0)
+	assert.Greater(t, api, download)
+	assert.Greater(t, infoJSON, api)
+
+	assert.Contains(t, out, "download:\n"+
+		"  TTL:            unlimited\n"+
+		"  Entries:        0 / 0 (0.0% valid)\n"+
+		"  Size:           0 B (avg 0 B)\n"+
+		"  Age:            -\n"+
+		"  Backend:\n"+
+		"    Type:                file_system\n")
+	// The api cache has a TTL by default.
+	assert.Contains(t, out, "api:\n  TTL:            1h 0m\n")
+	assert.Contains(t, out, "    Stale locks:         0\n")
+}
+
+// statDirectories runs cache stat --json and returns each cache's backend
+// directory.
+func statDirectories(t *testing.T) map[string]string {
+	t.Helper()
+	out, err := runCLI(t, "cache", "stat", "--json")
+	require.NoError(t, err)
+
+	var stats map[string]struct {
+		Backend struct {
+			Directory string `json:"directory"`
+		} `json:"backend_info"`
+	}
+	require.NoError(t, json.Unmarshal([]byte(out), &stats))
+	dirs := map[string]string{}
+	for name, s := range stats {
+		dirs[name] = s.Backend.Directory
+	}
+	return dirs
+}
+
+func TestCacheStatJSONKeyOrder(t *testing.T) {
+	newSandbox(t)
+	out, err := runCLI(t, "cache", "stat", "--json")
+	require.NoError(t, err)
+
+	download := strings.Index(out, `"download":`)
+	api := strings.Index(out, `"api":`)
+	infoJSON := strings.Index(out, `"info_json":`)
+	require.GreaterOrEqual(t, download, 0)
+	assert.Greater(t, api, download)
+	assert.Greater(t, infoJSON, api)
+	assert.Contains(t, out, `"ttl": null`)
+	assert.Contains(t, out, `"ttl": 3600`)
+}
+
+func TestCacheEvictAll(t *testing.T) {
+	s := newSandbox(t)
+	dirs := statDirectories(t)
+	require.Contains(t, dirs, "download")
+
+	// Seed one entry in the download cache through the same backend.
+	fs, err := cache.NewFileSystem(dirs["download"], cache.FileSystemOptions{})
+	require.NoError(t, err)
+	srcPath := filepath.Join(s.root, "payload.bin")
+	require.NoError(t, os.WriteFile(srcPath, []byte("0123456789"), 0o644))
+	stored, err := fs.Store(context.Background(), "some-key", srcPath)
+	require.NoError(t, err)
+	require.True(t, stored)
+
+	out, err := runCLI(t, "cache", "evict", "--all")
+	require.NoError(t, err)
+	assert.Contains(t, out, "ℹ download :   1 entries removed (10 B)\n")
+	assert.Contains(t, out, "ℹ api      :   0 entries removed (0 B)\n")
+	assert.Contains(t, out, "ℹ info_json:   0 entries removed (0 B)\n")
+
+	entries, err := fs.Entries(context.Background())
+	require.NoError(t, err)
+	assert.Empty(t, entries)
+}
+
+func TestCacheEvictNamedCacheOnly(t *testing.T) {
+	newSandbox(t)
+	out, err := runCLI(t, "cache", "evict", "api", "--expired")
+	require.NoError(t, err)
+	assert.Contains(t, out, "api:   0 entries removed (0 B)\n")
+	assert.NotContains(t, out, "download")
+}
+
+func TestCacheEvictOptionValidation(t *testing.T) {
+	newSandbox(t)
+
+	_, err := runCLI(t, "cache", "evict")
+	require.Error(t, err)
+	assert.Equal(t, "One of --all, --expired, or --older-than must be specified", err.Error())
+
+	_, err = runCLI(t, "cache", "evict", "--all", "--expired")
+	require.Error(t, err)
+	assert.Equal(t, "Only one of --all, --expired, or --older-than can be specified", err.Error())
+
+	_, err = runCLI(t, "cache", "evict", "--older-than", "banana")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Invalid age format: banana")
+
+	_, err = runCLI(t, "cache", "evict", "bogus", "--all")
+	require.Error(t, err)
+	assert.Equal(t, "Unknown cache: bogus. Valid caches: download, api, info_json", err.Error())
+}
+
+func TestCacheEvictOlderThan(t *testing.T) {
+	s := newSandbox(t)
+	dirs := statDirectories(t)
+	fs, err := cache.NewFileSystem(dirs["download"], cache.FileSystemOptions{})
+	require.NoError(t, err)
+	srcPath := filepath.Join(s.root, "payload.bin")
+	require.NoError(t, os.WriteFile(srcPath, []byte("x"), 0o644))
+	_, err = fs.Store(context.Background(), "fresh-key", srcPath)
+	require.NoError(t, err)
+
+	// A fresh entry is not older than 1 hour.
+	out, err := runCLI(t, "cache", "evict", "download", "--older-than", "1h")
+	require.NoError(t, err)
+	assert.Contains(t, out, "download:   0 entries removed (0 B)\n")
+
+	entries, err := fs.Entries(context.Background())
+	require.NoError(t, err)
+	assert.Len(t, entries, 1)
+}

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -90,7 +90,7 @@ func NewRootCommand() (root *cobra.Command, reportError func(error)) {
 		newLaunchCommand(),
 		newManCommand(),
 		newMODCommand(c),
-		newCacheCommand(),
+		newCacheCommand(c),
 		newBlueprintCommand(c),
 		newRConCommand(),
 	)

--- a/internal/cli/formatting.go
+++ b/internal/cli/formatting.go
@@ -1,0 +1,44 @@
+package cli
+
+import "fmt"
+
+// formatSize renders a byte count with binary (IEC) prefixes, matching
+// Ruby's Formatting#format_size.
+func formatSize(size int64) string {
+	if size < 1024 {
+		return fmt.Sprintf("%d B", size)
+	}
+	units := []string{"B", "KiB", "MiB", "GiB", "TiB"}
+	value := float64(size)
+	unitIndex := 0
+	for value >= 1024 && unitIndex < len(units)-1 {
+		value /= 1024
+		unitIndex++
+	}
+	return fmt.Sprintf("%.1f %s", value, units[unitIndex])
+}
+
+// formatSizeLimit renders an optional size limit; nil means unlimited.
+func formatSizeLimit(size *int64) string {
+	if size == nil {
+		return "unlimited"
+	}
+	return formatSize(*size)
+}
+
+// formatDuration renders whole seconds in the largest suitable units,
+// matching Ruby's Formatting#format_duration.
+func formatDuration(seconds int64) string {
+	if seconds < 60 {
+		return fmt.Sprintf("%ds", seconds)
+	}
+	minutes := seconds / 60
+	if minutes < 60 {
+		return fmt.Sprintf("%dm", minutes)
+	}
+	hours := minutes / 60
+	if hours < 24 {
+		return fmt.Sprintf("%dh %dm", hours, minutes%60)
+	}
+	return fmt.Sprintf("%dd %dh", hours/24, hours%24)
+}

--- a/internal/cli/stubs.go
+++ b/internal/cli/stubs.go
@@ -67,18 +67,6 @@ func newMODCommand(c *cli) *cobra.Command {
 	return mod
 }
 
-func newCacheCommand() *cobra.Command {
-	cache := &cobra.Command{
-		Use:   "cache",
-		Short: "Manage caches",
-	}
-	cache.AddCommand(
-		&cobra.Command{Use: "stat", Short: "Show cache statistics", RunE: notImplemented},
-		&cobra.Command{Use: "evict", Short: "Clear cache entries", RunE: notImplemented},
-	)
-	return cache
-}
-
 func newRConCommand() *cobra.Command {
 	rcon := &cobra.Command{
 		Use:   "rcon",


### PR DESCRIPTION
## Summary
Implement `cache stat` and `cache evict` (Phase 10i).

## Changes
- `cache stat [--json]` — per-cache TTL, entry counts (valid/expired), size and age statistics, and backend info. `App.Caches()` exposes the configured caches in a fixed order (download, api, info_json — Ruby's config definition order) so output stays deterministic; JSON is assembled by hand to keep that key order
- `cache evict [cache-name]... (--all | --expired | --older-than AGE)` — exactly one criterion required; optionally restricted to named caches; reports per-cache removed counts and sizes with Ruby's alignment
- Port Ruby's `Formatting` helpers (IEC binary sizes, coarse `1h 0m`-style durations) as `internal/cli/formatting.go`

## Test Plan
- `mise run default` passes; tests cover formatting, age parsing, option validation, JSON key order, and evict against seeded filesystem-cache entries
- Verified with the real binary: `cache stat` output is byte-identical with the Ruby CLI against the same sandbox cache, both empty and after `mod show` populated the api cache; `evict api --all` removed the entry and stat returned to zero
