### PR TITLE
:sparkles: Implement launch command (Phase 10j)

### DIFF
--- a/doc/go-migration-roadmap.md
+++ b/doc/go-migration-roadmap.md
@@ -454,7 +454,7 @@ than one pass over the full list below.
 - [x] `cache stat` / `cache evict`
 
 #### Game
-- [ ] `launch` — launch Factorio (`os/exec`)
+- [x] `launch` — launch Factorio (`os/exec`)
 - [ ] `rcon exec` / `rcon eval` — via gorcon/rcon, using `config.rcon` settings
 
 ---

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -87,7 +87,7 @@ func NewRootCommand() (root *cobra.Command, reportError func(error)) {
 		newVersionCommand(),
 		newPathCommand(c),
 		newDownloadCommand(),
-		newLaunchCommand(),
+		newLaunchCommand(c),
 		newManCommand(),
 		newMODCommand(c),
 		newCacheCommand(c),

--- a/internal/cli/launch.go
+++ b/internal/cli/launch.go
@@ -1,0 +1,84 @@
+package cli
+
+import (
+	"slices"
+	"time"
+
+	"github.com/spf13/cobra"
+)
+
+// Game options that print and exit without daemonizing; the launch waits
+// for these instead of detaching.
+var synchronousLaunchOptions = []string{
+	"--dump-data",
+	"--dump-icon-sprites",
+	"--dump-prototype-locale",
+	"--help",
+	"--version",
+}
+
+// launchPollInterval is how often --wait polls the lock file; a variable so
+// tests can shorten it.
+var launchPollInterval = time.Second
+
+func newLaunchCommand(c *cli) *cobra.Command {
+	var wait bool
+
+	cmd := &cobra.Command{
+		Use:   "launch [-- <factorio-arg>...]",
+		Short: "Launch Factorio game",
+		Args:  cobra.ArbitraryArgs,
+		RunE: func(cmd *cobra.Command, args []string) error {
+			application, err := c.App()
+			if err != nil {
+				return err
+			}
+			if err := application.RequireGameStopped(); err != nil {
+				return err
+			}
+
+			async := !slices.ContainsFunc(args, func(arg string) bool {
+				return slices.Contains(synchronousLaunchOptions, arg)
+			})
+			application.Logger.Info("Launching Factorio", "args", args)
+			if err := application.Runtime.Launch(args, async); err != nil {
+				return err
+			}
+			application.Logger.Info("Factorio launched successfully", "async", async)
+
+			if !async || !wait {
+				return nil
+			}
+
+			// Factorio double-forks, so the started process cannot be
+			// waited on; poll the lock file instead: first until the game
+			// has created it, then until it disappears.
+			application.Logger.Debug("Waiting for game to start")
+			if err := waitForRunningState(application.Runtime.IsRunning, true); err != nil {
+				return err
+			}
+			application.Logger.Debug("Game started, waiting for termination")
+			if err := waitForRunningState(application.Runtime.IsRunning, false); err != nil {
+				return err
+			}
+			application.Logger.Info("Game terminated")
+			return nil
+		},
+	}
+	cmd.Flags().BoolVarP(&wait, "wait", "w", false, "Wait for the game to finish")
+	return cmd
+}
+
+// waitForRunningState polls isRunning until it reports want.
+func waitForRunningState(isRunning func() (bool, error), want bool) error {
+	for {
+		running, err := isRunning()
+		if err != nil {
+			return err
+		}
+		if running == want {
+			return nil
+		}
+		time.Sleep(launchPollInterval)
+	}
+}

--- a/internal/cli/launch_test.go
+++ b/internal/cli/launch_test.go
@@ -1,0 +1,89 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+	"time"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// writeFakeFactorio installs a shell script at the sandbox's
+// executable_path that appends its arguments to args.txt and then runs the
+// given extra script body.
+func writeFakeFactorio(t *testing.T, s *sandbox, body string) string {
+	t.Helper()
+	exePath := filepath.Join(s.root, "factorio", "bin", "x64", "factorio")
+	require.NoError(t, os.MkdirAll(filepath.Dir(exePath), 0o755))
+	script := "#!/bin/sh\necho \"$@\" >> \"" + filepath.Join(s.root, "args.txt") + "\"\n" + body
+	require.NoError(t, os.WriteFile(exePath, []byte(script), 0o755))
+	return filepath.Join(s.root, "args.txt")
+}
+
+func waitForFile(t *testing.T, path string) {
+	t.Helper()
+	deadline := time.Now().Add(5 * time.Second)
+	for time.Now().Before(deadline) {
+		if _, err := os.Stat(path); err == nil {
+			return
+		}
+		time.Sleep(10 * time.Millisecond)
+	}
+	t.Fatalf("file %s did not appear", path)
+}
+
+func TestLaunchSynchronousOption(t *testing.T) {
+	s := newSandbox(t)
+	argsPath := writeFakeFactorio(t, s, "")
+
+	out, err := runCLI(t, "launch", "--", "--version")
+	require.NoError(t, err)
+	assert.Empty(t, out)
+
+	// --version is synchronous, so the game has already run.
+	data, err := os.ReadFile(argsPath)
+	require.NoError(t, err)
+	assert.Equal(t, "--version\n", string(data))
+}
+
+func TestLaunchAsync(t *testing.T) {
+	s := newSandbox(t)
+	argsPath := writeFakeFactorio(t, s, "")
+
+	out, err := runCLI(t, "launch", "--", "--benchmark", "save.zip")
+	require.NoError(t, err)
+	assert.Empty(t, out)
+
+	// Detached: the invocation returns before the game does, so poll.
+	waitForFile(t, argsPath)
+	data, err := os.ReadFile(argsPath)
+	require.NoError(t, err)
+	assert.Equal(t, "--benchmark save.zip\n", string(data))
+}
+
+func TestLaunchWait(t *testing.T) {
+	s := newSandbox(t)
+	lockPath := filepath.Join(s.root, "factorio", ".lock")
+	// The fake game holds the lock briefly, like a daemonized Factorio.
+	writeFakeFactorio(t, s, "touch \""+lockPath+"\"\nsleep 0.2\nrm \""+lockPath+"\"\n")
+
+	original := launchPollInterval
+	launchPollInterval = 10 * time.Millisecond
+	t.Cleanup(func() { launchPollInterval = original })
+
+	_, err := runCLI(t, "launch", "--wait")
+	require.NoError(t, err)
+	assert.NoFileExists(t, lockPath, "wait must return only after the lock is gone")
+}
+
+func TestLaunchRequiresGameStopped(t *testing.T) {
+	s := newSandbox(t)
+	writeFakeFactorio(t, s, "")
+	require.NoError(t, os.WriteFile(filepath.Join(s.root, "factorio", ".lock"), nil, 0o644))
+
+	_, err := runCLI(t, "launch")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "running")
+}

