### PR TITLE
:sparkles: Implement download command (Phase 10k)

### DIFF
--- a/doc/go-migration-roadmap.md
+++ b/doc/go-migration-roadmap.md
@@ -448,7 +448,7 @@ than one pass over the full list below.
       no cache decorator, matching Ruby) and `FACTORIX_MODS_PORTAL_URL` as an
       optional endpoint override (mirrors/tests)
 - [x] `mod upload` / `mod edit` / `mod image list/add/edit`
-- [ ] `download` — download the game itself
+- [x] `download` — download the game itself
 
 #### Cache
 - [x] `cache stat` / `cache evict`

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -54,6 +54,11 @@ type App struct {
 	// resolves lazily on first use, so commands only require
 	// FACTORIO_API_KEY when a management operation actually runs.
 	ManagementAPI func() (*api.MODManagementAPI, error)
+
+	// GameDownloadAPI returns the client for the game download endpoints,
+	// wired like PortalAPI (api cache + retry, as in Ruby's
+	// api_http_client); the actual file download goes through Downloader.
+	GameDownloadAPI func() (*api.GameDownloadAPI, error)
 }
 
 // Options select the configuration and log level.
@@ -106,6 +111,7 @@ func New(opts Options) (*App, error) {
 	a.Downloader = sync.OnceValues(a.buildDownloader)
 	a.MODDownloadAPI = sync.OnceValues(a.buildMODDownloadAPI)
 	a.ManagementAPI = sync.OnceValues(a.buildManagementAPI)
+	a.GameDownloadAPI = sync.OnceValues(a.buildGameDownloadAPI)
 	return a, nil
 }
 
@@ -281,6 +287,33 @@ func (a *App) buildManagementAPI() (*api.MODManagementAPI, error) {
 		}
 	}
 	return management, nil
