### PR TITLE
:sparkles: Complete goreleaser setup for multi-platform releases (Phase 11e)

### DIFF
--- a/.github/workflows/go-release.yml
+++ b/.github/workflows/go-release.yml
@@ -1,0 +1,35 @@
+name: Go Release
+
+# Builds and publishes factorix binaries with goreleaser when a vX.Y.Z tag
+# is pushed. Not expected to fire until the main-branch swap to Go (see
+# doc/go-migration-roadmap.md) — validated in the meantime by the
+# goreleaser snapshot build in go.yml, which never pushes a tag.
+
+on:
+  push:
+    tags:
+      - "v*"
+
+permissions:
+  contents: write
+
+jobs:
+  release:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+        with:
+          fetch-depth: 0
+      - uses: actions/setup-go@v5
+        with:
+          go-version-file: go.mod
+      - name: Extract changelog for this version
+        run: |
+          VERSION=${GITHUB_REF_NAME#v}
+          sed -e "1,/^## \[$VERSION\] /d" CHANGELOG.md | sed -e '/^## \[/,$d' > release_notes.md
+      - uses: goreleaser/goreleaser-action@v6
+        with:
+          version: v2.17.0
+          args: release --clean --release-notes=release_notes.md
+        env:
+          GITHUB_TOKEN: ${{ secrets.GITHUB_TOKEN }}

--- a/.github/workflows/go.yml
+++ b/.github/workflows/go.yml
@@ -26,3 +26,13 @@ jobs:
           version: v2.12.2
       - name: Test
         run: go test ./...
+      - name: Validate goreleaser config
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: v2.17.0
+          args: check
+      - name: goreleaser snapshot build
+        uses: goreleaser/goreleaser-action@v6
+        with:
+          version: v2.17.0
+          args: release --snapshot --clean --skip=publish

--- a/.goreleaser.yaml
+++ b/.goreleaser.yaml
@@ -1,5 +1,15 @@
 version: 2
 
+# The GitHub Release itself is cut by the go-release CI workflow after a v*
+# tag is pushed — expected only after the main-branch swap to Go (see
+# doc/go-migration-roadmap.md), not during go-rewrite development. Until
+# then, validate this config with `mise run release-snapshot`, which never
+# touches GitHub or requires a tag.
+
+before:
+  hooks:
+    - go mod tidy
+
 builds:
   - main: ./cmd/factorix
     binary: factorix
@@ -15,6 +25,7 @@ builds:
       - amd64
       - arm64
     ignore:
+      # Windows on arm64 is not a supported Factorio platform.
       - goos: windows
         goarch: arm64
 
@@ -25,6 +36,18 @@ archives:
       - goos: windows
         formats:
           - zip
+    files:
+      - LICENSE.txt
+      - README.md
+      - doc/factorix.1
 
 checksum:
   name_template: checksums.txt
+
+changelog:
+  disable: true # CHANGELOG.md is maintained by hand; goreleaser should not regenerate it.
+
+release:
+  github:
+    owner: sakuro
+    name: factorix

--- a/doc/go-migration-roadmap.md
+++ b/doc/go-migration-roadmap.md
@@ -473,9 +473,11 @@ than one pass over the full list below.
       as golden files for unit tests
 - [ ] Integration tests for CLI commands using `httptest` for portal API
 - [x] `staticcheck` / `golangci-lint` in CI
-- [ ] `.goreleaser.yaml`
+- [x] `.goreleaser.yaml`
   - Targets: `linux/amd64`, `linux/arm64`, `darwin/amd64`, `darwin/arm64`, `windows/amd64`
-  - GitHub Releases with checksums
+  - GitHub Releases with checksums (`.github/workflows/go-release.yml`, fires
+    on a `v*` tag push — inert until the main swap; validated meanwhile by
+    a snapshot build in `go.yml`)
 - [ ] Swap `main` to `go-rewrite`; remove Ruby sources and Ruby CI
   (history and the `ruby` branch retain them); update README and docs; tag `v1.0.0`
 

--- a/mise.toml
+++ b/mise.toml
@@ -2,6 +2,7 @@
 go = "1.26"
 ruby = "3.3"
 golangci-lint = "2"
+goreleaser = "2"
 
 [env]
 _.path = ["bin", "exe"]
@@ -36,6 +37,10 @@ run = "gofmt -w ."
 [tasks.build]
 description = "Build the factorix binary"
 run = "go build -o factorix ./cmd/factorix"
+
+[tasks.release-snapshot]
+description = "Build release archives for all platforms without publishing"
+run = "goreleaser release --snapshot --clean --skip=publish"
 
 [tasks.default]
 description = "Run all Go checks (test + e2e + vet + lint + fmt-check)"


### PR DESCRIPTION
## Summary
Complete the goreleaser setup for multi-platform releases (Phase 11e), building on the minimal `.goreleaser.yaml` scaffolded in Phase 0.

## Changes
- `.goreleaser.yaml`: archives now bundle `LICENSE.txt`, `README.md`, `doc/factorix.1`; added `release.github`; disabled goreleaser's own commit-log changelog generation (`CHANGELOG.md` is hand-maintained with user-facing descriptions — a mechanical commit list would duplicate and dilute it, per discussion)
- Targets as scoped in the roadmap: `linux/amd64`, `linux/arm64`, `darwin/amd64`, `darwin/arm64`, `windows/amd64` (`windows/arm64` excluded — not a supported Factorio platform); `CGO_ENABLED=0` throughout (verified no cgo imports anywhere in the module)
- `.github/workflows/go-release.yml` fires on a `v*` tag push, extracts the matching `CHANGELOG.md` section for release notes (mirroring Ruby's `release-publish.yml`), and runs `goreleaser release`. Inert until the main-branch swap — no such tag is expected on `go-rewrite` beforehand
- `go.yml` validates the config (`goreleaser check`) and runs a full snapshot build (all 5 targets, `--skip=publish`) on every push/PR, so breakage surfaces immediately rather than at actual release time
- mise gains `goreleaser` as a tool and a `release-snapshot` task for local validation

## Test Plan
- `mise run default` passes
- `mise run release-snapshot` locally builds all 5 targets, embeds the version via ldflags, and produces correctly named archives (`.zip` for Windows, `.tar.gz` elsewhere) with `LICENSE.txt`/`README.md`/the man page and a `checksums.txt`; spot-checked the darwin/arm64 binary (`version`, `man`) and the Windows zip's `factorix.exe` naming
