### PR TITLE
:wrench: Add golangci-lint to CI (Phase 11d)

### DIFF
--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -20,5 +20,9 @@ jobs:
         run: go build ./...
       - name: Vet
         run: go vet ./...
+      - name: Lint
+        uses: golangci/golangci-lint-action@v7
+        with:
+          version: v2.12.2
       - name: Test
         run: go test ./...

--- a/.golangci.yml
+++ b/.golangci.yml
@@ -1,0 +1,49 @@
+version: "2"
+
+linters:
+  default: standard
+  enable:
+    - staticcheck
+    - unconvert
+    - unparam
+  settings:
+    errcheck:
+      exclude-functions:
+        # Errors from Close on read-only/already-flushed resources, from
+        # best-effort temp-file cleanup, and from writes to the process's
+        # own stdout/stderr are not actionable.
+        - (io.Closer).Close
+        - (*os.File).Close
+        - (net.Conn).Close
+        - (*archive/zip.ReadCloser).Close
+        - (*github.com/sakuro/factorix/internal/rcon.Client).Close
+        - os.Remove
+        - os.RemoveAll
+        - fmt.Fprintln
+        - fmt.Fprintf
+        - fmt.Fprint
+        - (*github.com/fatih/color.Color).Fprintln
+    staticcheck:
+      checks:
+        - all
+        # Error strings deliberately match Ruby's user-facing messages
+        # verbatim (capitalization, trailing punctuation) for CLI parity.
+        - -ST1005
+
+  exclusions:
+    rules:
+      # Test helpers commonly take unused parameters (t *testing.T kept for
+      # signature consistency, sandbox setup helpers) — not worth annotating.
+      - path: _test\.go
+        linters:
+          - unparam
+      # Test-only bookkeeping (env var setup/teardown, temp dir cleanup,
+      # canned httptest responses) — assertions catch real failures here,
+      # not the return value of these calls.
+      - path: _test\.go
+        linters:
+          - errcheck
+
+formatters:
+  enable:
+    - gofmt

--- a/doc/go-migration-roadmap.md
+++ b/doc/go-migration-roadmap.md
@@ -472,7 +472,7 @@ than one pass over the full list below.
 - [x] Reuse the Ruby fixtures (`spec/fixtures`: `test-save.zip`, mod-list, changelog samples)
       as golden files for unit tests
 - [ ] Integration tests for CLI commands using `httptest` for portal API
-- [ ] `staticcheck` / `golangci-lint` in CI
+- [x] `staticcheck` / `golangci-lint` in CI
 - [ ] `.goreleaser.yaml`
   - Targets: `linux/amd64`, `linux/arm64`, `darwin/amd64`, `darwin/arm64`, `windows/amd64`
   - GitHub Releases with checksums

--- a/internal/api/management.go
+++ b/internal/api/management.go
@@ -25,10 +25,9 @@ type Uploader interface {
 }
 
 // Metadata fields accepted by FinishUpload (init_publish scenario only).
+// EditDetails needs no equivalent: its metadata is the typed EditMetadata
+// struct, so the compiler rejects unknown fields instead of a runtime check.
 var allowedUploadMetadata = []string{"description", "category", "license", "source_url"}
-
-// Metadata fields accepted by EditDetails.
-var allowedEditMetadata = []string{"description", "summary", "title", "category", "tags", "license", "homepage", "source_url", "faq", "deprecated"}
 
 // MODManagementAPI performs portal operations that require an API key:
 // publishing, uploading releases, editing details and images.

