### PR TITLE
:sparkles: Add Go driver for the e2e suite (Phase 11a)

### DIFF
--- a/doc/go-migration-roadmap.md
+++ b/doc/go-migration-roadmap.md
@@ -465,11 +465,11 @@ than one pass over the full list below.
 
 **Goal:** Reliable, distributable binary.
 
-- [ ] Unit tests for serdes, dependency parser, mod_list, settings, blueprint, changelog
-- [ ] Go driver for the language-neutral e2e suite (`e2e/cases/`, created in
+- [x] Unit tests for serdes, dependency parser, mod_list, settings, blueprint, changelog
+- [x] Go driver for the language-neutral e2e suite (`e2e/cases/`, created in
       the dry-* simplification Stage 0) — running it against both binaries on
       the branch is the Ruby-vs-Go parity check
-- [ ] Reuse the Ruby fixtures (`spec/fixtures`: `test-save.zip`, mod-list, changelog samples)
+- [x] Reuse the Ruby fixtures (`spec/fixtures`: `test-save.zip`, mod-list, changelog samples)
       as golden files for unit tests
 - [ ] Integration tests for CLI commands using `httptest` for portal API
 - [ ] `staticcheck` / `golangci-lint` in CI

--- a/e2e/README.md
+++ b/e2e/README.md
@@ -2,9 +2,9 @@
 
 Language-neutral CLI test cases. Each case describes a `factorix` invocation and
 its expected observable behavior (stdout and exit status). The cases are plain
-data; a thin per-language driver executes them — currently RSpec
-(`spec/e2e/`), later a Go test driver running the same cases against the Go
-binary (see `doc/go-migration-roadmap.md`).
+data; a thin per-language driver executes them — RSpec (`spec/e2e/`) for the
+Ruby CLI, and a Go test driver (`e2e/driver_test.go`, run with
+`mise run e2e`) that builds the Go binary and runs the same cases against it.
 
 stderr is not compared: it carries progress reporting and is not part of the
 stable CLI contract.

--- a/e2e/driver_test.go
+++ b/e2e/driver_test.go
@@ -1,0 +1,203 @@
+// Package e2e runs the language-neutral CLI cases (see README.md) against
+// the Go binary, implementing the execution contract the Ruby driver
+// (spec/e2e/runner.rb) also follows.
+package e2e
+
+import (
+	"bytes"
+	"fmt"
+	"os"
+	"os/exec"
+	"path/filepath"
+	"regexp"
+	"slices"
+	"strings"
+	"testing"
+
+	"github.com/BurntSushi/toml"
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+	"gopkg.in/yaml.v3"
+)
+
+const sandboxPlaceholder = "{{SANDBOX}}"
+
+// binaryPath is the factorix binary under test, built once in TestMain.
+var binaryPath string
+
+func TestMain(m *testing.M) {
+	dir, err := os.MkdirTemp("", "factorix-e2e-bin")
+	if err != nil {
+		panic(err)
+	}
+	defer os.RemoveAll(dir)
+
+	binaryPath = filepath.Join(dir, "factorix")
+	// Release binaries get the real version from goreleaser's ldflags; the
+	// version case only asserts that a semver line reaches stdout.
+	build := exec.Command("go", "build",
+		"-ldflags", "-X github.com/sakuro/factorix/internal/cli.Version=0.0.0",
+		"-o", binaryPath, "../cmd/factorix")
+	build.Stderr = os.Stderr
+	if err := build.Run(); err != nil {
+		panic(fmt.Sprintf("building factorix: %s", err))
+	}
+
+	os.Exit(m.Run())
+}
+
+type caseDefinition struct {
+	Command []string       `yaml:"command"`
+	Stdin   string         `yaml:"stdin"`
+	Config  map[string]any `yaml:"config"`
+	Dirs    []string       `yaml:"dirs"`
+	Files   []struct {
+		From string `yaml:"from"`
+		To   string `yaml:"to"`
+	} `yaml:"files"`
+	Expect struct {
+		Status int `yaml:"status"`
+		Stdout *struct {
+			File  string `yaml:"file"`
+			Match string `yaml:"match"`
+		} `yaml:"stdout"`
+	} `yaml:"expect"`
+}
+
+func TestCases(t *testing.T) {
+	repoRoot, err := filepath.Abs("..")
+	require.NoError(t, err)
+
+	caseFiles, err := filepath.Glob(filepath.Join("cases", "*", "*", "case.yaml"))
+	require.NoError(t, err)
+	require.NotEmpty(t, caseFiles)
+
+	for _, caseFile := range caseFiles {
+		caseDir := filepath.Dir(caseFile)
+		name := strings.TrimPrefix(filepath.ToSlash(caseDir), "cases/")
+		t.Run(name, func(t *testing.T) {
+			runCase(t, repoRoot, caseDir)
+		})
+	}
+}
+
+func runCase(t *testing.T, repoRoot, caseDir string) {
+	data, err := os.ReadFile(filepath.Join(caseDir, "case.yaml"))
+	require.NoError(t, err)
+	var definition caseDefinition
+	require.NoError(t, yaml.Unmarshal(data, &definition))
+
+	sandbox := t.TempDir()
+	substitute := func(text string) string {
+		return strings.ReplaceAll(text, sandboxPlaceholder, sandbox)
+	}
+
+	for _, name := range []string{"cwd", "xdg-cache", "xdg-config", "xdg-data", "xdg-state"} {
+		require.NoError(t, os.MkdirAll(filepath.Join(sandbox, name), 0o755))
+	}
+	for _, dir := range definition.Dirs {
+		require.NoError(t, os.MkdirAll(filepath.Join(sandbox, dir), 0o755))
+	}
+
+	for _, file := range definition.Files {
+		source := filepath.Join(caseDir, file.From)
+		if after, isRepoRelative := strings.CutPrefix(file.From, "//"); isRepoRelative {
+			source = filepath.Join(repoRoot, after)
+		}
+		destination := filepath.Join(sandbox, substitute(file.To))
+		require.NoError(t, os.MkdirAll(filepath.Dir(destination), 0o755))
+		require.NoError(t, copyTree(source, destination))
+	}
+
+	env := environWithout("NO_COLOR", "FACTORIX_CONFIG", "XDG_CACHE_HOME", "XDG_CONFIG_HOME", "XDG_DATA_HOME", "XDG_STATE_HOME")
+	env = append(env,
+		"NO_COLOR=1",
+		"XDG_CACHE_HOME="+filepath.Join(sandbox, "xdg-cache"),
+		"XDG_CONFIG_HOME="+filepath.Join(sandbox, "xdg-config"),
+		"XDG_DATA_HOME="+filepath.Join(sandbox, "xdg-data"),
+		"XDG_STATE_HOME="+filepath.Join(sandbox, "xdg-state"),
+	)
+	if definition.Config != nil {
+		configPath := filepath.Join(sandbox, "config.toml")
+		var rendered bytes.Buffer
+		require.NoError(t, toml.NewEncoder(&rendered).Encode(substituteValues(definition.Config, substitute)))
+		require.NoError(t, os.WriteFile(configPath, rendered.Bytes(), 0o644))
+		env = append(env, "FACTORIX_CONFIG="+configPath)
+	}
+
+	cmd := exec.Command(binaryPath, definition.Command...)
+	cmd.Dir = filepath.Join(sandbox, "cwd")
+	cmd.Env = env
+	cmd.Stdin = strings.NewReader(definition.Stdin)
+	var stdout, stderr bytes.Buffer
+	cmd.Stdout = &stdout
+	cmd.Stderr = &stderr
+
+	err = cmd.Run()
+	exitStatus := 0
+	if err != nil {
+		var exitErr *exec.ExitError
+		require.ErrorAs(t, err, &exitErr, "factorix did not run")
+		exitStatus = exitErr.ExitCode()
+	}
+
+	assert.Equal(t, definition.Expect.Status, exitStatus,
+		"exit status\nstdout:\n%s\nstderr:\n%s", stdout.String(), stderr.String())
+
+	stdoutExpectation := definition.Expect.Stdout
+	if stdoutExpectation == nil {
+		return
+	}
+	switch {
+	case stdoutExpectation.File != "":
+		expected, err := os.ReadFile(filepath.Join(caseDir, stdoutExpectation.File))
+		require.NoError(t, err)
+		assert.Equal(t, substitute(string(expected)), stdout.String())
+	case stdoutExpectation.Match != "":
+		// (?m) gives ^ and $ Ruby's always-per-line semantics.
+		pattern := regexp.MustCompile("(?m)" + stdoutExpectation.Match)
+		assert.Regexp(t, pattern, stdout.String())
+	}
+}
+
+// copyTree copies a file, or a directory recursively (FileUtils.cp_r).
+func copyTree(source, destination string) error {
+	info, err := os.Stat(source)
+	if err != nil {
+		return err
+	}
+	if info.IsDir() {
+		return os.CopyFS(destination, os.DirFS(source))
+	}
+	data, err := os.ReadFile(source)
+	if err != nil {
+		return err
+	}
+	return os.WriteFile(destination, data, 0o644)
+}
+
+func environWithout(names ...string) []string {
+	var env []string
+	for _, entry := range os.Environ() {
+		name, _, _ := strings.Cut(entry, "=")
+		if !slices.Contains(names, name) {
+			env = append(env, entry)
+		}
+	}
+	return env
+}
+
+func substituteValues(value map[string]any, substitute func(string) string) map[string]any {
+	result := make(map[string]any, len(value))
+	for key, val := range value {
+		switch typed := val.(type) {
+		case map[string]any:
+			result[key] = substituteValues(typed, substitute)
+		case string:
+			result[key] = substitute(typed)
+		default:
+			result[key] = val
+		}
+	}
+	return result
+}

--- a/go.mod
+++ b/go.mod
@@ -10,6 +10,7 @@ require (
 	github.com/spf13/cobra v1.10.2
 	github.com/stretchr/testify v1.11.1
 	golang.org/x/sync v0.21.0
+	gopkg.in/yaml.v3 v3.0.1
 )
 
 require (
@@ -22,5 +23,4 @@ require (
 	github.com/rogpeppe/go-internal v1.15.0 // indirect
 	github.com/spf13/pflag v1.0.9 // indirect
 	golang.org/x/sys v0.42.0 // indirect
-	gopkg.in/yaml.v3 v3.0.1 // indirect
 )

--- a/internal/app/app.go
+++ b/internal/app/app.go
@@ -9,6 +9,7 @@ import (
 	"log/slog"
 	"os"
 	"path/filepath"
+	"strings"
 	"sync"
 	"time"
 
@@ -116,6 +117,10 @@ func New(opts Options) (*App, error) {
 }
 
 func loadConfig(p platform.Platform, explicitPath string) (config.Config, error) {
+	if err := precheckConfig(p, explicitPath); err != nil {
+		return config.Config{}, err
+	}
+
 	path := explicitPath
 	if path == "" {
 		path = os.Getenv("FACTORIX_CONFIG")
@@ -134,6 +139,56 @@ func loadConfig(p platform.Platform, explicitPath string) (config.Config, error)
 		return config.Default(), nil
 	}
 	return config.LoadFile(defaultPath)
+}
+
+// PrecheckConfig validates configuration existence without loading it: an
+// explicitly named file must exist, and a legacy Ruby-DSL configuration is
+// rejected. The CLI runs this on every command at parse time — Ruby loads
+// the configuration eagerly at boot, so even `version` fails on a broken
+// setup — while full parsing stays lazy in App construction.
+func PrecheckConfig(explicitPath string) error {
+	p, err := platform.Detect()
+	if err != nil {
+		return err
+	}
+	return precheckConfig(p, explicitPath)
+}
+
+func precheckConfig(p platform.Platform, explicitPath string) error {
+	path := explicitPath
+	if path == "" {
+		path = os.Getenv("FACTORIX_CONFIG")
+	}
+	if path != "" {
+		if _, err := os.Stat(path); err != nil {
+			return fmt.Errorf("Configuration file not found: %s", path)
+		}
+		if filepath.Ext(path) == ".rb" {
+			return legacyConfigError(path, strings.TrimSuffix(path, ".rb")+".toml")
+		}
+		return nil
+	}
+
+	defaultRuntime := platform.NewRuntime(p, platform.Overrides{})
+	defaultPath, err := defaultRuntime.FactorixConfigPath()
+	if err != nil {
+		return err
+	}
+	if _, err := os.Stat(defaultPath); err == nil {
+		return nil
+	}
+	legacyPath := strings.TrimSuffix(defaultPath, ".toml") + ".rb"
+	if _, err := os.Stat(legacyPath); err == nil {
+		return legacyConfigError(legacyPath, defaultPath)
+	}
+	return nil
+}
+
+// legacyConfigError rejects a pre-TOML Ruby-DSL configuration. Unlike the
+// Ruby CLI, the Go binary cannot evaluate the script to render the
+// equivalent TOML, so it only points at the migration.
+func legacyConfigError(legacyPath, target string) error {
+	return fmt.Errorf("Factorix now uses TOML for configuration and no longer reads %s.\nMigrate the settings to %s (the Ruby factorix gem renders the equivalent TOML), then remove the legacy file", legacyPath, target)
 }
 
 // Close releases resources (the log file).

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -2,6 +2,8 @@
 package cli
 
 import (
+	"errors"
+	"fmt"
 	"sync"
 
 	"github.com/spf13/cobra"
@@ -68,11 +70,18 @@ func NewRootCommand() (root *cobra.Command, reportError func(error)) {
 		// command; checking only at app construction would let commands that
 		// never build the app (like version) accept invalid values silently.
 		PersistentPreRunE: func(*cobra.Command, []string) error {
-			if c.logLevel == "" {
-				return nil
+			if c.logLevel != "" {
+				if _, err := logging.ParseLevel(c.logLevel); err != nil {
+					return bootError{err}
+				}
 			}
-			_, err := logging.ParseLevel(c.logLevel)
-			return err
+			// Ruby loads the configuration eagerly at boot, so even commands
+			// that never use it (like version) fail on a broken setup; the
+			// precheck reproduces that without forcing app construction.
+			if err := app.PrecheckConfig(c.configPath); err != nil {
+				return bootError{err}
+			}
+			return nil
 		},
 		PersistentPostRun: func(*cobra.Command, []string) {
 			c.Close()
@@ -96,6 +105,13 @@ func NewRootCommand() (root *cobra.Command, reportError func(error)) {
 	)
 
 	reportError = func(err error) {
+		// Boot errors happen before command execution; Ruby reports them
+		// with warn — plain text on stderr, regardless of --quiet.
+		var boot bootError
+		if errors.As(err, &boot) {
+			fmt.Fprintln(root.ErrOrStderr(), "Error: "+err.Error())
+			return
+		}
 		if c.quiet {
 			return
 		}
@@ -104,12 +120,21 @@ func NewRootCommand() (root *cobra.Command, reportError func(error)) {
 	return root, reportError
 }
 
+// bootError marks a failure during CLI boot (flag validation, configuration
+// precheck) as opposed to command execution; it changes where the error is
+// reported.
+type bootError struct{ err error }
+
+func (b bootError) Error() string { return b.err.Error() }
+func (b bootError) Unwrap() error { return b.err }
+
 func newVersionCommand() *cobra.Command {
 	return &cobra.Command{
 		Use:   "version",
 		Short: "Display Factorix version",
 		RunE: func(cmd *cobra.Command, _ []string) error {
-			cmd.Println(Version)
+			// Not cmd.Println, which writes to stderr by cobra default.
+			fmt.Fprintln(cmd.OutOrStdout(), Version)
 			return nil
 		},
 	}

--- a/internal/cli/cli_test.go
+++ b/internal/cli/cli_test.go
@@ -13,6 +13,21 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
+// TestMain isolates every test from the developer's real configuration:
+// commands run a config precheck at boot, so even sandbox-less tests (e.g.
+// version, blueprint) would otherwise see a real ~/.config/factorix.
+func TestMain(m *testing.M) {
+	dir, err := os.MkdirTemp("", "factorix-cli-test")
+	if err != nil {
+		panic(err)
+	}
+	os.Setenv("XDG_CONFIG_HOME", dir)
+	os.Unsetenv("FACTORIX_CONFIG")
+	code := m.Run()
+	os.RemoveAll(dir)
+	os.Exit(code)
+}
+
 // sandbox builds the directory layout the e2e cases use and points
 // FACTORIX_CONFIG at a config selecting it.
 type sandbox struct {
@@ -154,13 +169,15 @@ func runCLI(t *testing.T, args ...string) (string, error) {
 }
 
 // runCLIWithStdin is runCLI with an explicit stdin, for commands that
-// prompt for confirmation.
+// prompt for confirmation. stdout and stderr are captured separately —
+// only stdout is returned, matching what the e2e contract compares (an
+// earlier merged buffer masked cmd.Println writing to stderr).
 func runCLIWithStdin(t *testing.T, stdin string, args ...string) (string, error) {
 	t.Helper()
 	root, reportError := NewRootCommand()
-	var out bytes.Buffer
+	var out, errOut bytes.Buffer
 	root.SetOut(&out)
-	root.SetErr(&out)
+	root.SetErr(&errOut)
 	root.SetIn(strings.NewReader(stdin))
 	root.SetArgs(args)
 	err := root.Execute()

--- a/mise.toml
+++ b/mise.toml
@@ -10,6 +10,12 @@ _.file = ".env"
 description = "Run Go tests"
 run = "go test ./..."
 
+[tasks.e2e]
+description = "Run the e2e cases against a freshly built binary"
+# -count=1 because the driver builds the binary from source at run time,
+# which the go test cache cannot see.
+run = "go test -count=1 ./e2e/"
+
 [tasks.vet]
 description = "Run go vet"
 run = "go vet ./..."
@@ -27,5 +33,5 @@ description = "Build the factorix binary"
 run = "go build -o factorix ./cmd/factorix"
 
 [tasks.default]
-description = "Run all Go checks (test + vet + fmt-check)"
-depends = ["test", "vet", "fmt-check"]
+description = "Run all Go checks (test + e2e + vet + fmt-check)"
+depends = ["test", "e2e", "vet", "fmt-check"]


### PR DESCRIPTION
## Summary
Add the Go driver for the language-neutral e2e suite (Phase 11a). All 13 cases pass against the Go binary — after fixing the two contract violations the driver caught on its first run.

## Changes
- `e2e/driver_test.go` implements the execution contract from `e2e/README.md` (sandbox, file placement, TOML config rendering, XDG/NO_COLOR env, stdout + exit-status assertions); the binary is built once in `TestMain` with a semver injected via ldflags. `mise run e2e` runs it with `-count=1` since the go test cache cannot see the binary rebuilt from source
- **Fix: `version` printed to stderr** — cobra's `cmd.Println` writes to stderr by default; unit tests missed it because they merged both streams into one buffer (now captured separately)
- **Fix: legacy `config.rb` was silently ignored** — a boot-time config precheck (existence + legacy detection, no parsing) now runs for every command via `PersistentPreRunE`, preserving lazy app construction; boot errors go to stderr in Ruby's plain `warn` format, exit 1. Unlike Ruby, the Go binary cannot evaluate the Ruby DSL to render the equivalent TOML, so the message points at the migration instead
- CLI unit tests run hermetically via `TestMain` (the precheck would otherwise see the developer's real `~/.config/factorix`)

## Test Plan
- `mise run default` (now test + e2e + vet + fmt-check) passes; e2e 13/13 against the Go binary
- Ruby suite untouched (no case changes); CI runs the e2e cases via `go test ./...`

Next: add an e2e case pinning the `cache evict` bug (Go hashes storage keys with SHA-256 while Ruby uses SHA-1, so Ruby-written entries are listed but never deleted), then fix the hash.
