### PR TITLE
:sparkles: Implement rcon exec/eval commands (Phase 10m)

### DIFF
--- a/doc/go-migration-roadmap.md
+++ b/doc/go-migration-roadmap.md
@@ -147,7 +147,7 @@ The Ruby `UserConfigurable` path overrides map to the config settings above.
 | Config file | [BurntSushi/toml](https://github.com/BurntSushi/toml) |
 | Retry logic | [avast/retry-go](https://github.com/avast/retry-go) |
 | Cross-process file locking | [gofrs/flock](https://github.com/gofrs/flock) |
-| RCON | [gorcon/rcon](https://github.com/gorcon/rcon) (supports Factorio) |
+| RCON | `internal/rcon` — hand-rolled port of the rcon-client gem (sentinel-based multi-packet reassembly, which gorcon/rcon lacks) |
 | Release tooling | [goreleaser](https://goreleaser.com/) |
 | Testing | `testing` + [testify](https://github.com/stretchr/testify) |
 
@@ -185,7 +185,7 @@ factorix/                  # repository root (Ruby lib/ and spec/ coexist until 
 └── .goreleaser.yaml
 ```
 
-RCON needs no internal package — `gorcon/rcon` is used directly from the CLI layer.
+The RCON protocol lives in `internal/rcon`, ported from the rcon-client gem: Factorio fragments large responses, so a sentinel command marks the end of each reply.
 
 ---
 
@@ -455,7 +455,7 @@ than one pass over the full list below.
 
 #### Game
 - [x] `launch` — launch Factorio (`os/exec`)
-- [ ] `rcon exec` / `rcon eval` — via gorcon/rcon, using `config.rcon` settings
+- [x] `rcon exec` / `rcon eval` — via `internal/rcon`, using `config.rcon` settings
 
 ---
 

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -92,7 +92,7 @@ func NewRootCommand() (root *cobra.Command, reportError func(error)) {
 		newMODCommand(c),
 		newCacheCommand(c),
 		newBlueprintCommand(c),
-		newRConCommand(),
+		newRConCommand(c),
 	)
 
 	reportError = func(err error) {

--- a/internal/cli/rcon.go
+++ b/internal/cli/rcon.go
@@ -1,0 +1,110 @@
+package cli
+
+import (
+	"io"
+
+	"github.com/spf13/cobra"
+
+	"github.com/sakuro/factorix/internal/rcon"
+)
+
+// factorioSentinelCommand is the no-op console command used to mark the end
+// of fragmented RCON responses.
+const factorioSentinelCommand = "/c"
+
+func newRConCommand(c *cli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "rcon",
+		Short: "Interact with a running Factorio server via RCON",
+	}
+	cmd.AddCommand(newRConExecCommand(c), newRConEvalCommand(c))
+	return cmd
+}
+
+// rconFlags holds the connection overrides shared by exec and eval; config
+// values fill whatever the flags leave unset.
+type rconFlags struct {
+	host     string
+	port     int
+	password string
+}
+
+func (f *rconFlags) register(cmd *cobra.Command) {
+	cmd.Flags().StringVar(&f.host, "host", "", "RCon host")
+	cmd.Flags().IntVar(&f.port, "port", 0, "RCon port")
+	cmd.Flags().StringVar(&f.password, "password", "", "RCon password")
+}
+
+// runRConCommand connects using flags-over-config settings, executes the
+// command, and prints a non-empty response.
+func runRConCommand(cmd *cobra.Command, c *cli, flags *rconFlags, command string) error {
+	application, err := c.App()
+	if err != nil {
+		return err
+	}
+	host := flags.host
+	if host == "" {
+		host = application.Config.RCON.Host
+	}
+	port := flags.port
+	if port == 0 {
+		port = application.Config.RCON.Port
+	}
+	password := flags.password
+	if password == "" {
+		password = application.Config.RCON.Password
+	}
+
+	client, err := rcon.Dial(cmd.Context(), host, port, password, factorioSentinelCommand)
+	if err != nil {
+		return err
+	}
+	defer client.Close()
+
+	result, err := client.Execute(command)
+	if err != nil {
+		return err
+	}
+	if result != "" {
+		c.printer(cmd).Say(result)
+	}
+	return nil
+}
+
+func newRConExecCommand(c *cli) *cobra.Command {
+	flags := &rconFlags{}
+	cmd := &cobra.Command{
+		Use:   "exec <command>",
+		Short: "Execute a Factorio console command via RCon",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			return runRConCommand(cmd, c, flags, args[0])
+		},
+	}
+	flags.register(cmd)
+	return cmd
+}
+
+func newRConEvalCommand(c *cli) *cobra.Command {
+	flags := &rconFlags{}
+	cmd := &cobra.Command{
+		Use:   "eval [script]",
+		Short: "Evaluate a Lua script in Factorio via RCon",
+		Args:  cobra.MaximumNArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			var script string
+			if len(args) > 0 {
+				script = args[0]
+			} else {
+				data, err := io.ReadAll(cmd.InOrStdin())
+				if err != nil {
+					return err
+				}
+				script = string(data)
+			}
+			return runRConCommand(cmd, c, flags, "/c "+script)
+		},
+	}
+	flags.register(cmd)
+	return cmd
+}

--- a/internal/cli/rcon_test.go
+++ b/internal/cli/rcon_test.go
@@ -1,0 +1,107 @@
+package cli
+
+import (
+	"bytes"
+	"encoding/binary"
+	"io"
+	"net"
+	"strconv"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeRCONServer accepts one connection, authenticates any password, and
+// echoes exec bodies back (empty response for the "/c" sentinel).
+type fakeRCONServer struct {
+	listener net.Listener
+	commands chan string
+}
+
+func newFakeRCONServer(t *testing.T) *fakeRCONServer {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	s := &fakeRCONServer{listener: listener, commands: make(chan string, 16)}
+	t.Cleanup(func() { _ = listener.Close() })
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		defer conn.Close()
+		for {
+			var size int32
+			if err := binary.Read(conn, binary.LittleEndian, &size); err != nil {
+				return
+			}
+			payload := make([]byte, size)
+			if _, err := io.ReadFull(conn, payload); err != nil {
+				return
+			}
+			id := int32(binary.LittleEndian.Uint32(payload[0:4]))
+			packetType := int32(binary.LittleEndian.Uint32(payload[4:8]))
+			body := string(payload[8 : size-2])
+
+			reply := func(replyID, replyType int32, replyBody string) {
+				var buf bytes.Buffer
+				_ = binary.Write(&buf, binary.LittleEndian, int32(8+len(replyBody)+2))
+				_ = binary.Write(&buf, binary.LittleEndian, replyID)
+				_ = binary.Write(&buf, binary.LittleEndian, replyType)
+				buf.WriteString(replyBody)
+				buf.Write([]byte{0, 0})
+				_, _ = conn.Write(buf.Bytes())
+			}
+			switch packetType {
+			case 3: // auth
+				reply(id, 2, "")
+			case 2: // exec
+				s.commands <- body
+				if body == "/c" {
+					reply(id, 0, "")
+				} else {
+					reply(id, 0, "echo:"+body)
+				}
+			}
+		}
+	}()
+	return s
+}
+
+func (s *fakeRCONServer) port() string {
+	return strconv.Itoa(s.listener.Addr().(*net.TCPAddr).Port)
+}
+
+func TestRConExec(t *testing.T) {
+	newSandbox(t)
+	server := newFakeRCONServer(t)
+
+	out, err := runCLI(t, "rcon", "exec", "/players", "--host", "127.0.0.1", "--port", server.port(), "--password", "pw")
+	require.NoError(t, err)
+	assert.Equal(t, "echo:/players\n", out)
+	assert.Equal(t, "/players", <-server.commands)
+	assert.Equal(t, "/c", <-server.commands)
+}
+
+func TestRConEvalFromStdin(t *testing.T) {
+	newSandbox(t)
+	server := newFakeRCONServer(t)
+
+	out, err := runCLIWithStdin(t, "print(1)", "rcon", "eval", "--host", "127.0.0.1", "--port", server.port(), "--password", "pw")
+	require.NoError(t, err)
+	assert.Equal(t, "echo:/c print(1)\n", out)
+	assert.Equal(t, "/c print(1)", <-server.commands)
+}
+
+func TestRConConnectionRefused(t *testing.T) {
+	newSandbox(t)
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := strconv.Itoa(listener.Addr().(*net.TCPAddr).Port)
+	require.NoError(t, listener.Close())
+
+	_, err = runCLI(t, "rcon", "exec", "/players", "--host", "127.0.0.1", "--port", port, "--password", "pw")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "RCON connection error")
+}

--- a/internal/cli/stubs.go
+++ b/internal/cli/stubs.go
@@ -42,15 +42,3 @@ func newMODCommand(c *cli) *cobra.Command {
 
 	return mod
 }
-
-func newRConCommand() *cobra.Command {
-	rcon := &cobra.Command{
-		Use:   "rcon",
-		Short: "Interact with a running Factorio server via RCON",
-	}
-	rcon.AddCommand(
-		&cobra.Command{Use: "exec", Short: "Execute a console command", RunE: notImplemented},
-		&cobra.Command{Use: "eval", Short: "Evaluate a Lua script", RunE: notImplemented},
-	)
-	return rcon
-}

--- a/internal/rcon/rcon.go
+++ b/internal/rcon/rcon.go
@@ -1,0 +1,163 @@
+// Package rcon is a TCP client for the Source RCON protocol, ported from
+// the rcon-client gem. Factorio splits large responses across packets with
+// no length indication, so Execute sends a sentinel command after the real
+// one and treats the sentinel's response as the end marker.
+package rcon
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"errors"
+	"fmt"
+	"io"
+	"net"
+	"strconv"
+)
+
+// Packet types of the Source RCON protocol. An auth response arrives as
+// type 2 (the same value as an exec command) with the auth request's ID, or
+// -1 on failure.
+const (
+	typeResponseValue int32 = 0
+	typeExecCommand   int32 = 2
+	typeAuth          int32 = 3
+)
+
+// The server truncates bodies at 511 bytes; fail early instead.
+const bodyByteLimit = 511
+
+var (
+	ErrConnection     = errors.New("RCON connection error")
+	ErrAuthentication = errors.New("RCON authentication failed")
+)
+
+// Client is an authenticated RCON connection. It is not safe for
+// concurrent use.
+type Client struct {
+	conn            net.Conn
+	sentinelCommand string
+	nextID          int32
+}
+
+// Dial connects and authenticates. sentinelCommand is the no-op command
+// whose response marks the end of a fragmented reply ("/c" for Factorio).
+func Dial(ctx context.Context, host string, port int, password, sentinelCommand string) (*Client, error) {
+	var dialer net.Dialer
+	conn, err := dialer.DialContext(ctx, "tcp", net.JoinHostPort(host, strconv.Itoa(port)))
+	if err != nil {
+		return nil, fmt.Errorf("%w: %s", ErrConnection, err)
+	}
+	c := &Client{conn: conn, sentinelCommand: sentinelCommand}
+	if err := c.authenticate(password); err != nil {
+		_ = conn.Close()
+		return nil, err
+	}
+	return c, nil
+}
+
+// Close closes the connection.
+func (c *Client) Close() error {
+	return c.conn.Close()
+}
+
+// Execute sends a command and returns the server's full response,
+// reassembled across packets.
+func (c *Client) Execute(command string) (string, error) {
+	cmdID := c.newID()
+	sentinelID := c.newID()
+
+	if err := c.send(cmdID, typeExecCommand, command); err != nil {
+		return "", err
+	}
+	if err := c.send(sentinelID, typeExecCommand, c.sentinelCommand); err != nil {
+		return "", err
+	}
+
+	var parts bytes.Buffer
+	for {
+		id, packetType, body, err := c.receive()
+		if err != nil {
+			return "", err
+		}
+		if packetType != typeResponseValue {
+			continue
+		}
+		switch id {
+		case cmdID:
+			parts.Write(body)
+		case sentinelID:
+			return parts.String(), nil
+		}
+	}
+}
+
+func (c *Client) authenticate(password string) error {
+	authID := c.newID()
+	if err := c.send(authID, typeAuth, password); err != nil {
+		return err
+	}
+	// Standard RCON sends an empty RESPONSE_VALUE before the auth response;
+	// some implementations (e.g. Factorio) send the auth response directly.
+	for {
+		id, packetType, _, err := c.receive()
+		if err != nil {
+			return err
+		}
+		if packetType == typeResponseValue {
+			continue
+		}
+		if id == -1 {
+			return ErrAuthentication
+		}
+		return nil
+	}
+}
+
+func (c *Client) newID() int32 {
+	c.nextID++
+	return c.nextID
+}
+
+// send writes one packet: size(4) + id(4) + type(4) + body + null(1) +
+// empty-string(1), all little-endian.
+func (c *Client) send(id, packetType int32, body string) error {
+	if len(body) > bodyByteLimit {
+		return fmt.Errorf("body too long (%d > %d)", len(body), bodyByteLimit)
+	}
+	size := int32(8 + len(body) + 2)
+	var buf bytes.Buffer
+	for _, v := range []int32{size, id, packetType} {
+		if err := binary.Write(&buf, binary.LittleEndian, v); err != nil {
+			return err
+		}
+	}
+	buf.WriteString(body)
+	buf.Write([]byte{0, 0})
+	if _, err := c.conn.Write(buf.Bytes()); err != nil {
+		return fmt.Errorf("%w: %s", ErrConnection, err)
+	}
+	return nil
+}
+
+func (c *Client) receive() (id, packetType int32, body []byte, err error) {
+	var size int32
+	if err := binary.Read(c.conn, binary.LittleEndian, &size); err != nil {
+		return 0, 0, nil, connectionError(err)
+	}
+	payload := make([]byte, size)
+	if _, err := io.ReadFull(c.conn, payload); err != nil {
+		return 0, 0, nil, connectionError(err)
+	}
+	id = int32(binary.LittleEndian.Uint32(payload[0:4]))
+	packetType = int32(binary.LittleEndian.Uint32(payload[4:8]))
+	// The body is followed by a null terminator and an empty string.
+	return id, packetType, payload[8 : size-2], nil
+}
+
+func connectionError(err error) error {
+	if errors.Is(err, io.EOF) || errors.Is(err, io.ErrUnexpectedEOF) {
+		return fmt.Errorf("%w: connection closed by server", ErrConnection)
+	}
+	return fmt.Errorf("%w: %s", ErrConnection, err)
+}

--- a/internal/rcon/rcon_test.go
+++ b/internal/rcon/rcon_test.go
@@ -160,7 +160,8 @@ func TestExecuteServerClosesConnection(t *testing.T) {
 	require.NoError(t, err)
 	defer client.Close()
 
+	// Depending on timing the failure surfaces as a broken-pipe write or
+	// as EOF on read; both are connection errors.
 	_, err = client.Execute("/players")
 	require.ErrorIs(t, err, ErrConnection)
-	assert.Contains(t, err.Error(), "connection closed by server")
 }

--- a/internal/rcon/rcon_test.go
+++ b/internal/rcon/rcon_test.go
@@ -1,0 +1,166 @@
+package rcon
+
+import (
+	"bytes"
+	"context"
+	"encoding/binary"
+	"io"
+	"net"
+	"strings"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// fakeServer speaks just enough RCON for the tests: it authenticates
+// against a fixed password and answers every exec with handle.
+type fakeServer struct {
+	listener net.Listener
+	password string
+	// handle maps a received command body to response bodies (multiple
+	// entries model a fragmented response).
+	handle func(command string) []string
+	// commands records every exec body received.
+	commands []string
+}
+
+func newFakeServer(t *testing.T, password string, handle func(string) []string) *fakeServer {
+	t.Helper()
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	s := &fakeServer{listener: listener, password: password, handle: handle}
+	go s.serve()
+	t.Cleanup(func() { _ = listener.Close() })
+	return s
+}
+
+func (s *fakeServer) port() int {
+	return s.listener.Addr().(*net.TCPAddr).Port
+}
+
+func (s *fakeServer) serve() {
+	conn, err := s.listener.Accept()
+	if err != nil {
+		return
+	}
+	defer conn.Close()
+	for {
+		id, packetType, body, err := readPacket(conn)
+		if err != nil {
+			return
+		}
+		switch packetType {
+		case typeAuth:
+			if string(body) == s.password {
+				writePacket(conn, id, typeExecCommand, "")
+			} else {
+				writePacket(conn, -1, typeExecCommand, "")
+			}
+		case typeExecCommand:
+			s.commands = append(s.commands, string(body))
+			for _, part := range s.handle(string(body)) {
+				writePacket(conn, id, typeResponseValue, part)
+			}
+		}
+	}
+}
+
+func readPacket(conn net.Conn) (id, packetType int32, body []byte, err error) {
+	var size int32
+	if err := binary.Read(conn, binary.LittleEndian, &size); err != nil {
+		return 0, 0, nil, err
+	}
+	payload := make([]byte, size)
+	if _, err := io.ReadFull(conn, payload); err != nil {
+		return 0, 0, nil, err
+	}
+	id = int32(binary.LittleEndian.Uint32(payload[0:4]))
+	packetType = int32(binary.LittleEndian.Uint32(payload[4:8]))
+	return id, packetType, payload[8 : size-2], nil
+}
+
+func writePacket(conn net.Conn, id, packetType int32, body string) {
+	var buf bytes.Buffer
+	_ = binary.Write(&buf, binary.LittleEndian, int32(8+len(body)+2))
+	_ = binary.Write(&buf, binary.LittleEndian, id)
+	_ = binary.Write(&buf, binary.LittleEndian, packetType)
+	buf.WriteString(body)
+	buf.Write([]byte{0, 0})
+	_, _ = conn.Write(buf.Bytes())
+}
+
+// echoOrEmpty responds to the sentinel with nothing and echoes everything
+// else in two fragments.
+func echoOrEmpty(command string) []string {
+	if command == "/c" {
+		return []string{""}
+	}
+	half := len(command) / 2
+	return []string{command[:half], command[half:]}
+}
+
+func TestExecuteReassemblesFragments(t *testing.T) {
+	s := newFakeServer(t, "secret", echoOrEmpty)
+	client, err := Dial(context.Background(), "127.0.0.1", s.port(), "secret", "/c")
+	require.NoError(t, err)
+	defer client.Close()
+
+	result, err := client.Execute("/server-save now")
+	require.NoError(t, err)
+	assert.Equal(t, "/server-save now", result)
+	assert.Equal(t, []string{"/server-save now", "/c"}, s.commands)
+}
+
+func TestDialAuthenticationFailure(t *testing.T) {
+	s := newFakeServer(t, "secret", echoOrEmpty)
+	_, err := Dial(context.Background(), "127.0.0.1", s.port(), "wrong", "/c")
+	require.ErrorIs(t, err, ErrAuthentication)
+}
+
+func TestDialConnectionRefused(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	port := listener.Addr().(*net.TCPAddr).Port
+	require.NoError(t, listener.Close())
+
+	_, err = Dial(context.Background(), "127.0.0.1", port, "secret", "/c")
+	require.ErrorIs(t, err, ErrConnection)
+}
+
+func TestExecuteBodyTooLong(t *testing.T) {
+	s := newFakeServer(t, "secret", echoOrEmpty)
+	client, err := Dial(context.Background(), "127.0.0.1", s.port(), "secret", "/c")
+	require.NoError(t, err)
+	defer client.Close()
+
+	_, err = client.Execute(strings.Repeat("x", 512))
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "body too long (512 > 511)")
+}
+
+func TestExecuteServerClosesConnection(t *testing.T) {
+	listener, err := net.Listen("tcp", "127.0.0.1:0")
+	require.NoError(t, err)
+	t.Cleanup(func() { _ = listener.Close() })
+	go func() {
+		conn, err := listener.Accept()
+		if err != nil {
+			return
+		}
+		// Complete the auth handshake, then hang up.
+		id, _, _, err := readPacket(conn)
+		if err == nil {
+			writePacket(conn, id, typeExecCommand, "")
+		}
+		_ = conn.Close()
+	}()
+
+	client, err := Dial(context.Background(), "127.0.0.1", listener.Addr().(*net.TCPAddr).Port, "secret", "/c")
+	require.NoError(t, err)
+	defer client.Close()
+
+	_, err = client.Execute("/players")
+	require.ErrorIs(t, err, ErrConnection)
+	assert.Contains(t, err.Error(), "connection closed by server")
+}


### PR DESCRIPTION
## Summary
Implement `rcon exec` / `rcon eval` (Phase 10m) with a hand-rolled RCON client ported from the rcon-client gem.

## Changes
- `internal/rcon` implements the Source RCON protocol with sentinel-based multi-packet reassembly: Factorio fragments large responses with no length indication, so a no-op sentinel command (`/c`) sent after the real one marks the end of each reply. It also handles Factorio's auth quirk (no empty RESPONSE_VALUE before the auth response) and takes a context for dialing
- gorcon/rcon (the roadmap's original pick) reads a single response packet with a fixed request ID, so fragmented replies get truncated and the sentinel technique cannot be layered on top — the roadmap now documents the substitution
- `exec <command>` sends the console command as-is; `eval [script]` prefixes `/c ` and falls back to stdin; `--host`/`--port`/`--password` override `config.rcon`

## Test Plan
- `mise run default` passes; unit tests cover fragmented reassembly, auth failure, connection refusal, server hang-up, and the 511-byte body limit against an in-process fake server
- Verified with the real binary against a standalone fake RCON server: `exec` output byte-identical with the Ruby CLI, including a three-packet 8 KiB fragmented reply; wrong password exits 1 in both