+}
+
+func (a *App) buildGameDownloadAPI() (*api.GameDownloadAPI, error) {
+	apiCache, err := a.newCache("api", a.Config.Cache.API)
+	if err != nil {
+		return nil, err
+	}
+	base := httpx.NewBaseTransport(
+		time.Duration(a.Config.HTTP.ConnectTimeout)*time.Second,
+		time.Duration(a.Config.HTTP.ReadTimeout)*time.Second,
+	)
+	transport := httpx.NewRetryTransport(
+		httpx.NewCacheTransport(base, apiCache, a.Logger),
+		httpx.RetryOptions{Logger: a.Logger},
+	)
+	client := httpx.NewClient(httpx.Options{
+		Transport:    transport,
+		MaskedParams: maskedQueryParams,
+		Logger:       a.Logger,
+	})
+	playerDataPath, err := a.Runtime.PlayerDataPath()
+	if err != nil {
+		return nil, err
+	}
+	return api.NewGameDownloadAPI(client, func() (api.ServiceCredential, error) {
+		return api.LoadServiceCredential(playerDataPath)
+	}, a.Logger), nil
 }
 
 // RequireGameStopped fails when Factorio is running; commands that modify

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -86,7 +86,7 @@ func NewRootCommand() (root *cobra.Command, reportError func(error)) {
 	root.AddCommand(
 		newVersionCommand(),
 		newPathCommand(c),
-		newDownloadCommand(),
+		newDownloadCommand(c),
 		newLaunchCommand(c),
 		newManCommand(),
 		newMODCommand(c),

--- a/internal/cli/download.go
+++ b/internal/cli/download.go
@@ -1,0 +1,133 @@
+package cli
+
+import (
+	"errors"
+	"fmt"
+	"os"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	"github.com/sakuro/factorix/internal/api"
+	"github.com/sakuro/factorix/internal/mod"
+	"github.com/sakuro/factorix/internal/transfer"
+)
+
+// downloadPlatformMap maps the runtime platform name to the download API's
+// platform identifier.
+var downloadPlatformMap = map[string]string{
+	"MacOS":   "osx",
+	"Linux":   "linux64",
+	"Windows": "win64",
+	"WSL":     "win64",
+}
+
+// The download API serves nothing older than 2.0.
+const minimumGameMajorVersion = 2
+
+func newDownloadCommand(c *cli) *cobra.Command {
+	var build, platform, channel, directory, output string
+
+	cmd := &cobra.Command{
+		Use:   "download [version]",
+		Short: "Download Factorio game files",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			version := "latest"
+			if len(args) > 0 {
+				version = args[0]
+			}
+
+			application, err := c.App()
+			if err != nil {
+				return err
+			}
+			if platform == "" {
+				name := application.Runtime.PlatformName()
+				platform = downloadPlatformMap[name]
+				if platform == "" {
+					return fmt.Errorf("Cannot auto-detect platform for %s", name)
+				}
+			}
+
+			gameDownload, err := application.GameDownloadAPI()
+			if err != nil {
+				return err
+			}
+			resolved, err := resolveGameVersion(cmd, gameDownload, version, channel, build)
+			if err != nil {
+				return err
+			}
+
+			downloadDir, err := filepath.Abs(directory)
+			if err != nil {
+				return err
+			}
+			if _, err := os.Stat(downloadDir); errors.Is(err, os.ErrNotExist) {
+				return fmt.Errorf("Download directory does not exist: %s", downloadDir)
+			} else if err != nil {
+				return err
+			}
+
+			filename := output
+			if filename == "" {
+				filename, err = gameDownload.ResolveFilename(cmd.Context(), resolved, build, platform)
+				if err != nil {
+					return err
+				}
+			}
+			outputPath := filepath.Join(downloadDir, filename)
+
+			p := c.printer(cmd)
+			p.Info(fmt.Sprintf("Downloading Factorio %s (%s/%s)...", resolved, build, platform))
+
+			downloadURL, err := gameDownload.DownloadURL(resolved, build, platform)
+			if err != nil {
+				return err
+			}
+			downloader, err := application.Downloader()
+			if err != nil {
+				return err
+			}
+			if err := downloader.Download(cmd.Context(), downloadURL, outputPath, transfer.DownloadOptions{}); err != nil {
+				return err
+			}
+
+			p.Success("Downloaded to " + outputPath)
+			return nil
+		},
+	}
+	cmd.Flags().StringVarP(&build, "build", "b", "alpha", "Build type")
+	cmd.Flags().StringVarP(&platform, "platform", "p", "", "Platform (default: auto-detect)")
+	// Ruby aliases -c to --channel here, but that collides with the global
+	// --config-path shorthand, which cobra rejects; channel is long-form only.
+	cmd.Flags().StringVar(&channel, "channel", "stable", "Release channel")
+	cmd.Flags().StringVarP(&directory, "directory", "d", ".", "Download directory")
+	cmd.Flags().StringVarP(&output, "output", "o", "", "Output filename (default: from server)")
+	return cmd
+}
+
+// resolveGameVersion turns "latest" into a concrete version via the API and
+// enforces the version format and the 2.0 minimum.
+func resolveGameVersion(cmd *cobra.Command, gameDownload *api.GameDownloadAPI, version, channel, build string) (string, error) {
+	resolved := version
+	if version == "latest" {
+		v, err := gameDownload.LatestVersion(cmd.Context(), channel, build)
+		if err != nil {
+			return "", err
+		}
+		if v == "" {
+			return "", fmt.Errorf("No %s version available for %s", channel, build)
+		}
+		resolved = v
+	}
+
+	gameVersion, err := mod.ParseGameVersion(resolved)
+	if err != nil {
+		return "", fmt.Errorf("Invalid version format: %s", err)
+	}
+	if gameVersion.Major < minimumGameMajorVersion {
+		return "", fmt.Errorf("Version %s is not supported. Minimum version is %d.0.0", resolved, minimumGameMajorVersion)
+	}
+	return resolved, nil
+}

--- a/internal/cli/download_test.go
+++ b/internal/cli/download_test.go
@@ -1,0 +1,53 @@
+package cli
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestDownloadRejectsOldVersion(t *testing.T) {
+	newSandbox(t)
+	_, err := runCLI(t, "download", "1.1.110")
+	require.Error(t, err)
+	assert.Equal(t, "Version 1.1.110 is not supported. Minimum version is 2.0.0", err.Error())
+}
+
+func TestDownloadRejectsInvalidVersion(t *testing.T) {
+	newSandbox(t)
+	_, err := runCLI(t, "download", "banana")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Invalid version format: ")
+}
+
+func TestDownloadRejectsMissingDirectory(t *testing.T) {
+	s := newSandbox(t)
+	missing := filepath.Join(s.root, "no-such-dir")
+	_, err := runCLI(t, "download", "2.0.0", "-d", missing, "-o", "game.tar.xz")
+	require.Error(t, err)
+	assert.Equal(t, "Download directory does not exist: "+missing, err.Error())
+}
+
+func TestDownloadRejectsInvalidBuildAndPlatform(t *testing.T) {
+	newSandbox(t)
+	_, err := runCLI(t, "download", "2.0.0", "-b", "bogus", "-o", "game.tar.xz")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `invalid build: "bogus"`)
+
+	_, err = runCLI(t, "download", "2.0.0", "-p", "bogus", "-o", "game.tar.xz")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), `invalid platform: "bogus"`)
+}
+
+// Without player-data.json or FACTORIO_USERNAME/FACTORIO_TOKEN the download
+// must fail at credential resolution, before any request.
+func TestDownloadRequiresCredentials(t *testing.T) {
+	newSandbox(t)
+	t.Setenv("FACTORIO_USERNAME", "")
+	t.Setenv("FACTORIO_TOKEN", "")
+	_, err := runCLI(t, "download", "2.0.0", "-o", "game.tar.xz")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "credential")
+}

