### PR TITLE
:fire: Remove the not-implemented stub machinery

### DIFF
--- a/internal/cli/mod.go
+++ b/internal/cli/mod.go
@@ -1,18 +1,8 @@
 package cli
 
 import (
-	"errors"
-
 	"github.com/spf13/cobra"
 )
-
-// errNotImplemented marks commands scheduled for later phases of the Go
-// migration (see doc/go-migration-roadmap.md).
-var errNotImplemented = errors.New("not implemented yet")
-
-func notImplemented(cmd *cobra.Command, _ []string) error {
-	return errNotImplemented
-}
 
 func newMODCommand(c *cli) *cobra.Command {
 	mod := &cobra.Command{
@@ -31,8 +21,6 @@ func newMODCommand(c *cli) *cobra.Command {
 		newMODInstallCommand(c),
 		newMODUninstallCommand(c),
 		newMODUpdateCommand(c),
-	)
-	mod.AddCommand(
 		newMODSyncCommand(c),
 		newMODUploadCommand(c),
 		newMODEditCommand(c),


### PR DESCRIPTION
## Summary
Post-Phase 10 cleanup: every command is implemented, so the stub machinery is dead code.

## Changes
- Rename `internal/cli/stubs.go` to `mod.go` (it only held the real `mod` command tree) and drop the unused `notImplemented` helper

## Test Plan
- `mise run default` passes