--- a/internal/cli/mod_download.go
+++ b/internal/cli/mod_download.go
@@ -183,12 +183,14 @@ func resolveDownloadDependencies(ctx context.Context, application *app.App, init
 		results, err := fetchMODInfoConcurrently(ctx, jobs, specs, func(ctx context.Context, spec modSpec) (fetchedMODInfo, error) {
 			info, err := portalAPI.GetMODFull(ctx, spec.MOD.Name)
 			if err != nil {
-				return fetchedMODInfo{}, warnAndSkip(application, spec.MOD.Name, err)
+				warnAndSkip(application, spec.MOD.Name, err)
+				return fetchedMODInfo{}, nil
 			}
 			i := slices.IndexFunc(newDeps, func(d requiredDependency) bool { return d.name == spec.MOD.Name })
 			release := findCompatibleRelease(info, newDeps[i].requirement)
 			if release == nil {
-				return fetchedMODInfo{}, warnAndSkip(application, spec.MOD.Name, errors.New("no compatible release found"))
+				warnAndSkip(application, spec.MOD.Name, errors.New("no compatible release found"))
+				return fetchedMODInfo{}, nil
 			}
 			return fetchedMODInfo{MOD: spec.MOD, MODInfo: info, Release: *release}, nil
 		})
@@ -208,11 +210,10 @@ func resolveDownloadDependencies(ctx context.Context, application *app.App, init
 	return slices.Collect(maps.Values(known)), nil
 }
 
-// warnAndSkip logs and returns nil so the caller treats the dependency as
-// skippable rather than fatal.
-func warnAndSkip(application *app.App, modName string, cause error) error {
+// warnAndSkip logs a dependency the caller treats as skippable rather than
+// fatal.
+func warnAndSkip(application *app.App, modName string, cause error) {
 	application.Logger.Warn("Skipping dependency", "mod", modName, "reason", cause)
-	return nil
 }
 
 func collectNewDependencies(batch []string, known map[string]fetchedMODInfo, processed map[string]bool) []requiredDependency {

--- a/internal/cli/mod_list.go
+++ b/internal/cli/mod_list.go
@@ -108,7 +108,7 @@ func newMODListCommand(c *cli) *cobra.Command {
 			mods := buildListedMODs(state)
 			totalCount := len(mods)
 
-			mods, err = applyListFilters(cmd.Context(), c, application, mods, filters)
+			mods, err = applyListFilters(cmd.Context(), application, mods, filters)
 			if err != nil {
 				return err
 			}
@@ -198,7 +198,7 @@ func buildListedMODs(state *modState) []*listedMOD {
 	return mods
 }
 
-func applyListFilters(ctx context.Context, c *cli, application *app.App, mods []*listedMOD, filters listFilters) ([]*listedMOD, error) {
+func applyListFilters(ctx context.Context, application *app.App, mods []*listedMOD, filters listFilters) ([]*listedMOD, error) {
 	filter := func(keep func(*listedMOD) bool) []*listedMOD {
 		var result []*listedMOD
 		for _, m := range mods {

--- a/internal/platform/macos.go
+++ b/internal/platform/macos.go
@@ -36,8 +36,8 @@ func (MacOS) DefaultStateHomeDir() (string, error) {
 	return homePath(".local", "state")
 }
 
-// Logs follow the macOS convention (~/Library/Logs), not the XDG state
-// directory.
+// DefaultFactorixLogPath follows the macOS convention (~/Library/Logs), not
+// the XDG state directory.
 func (MacOS) DefaultFactorixLogPath() (string, error) {
 	dir, err := homePath("Library", "Logs")
 	if err != nil {

--- a/internal/save/save_file.go
+++ b/internal/save/save_file.go
@@ -96,6 +96,13 @@ type headerReader struct {
 	err error
 }
 
+// u8, u32, and boolean currently have no call site that keeps their
+// result — the header fields they read are skipped, not interpreted — but
+// they return a value to stay symmetric with u16/gameVersion/modVersion/str,
+// which do. Splitting the API into "value" and "skip" variants would read
+// worse than the occasional discarded return.
+//
+//nolint:unparam
 func (h *headerReader) u8() uint8 {
 	var v uint8
 	if h.err == nil {
@@ -112,6 +119,7 @@ func (h *headerReader) u16() uint16 {
 	return v
 }
 
+//nolint:unparam // see u8
 func (h *headerReader) u32() uint32 {
 	var v uint32
 	if h.err == nil {
@@ -128,6 +136,7 @@ func (h *headerReader) optimU32() uint32 {
 	return v
 }
 
+//nolint:unparam // see u8
 func (h *headerReader) boolean() bool {
 	var v bool
 	if h.err == nil {

--- a/mise.toml
+++ b/mise.toml
@@ -1,6 +1,7 @@
 [tools]
 go = "1.26"
 ruby = "3.3"
+golangci-lint = "2"
 
 [env]
 _.path = ["bin", "exe"]
@@ -20,6 +21,10 @@ run = "go test -count=1 ./e2e/"
 description = "Run go vet"
 run = "go vet ./..."
 
+[tasks.lint]
+description = "Run golangci-lint (includes staticcheck)"
+run = "golangci-lint run ./..."
+
 [tasks.fmt-check]
 description = "Check gofmt formatting"
 run = "test -z \"$(gofmt -l .)\""
@@ -33,5 +38,5 @@ description = "Build the factorix binary"
 run = "go build -o factorix ./cmd/factorix"
 
 [tasks.default]
-description = "Run all Go checks (test + e2e + vet + fmt-check)"
-depends = ["test", "e2e", "vet", "fmt-check"]
+description = "Run all Go checks (test + e2e + vet + lint + fmt-check)"
+depends = ["test", "e2e", "vet", "lint", "fmt-check"]


### PR DESCRIPTION
## Summary
Add golangci-lint to CI (Phase 11d). It bundles staticcheck plus errcheck, unused, unconvert, and unparam, so this covers the roadmap's "staticcheck / golangci-lint" item with a single tool.

## Changes
- `.golangci.yml` (v2 config), a mise tool entry + `lint` task wired into `default`, and a CI step (`golangci-lint-action`, pinned to `v2.12.2` to match mise)
- Two deliberate config exclusions, not behavior changes:
  - `staticcheck` disables `ST1005` (capitalized/punctuated error strings) — it conflicts with the project's established convention of matching Ruby's user-facing error messages verbatim
  - `errcheck` ignores `Close` on read-only resources, best-effort temp-file cleanup (`os.Remove`/`os.RemoveAll`), and stdout/stderr writes (none of these are actionable in this codebase), plus everything in `_test.go` (test assertions already catch real setup failures)
- Fixed the handful of findings that were real bugs or dead code, not style:
  - `applyListFilters` dropped an unused `*cli` parameter
  - `warnAndSkip` returned an always-nil `error`, which was misleading at call sites — now `void`, with callers returning `nil` explicitly
  - `allowedEditMetadata` was fully dead: `EditDetails` moved to the typed `EditMetadata` struct, which the compiler already validates, so the old runtime key-list has no caller
  - a doc comment on `MacOS.DefaultFactorixLogPath` didn't start with the identifier
  - `headerReader.u8`/`u32`/`boolean` keep an unused-by-every-caller return value on purpose, for symmetry with the sibling field readers whose value callers do use — annotated with `//nolint:unparam` explaining why, rather than breaking the reader's uniform API

## Test Plan
- `mise run default` (test + e2e + vet + lint + fmt-check) passes; `golangci-lint run ./...` reports 0 issues