--- a/internal/cli/stubs.go
+++ b/internal/cli/stubs.go
@@ -14,14 +14,6 @@ func notImplemented(cmd *cobra.Command, _ []string) error {
 	return errNotImplemented
 }
 
-func newDownloadCommand() *cobra.Command {
-	return &cobra.Command{
-		Use:   "download",
-		Short: "Download the game",
-		RunE:  notImplemented,
-	}
-}
-
 func newManCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "man",

--- a/internal/platform/linux.go
+++ b/internal/platform/linux.go
@@ -41,3 +41,6 @@ func (l Linux) DefaultFactorixLogPath() (string, error) {
 	}
 	return filepath.Join(stateHome, "factorix", "factorix.log"), nil
 }
+
+// Name identifies the platform.
+func (Linux) Name() string { return "Linux" }

--- a/internal/platform/macos.go
+++ b/internal/platform/macos.go
@@ -45,3 +45,6 @@ func (MacOS) DefaultFactorixLogPath() (string, error) {
 	}
 	return filepath.Join(dir, "factorix", "factorix.log"), nil
 }
+
+// Name identifies the platform.
+func (MacOS) Name() string { return "MacOS" }

--- a/internal/platform/platform.go
+++ b/internal/platform/platform.go
@@ -26,6 +26,8 @@ var ErrMissingEnv = errors.New("required environment variable is not set")
 // return the fallbacks used when the corresponding XDG_* environment
 // variable is not set.
 type Platform interface {
+	// Name identifies the platform ("Linux", "MacOS", "Windows", "WSL").
+	Name() string
 	GameExecutablePath() (string, error)
 	GameUserDir() (string, error)
 	GameDataDir() (string, error)
@@ -149,6 +151,12 @@ func (r *Runtime) IsRunning() (bool, error) {
 		return false, nil
 	}
 	return false, err
+}
+
+// PlatformName identifies the underlying platform ("Linux", "MacOS",
+// "Windows", "WSL").
+func (r *Runtime) PlatformName() string {
+	return r.platform.Name()
 }
 
 // Launch starts Factorio with the given arguments. Factorio daemonizes

--- a/internal/platform/windows.go
+++ b/internal/platform/windows.go
@@ -83,3 +83,6 @@ func (w Windows) DefaultFactorixLogPath() (string, error) {
 	}
 	return filepath.Join(stateHome, "factorix", "factorix.log"), nil
 }
+
+// Name identifies the platform.
+func (Windows) Name() string { return "Windows" }

--- a/internal/platform/wsl.go
+++ b/internal/platform/wsl.go
@@ -142,3 +142,6 @@ func (w *WSL) DefaultFactorixLogPath() (string, error) {
 	}
 	return filepath.Join(stateHome, "factorix", "factorix.log"), nil
 }
+
+// Name identifies the platform.
+func (*WSL) Name() string { return "WSL" }


### PR DESCRIPTION
## Summary
Implement `download [version]` (Phase 10k) — download Factorio game files from the official download API.

## Changes
- Resolves `latest` per `--channel`/`--build` via the latest-releases API, enforces the 2.0 minimum version, and auto-detects the platform from the runtime (`Platform` gains `Name()`; WSL maps to `win64`)
- Filename comes from the HEAD redirect unless `-o` is given; the file downloads through the shared `Downloader` (download cache, credential-stripped keys)
- App gains a memoized `GameDownloadAPI` wired like `PortalAPI` (api cache + retry, matching Ruby's `api_http_client`); `FACTORIO_USERNAME`/`FACTORIO_TOKEN` or player-data.json resolve lazily
- Note: Ruby aliases `-c` to `--channel`, but the global `--config-path -c` shadows it — `download -c experimental` in Ruby actually fails with "Configuration file not found: experimental". cobra rejects the shorthand collision outright, so channel is long-form only in Go (arguably fixing the Ruby bug)

## Test Plan
- `mise run default` passes; offline tests cover version-format/minimum validation, missing directory, invalid build/platform, and credential-resolution failure before any request
- Live-verified: latest headless resolved to 2.0.77 with server-side filename (57 MB valid XZ archive); explicit `2.0.72 -o` works; experimental channel resolves
