### PR TITLE
:sparkles: Adopt cobra's built-in completion command (Phase 10n)

### DIFF
--- a/doc/go-migration-roadmap.md
+++ b/doc/go-migration-roadmap.md
@@ -22,8 +22,10 @@ Sequencing:
    and keeping them enables Ruby-vs-Go parity testing against the same fixtures.
    Pull requests during this period target `go-rewrite`, not `main`.
 3. At parity, `main` is replaced, Ruby sources are removed (history retains
-   them), and goreleaser tags continue the gem's `vX.Y.Z` sequence — reaching
-   parity is the `v1.0.0` milestone.
+   them; this includes `completion/` — the Go binary generates completion
+   scripts on demand via cobra, so the hand-written ones only serve the
+   Ruby CLI), and goreleaser tags continue the gem's `vX.Y.Z` sequence —
+   reaching parity is the `v1.0.0` milestone.
 
 **Prerequisite work in the Ruby repository:** the
 [dry-* simplification plan](dry-simplification-plan.md) — DI container →
@@ -411,7 +413,7 @@ than one pass over the full list below.
 #### Informational
 - [x] `version` — print version
 - [x] `path` — print Factorio/Factorix paths
-- [ ] `completion` — generate shell completion (cobra built-in)
+- [x] `completion` — generate shell completion (cobra built-in)
 - [x] `man` — embedded doc/factorix.1 via go:embed, rendered with the system man
 
 #### Local MOD Management

--- a/internal/cli/completion_test.go
+++ b/internal/cli/completion_test.go
@@ -1,0 +1,22 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Completion is cobra's built-in command; the scripts are generated from
+// the live command tree (unlike Ruby's hand-written completion/ scripts).
+func TestCompletionGeneratesScripts(t *testing.T) {
+	for shell, marker := range map[string]string{
+		"bash": "factorix",
+		"fish": "complete",
+		"zsh":  "#compdef factorix",
+	} {
+		out, err := runCLI(t, "completion", shell)
+		require.NoError(t, err, shell)
+		assert.Contains(t, out, marker, shell)
+	}
+}


### PR DESCRIPTION
## Summary
Adopt cobra's built-in `completion` command (Phase 10n), completing the Phase 10 command list.

## Changes
- Use cobra's default `completion bash|zsh|fish|powershell` as-is: the generated scripts are thin shims that query the binary's hidden `__complete` command on every TAB, so completions always match the live command tree — unlike Ruby's hand-written `completion/` scripts (1164 lines, now slated for removal at the main swap; noted in the roadmap)
- Deliberate departures from Ruby: the shell must be named (no `$SHELL` auto-detection) and PowerShell is additionally supported. `eval "$(factorix completion zsh)"` still works — the zsh script registers `compdef` and guards against self-execution when eval-ed (verified)

## Test Plan
- `mise run default` passes; a test generates all three scripts through the real command tree
- Verified eval-loading in real zsh and bash sessions (function defined and registered in `$_comps`)