--- a/internal/cli/stubs.go
+++ b/internal/cli/stubs.go
@@ -22,14 +22,6 @@ func newDownloadCommand() *cobra.Command {
 	}
 }
 
-func newLaunchCommand() *cobra.Command {
-	return &cobra.Command{
-		Use:   "launch",
-		Short: "Launch Factorio",
-		RunE:  notImplemented,
-	}
-}
-
 func newManCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "man",

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -7,6 +7,7 @@ import (
 	"errors"
 	"fmt"
 	"os"
+	"os/exec"
 	"path/filepath"
 )
 
@@ -148,6 +149,42 @@ func (r *Runtime) IsRunning() (bool, error) {
 		return false, nil
 	}
 	return false, err
+}
+
+// Launch starts Factorio with the given arguments. Factorio daemonizes
+// itself (double fork), so the direct child is not the game: async starts
+// it and returns immediately (stdout discarded, as in Ruby's spawn with
+// out: IO::NULL); synchronous waits for the direct child with inherited
+// stdio — meaningful only for non-daemonizing options like --help — and
+// ignores its exit status, as Ruby's system does.
+func (r *Runtime) Launch(args []string, async bool) error {
+	exe, err := r.ExecutablePath()
+	if err != nil {
+		return err
+	}
+	cmd := exec.Command(exe, args...)
+	// Ruby launches with argv[0] set to "factorio"; keep that visible name.
+	cmd.Args = append([]string{"factorio"}, args...)
+
+	if async {
+		cmd.Stderr = os.Stderr
+		if err := cmd.Start(); err != nil {
+			return err
+		}
+		return cmd.Process.Release()
+	}
+
+	cmd.Stdin = os.Stdin
+	cmd.Stdout = os.Stdout
+	cmd.Stderr = os.Stderr
+	if err := cmd.Run(); err != nil {
+		var exitErr *exec.ExitError
+		if errors.As(err, &exitErr) {
+			return nil
+		}
+		return err
+	}
+	return nil
 }
 
 // xdgDir returns the environment variable's value when set (even if empty,


### PR DESCRIPTION
## Summary
Implement `launch` (Phase 10j) — start Factorio with optional pass-through arguments.

## Changes
- `Runtime.Launch` starts the game detached by default. Factorio double-forks, so the direct child is not the game: `--wait` polls the lock file (appear, then disappear) instead of waiting on a process, and `IsRunning` remains the only state signal
- Options that print and exit without daemonizing (`--help`, `--version`, `--dump-*`) run synchronously with inherited stdio; the game's exit status is ignored, as in Ruby's `system`
- `argv[0]` is set to `factorio`, matching Ruby's `spawn`

## Test Plan
- `mise run default` passes; tests drive the real command tree against a fake executable (sync args pass-through, async detachment, `--wait` lock-file polling, game-running rejection)
- Verified with the real binary and a fake game holding the lock: async returns in ~12 ms while the game completes on its own; `--wait` blocks until the lock clears
