### PR TITLE
:sparkles: Implement man command (Phase 10l)

### DIFF
--- a/doc/go-migration-roadmap.md
+++ b/doc/go-migration-roadmap.md
@@ -412,7 +412,7 @@ than one pass over the full list below.
 - [x] `version` — print version
 - [x] `path` — print Factorio/Factorix paths
 - [ ] `completion` — generate shell completion (cobra built-in)
-- [ ] `man` — man page (cobra `doc` package)
+- [x] `man` — embedded doc/factorix.1 via go:embed, rendered with the system man
 
 #### Local MOD Management
 - [x] `mod list` — list installed MODs

--- a/internal/cli/man.go
+++ b/internal/cli/man.go
@@ -1,0 +1,44 @@
+package cli
+
+import (
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+
+	"github.com/spf13/cobra"
+
+	factorix "github.com/sakuro/factorix"
+)
+
+func newManCommand() *cobra.Command {
+	return &cobra.Command{
+		Use:   "man",
+		Short: "Display the Factorix manual page",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			manPath, err := exec.LookPath("man")
+			if err != nil {
+				return fmt.Errorf("man command is not available on this system")
+			}
+
+			// The page ships inside the binary (single-binary distribution),
+			// so materialize it for man.
+			dir, err := os.MkdirTemp("", "factorix-man")
+			if err != nil {
+				return err
+			}
+			defer os.RemoveAll(dir)
+			pagePath := filepath.Join(dir, "factorix.1")
+			if err := os.WriteFile(pagePath, factorix.ManPage, 0o644); err != nil {
+				return err
+			}
+
+			man := exec.CommandContext(cmd.Context(), manPath, pagePath)
+			man.Stdin = os.Stdin
+			man.Stdout = cmd.OutOrStdout()
+			man.Stderr = cmd.ErrOrStderr()
+			return man.Run()
+		},
+	}
+}

--- a/internal/cli/man_test.go
+++ b/internal/cli/man_test.go
@@ -1,0 +1,23 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestManRendersEmbeddedPage(t *testing.T) {
+	// A pipe (non-TTY) makes man render without a pager.
+	out, err := runCLI(t, "man")
+	require.NoError(t, err)
+	assert.Contains(t, out, "factorix")
+	assert.Contains(t, out, "User Commands")
+}
+
+func TestManCommandNotAvailable(t *testing.T) {
+	t.Setenv("PATH", t.TempDir())
+	_, err := runCLI(t, "man")
+	require.Error(t, err)
+	assert.Equal(t, "man command is not available on this system", err.Error())
+}

--- a/internal/cli/stubs.go
+++ b/internal/cli/stubs.go
@@ -14,14 +14,6 @@ func notImplemented(cmd *cobra.Command, _ []string) error {
 	return errNotImplemented
 }
 
-func newManCommand() *cobra.Command {
-	return &cobra.Command{
-		Use:   "man",
-		Short: "Display the manual page",
-		RunE:  notImplemented,
-	}
-}
-
 func newMODCommand(c *cli) *cobra.Command {
 	mod := &cobra.Command{
 		Use:   "mod",

--- a/manpage.go
+++ b/manpage.go
@@ -1,0 +1,10 @@
+// Package factorix embeds distribution assets that must travel inside the
+// single binary.
+package factorix
+
+import _ "embed"
+
+// ManPage is the roff source of the factorix(1) manual page.
+//
+//go:embed doc/factorix.1
+var ManPage []byte


### PR DESCRIPTION
## Summary
Implement `man` (Phase 10l) — display the factorix(1) manual page.

## Changes
- Embed `doc/factorix.1` into the binary via `go:embed` (root-level `manpage.go`) and render it with the system `man` through a temp file — unlike the gem, the single binary cannot reference an on-disk page
- Missing `man` reports Ruby's exact "man command is not available on this system"

## Test Plan
- `mise run default` passes; tests render the page through a pipe and cover the missing-man path
- Verified with the real binary from an unrelated cwd (self-contained) and with `man` removed from PATH