### PR TITLE
:bug: Derive cache storage paths with SHA-1, matching Ruby

### DIFF
--- a/e2e/cases/cache/evict-all/case.yaml
+++ b/e2e/cases/cache/evict-all/case.yaml
@@ -1,0 +1,12 @@
+# The entry sits at the SHA-1-derived storage path of "e2e-test-key"
+# (89022852...), the layout the Ruby implementation writes; evicting it
+# proves the implementation under test resolves logical keys to the same
+# paths it enumerates.
+command: [cache, evict, --all]
+files:
+  - {from: files/entry, to: xdg-cache/factorix/download/89/022852f8c325075560d7bc1e7d907ca0de7009}
+  - {from: files/entry.metadata, to: xdg-cache/factorix/download/89/022852f8c325075560d7bc1e7d907ca0de7009.metadata}
+expect:
+  status: 0
+  stdout:
+    file: expected_stdout.txt

--- a/e2e/cases/cache/evict-all/expected_stdout.txt
+++ b/e2e/cases/cache/evict-all/expected_stdout.txt
@@ -1,0 +1,3 @@
+ℹ download :   1 entries removed (14 B)
+ℹ api      :   0 entries removed (0 B)
+ℹ info_json:   0 entries removed (0 B)

--- a/e2e/cases/cache/evict-all/files/entry
+++ b/e2e/cases/cache/evict-all/files/entry
@@ -1,0 +1,1 @@
+cached-content

--- a/e2e/cases/cache/evict-all/files/entry.metadata
+++ b/e2e/cases/cache/evict-all/files/entry.metadata
@@ -1,0 +1,1 @@
+{"logical_key":"e2e-test-key"}

--- a/internal/cache/filesystem.go
+++ b/internal/cache/filesystem.go
@@ -4,7 +4,7 @@ import (
 	"bytes"
 	"compress/zlib"
 	"context"
-	"crypto/sha256"
+	"crypto/sha1"
 	"encoding/hex"
 	"encoding/json"
 	"io"
@@ -66,8 +66,11 @@ func NewFileSystem(dir string, opts FileSystemOptions) (*FileSystem, error) {
 	}, nil
 }
 
+// dataPath derives the storage path with SHA-1 (not for security — it only
+// spreads keys over directories) so entries written by the Ruby
+// implementation resolve to the same locations.
 func (c *FileSystem) dataPath(key string) string {
-	sum := sha256.Sum256([]byte(key))
+	sum := sha1.Sum([]byte(key))
 	storageKey := hex.EncodeToString(sum[:])
 	return filepath.Join(c.dir, storageKey[:2], storageKey[2:])
 }


### PR DESCRIPTION
## Summary
Fix the reported `cache evict` no-op: Go derived cache storage paths with SHA-256 while Ruby uses SHA-1, so Ruby-written entries were listed by `stat`/`Entries()` (which walk the tree) but never matched by `Delete()` — and the two implementations never shared cache entries at all.

## Changes
- `internal/cache`: storage paths now derive from SHA-1, matching Ruby. The hash only spreads keys across directories (not security-relevant); the SHA-1 used for download verification is a separate matter dictated by the portal API, which publishes only a `sha1` digest per release
- New e2e case `cache/evict-all` seeds an entry at the SHA-1 path exactly as Ruby writes it and requires `cache evict --all` to remove it — green on Ruby, red on Go before the fix (the e2e-first workflow that pinned this bug)

## Test Plan
- `mise run default` passes (e2e now 14 cases, both drivers green — Ruby 14/14 confirmed)
- Cross-implementation verification with real binaries: Ruby populated the api cache via `mod show`; Go `stat` listed it, Go `mod show` shared it, and `cache evict api --all` removed it with `stat` returning to 0/0
