### PR TITLE
:white_check_mark: Add httptest integration tests for Portal-backed commands

### DIFF
--- a/internal/api/portal.go
+++ b/internal/api/portal.go
@@ -128,7 +128,10 @@ func (a *MODPortalAPI) GetMOD(ctx context.Context, name string) (*MODInfo, error
 }
 
 // GetMODFull retrieves full information for a MOD, including the detail
-// fields.
+// fields and the full Releases list. Confirmed against the live API:
+// MODInfo.LatestRelease is nil in this response (the Portal API wiki never
+// documents this, or how "latest" would even be chosen) — callers that
+// need a "latest" release must derive it from Releases themselves.
 func (a *MODPortalAPI) GetMODFull(ctx context.Context, name string) (*MODInfo, error) {
 	return a.getMOD(ctx, name, a.modFullURL(name))
 }

--- a/internal/cli/download_support.go
+++ b/internal/cli/download_support.go
@@ -41,7 +41,11 @@ func parseMODSpec(spec string) (modSpec, error) {
 }
 
 // findRelease returns the release matching spec: the most recently released
-// one for "latest", or the exact version otherwise.
+// one for "latest", or the exact version otherwise. "Latest" is computed
+// from Releases rather than trusting MODInfo.LatestRelease — the Portal API
+// wiki never specifies how that field is chosen (highest version? most
+// recent? filtered by Factorio-version compatibility?), so relying on it
+// would make "latest" mean something undocumented and possibly unstable.
 func findRelease(info *api.MODInfo, spec modSpec) *api.Release {
 	if spec.Latest {
 		return latestByReleaseDate(info.Releases)

--- a/internal/cli/mod_sync.go
+++ b/internal/cli/mod_sync.go
@@ -272,8 +272,14 @@ func planSyncInstallation(ctx context.Context, application *app.App, graph *depe
 }
 
 // findSyncRelease picks the exact save version in strict mode; otherwise
-// the portal's latest release, falling back to the highest version (as in
-// Ruby's Portal#upload — not release date, unlike mod download).
+// the portal's latest_release, falling back to the highest version. This
+// mirrors Ruby's mod/sync.rb#fetch_single_mod_info exactly, including its
+// inconsistency with mod install/download (download_support.rb, via
+// findRelease): that path never trusts latest_release — its selection
+// method is undocumented by the Portal API wiki — and instead computes
+// "latest" itself from release dates. Sync keeps the Ruby behavior as-is
+// rather than "fixing" a cross-command inconsistency outside this task's
+// scope.
 func findSyncRelease(info *api.MODInfo, spec modSpec) *api.Release {
 	if !spec.Latest {
 		for i := range info.Releases {

--- a/internal/cli/portal_integration_test.go
+++ b/internal/cli/portal_integration_test.go
@@ -1,0 +1,143 @@
+package cli
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+// Integration tests driving CLI commands against an httptest stand-in for
+// the MOD Portal (see portal_mock_test.go), covering the seams that unit
+// tests miss: request construction, JSON decoding, and error mapping for
+// commands that actually talk to the portal.
+
+func TestMODShowAgainstMockPortal(t *testing.T) {
+	s := baseSandbox(t)
+	s.writeMODList(t, modListEntry{name: "base", enabled: true})
+	portal := newMockPortal(t, portalMOD{
+		Name: "some-mod", Title: "Some MOD", Owner: "alice", Summary: "A test mod",
+		// mod show hits the /full endpoint, which never carries
+		// latest_release (confirmed against the live API — see
+		// writeMOD); it always derives "latest" from Releases.
+		Releases: []portalRelease{{Version: "1.2.0", InfoJSON: portalInfoJSON{FactorioVersion: "2.0"}}},
+	})
+	portal.withPortal(t)
+
+	out, err := runCLI(t, "mod", "show", "some-mod")
+	require.NoError(t, err)
+	assert.Contains(t, out, "Some MOD")
+	assert.Contains(t, out, "1.2.0")
+	assert.Contains(t, out, "Not installed")
+}
+
+func TestMODShowJSONAgainstMockPortal(t *testing.T) {
+	s := baseSandbox(t)
+	s.writeMODList(t, modListEntry{name: "base", enabled: true})
+	portal := newMockPortal(t, portalMOD{
+		Name: "some-mod", Title: "Some MOD", Owner: "alice",
+		Releases: []portalRelease{{Version: "1.2.0"}},
+	})
+	portal.withPortal(t)
+
+	out, err := runCLI(t, "mod", "show", "some-mod", "--json")
+	require.NoError(t, err)
+	assert.Contains(t, out, `"latest_version": "1.2.0"`)
+	assert.Contains(t, out, `"status": "not_installed"`)
+}
+
+func TestMODShowNotOnPortal(t *testing.T) {
+	baseSandbox(t)
+	portal := newMockPortal(t) // no mods registered
+	portal.withPortal(t)
+
+	_, err := runCLI(t, "mod", "show", "missing-mod")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "MOD not found on portal")
+}
+
+func TestMODShowInstalledVersionAgainstMockPortal(t *testing.T) {
+	s := baseSandbox(t)
+	s.writeInstalledMOD(t, "some-mod", "1.0.0", nil)
+	s.writeMODList(t, modListEntry{name: "base", enabled: true}, modListEntry{name: "some-mod", enabled: true})
+	portal := newMockPortal(t, portalMOD{
+		Name: "some-mod", Title: "Some MOD", Owner: "alice",
+		Releases: []portalRelease{{Version: "2.0.0"}},
+	})
+	portal.withPortal(t)
+
+	out, err := runCLI(t, "mod", "show", "some-mod")
+	require.NoError(t, err)
+	assert.Contains(t, out, "Enabled")
+	assert.Contains(t, out, "1.0.0 (update available)")
+}
+
+func TestMODSearchAgainstMockPortal(t *testing.T) {
+	s := baseSandbox(t)
+	_ = s
+	portal := newMockPortal(t,
+		portalMOD{Name: "alpha-mod", Title: "Alpha", Owner: "alice", LatestRelease: &portalRelease{Version: "1.0.0"}},
+		portalMOD{Name: "beta-mod", Title: "Beta", Owner: "bob", LatestRelease: &portalRelease{Version: "2.0.0"}},
+	)
+	portal.withPortal(t)
+
+	out, err := runCLI(t, "mod", "search")
+	require.NoError(t, err)
+	assert.Contains(t, out, "alpha-mod")
+	assert.Contains(t, out, "beta-mod")
+	assert.Contains(t, out, "2 MOD(s) found")
+}
+
+func TestMODSearchJSONAgainstMockPortal(t *testing.T) {
+	baseSandbox(t)
+	portal := newMockPortal(t, portalMOD{Name: "alpha-mod", Title: "Alpha", Owner: "alice"})
+	portal.withPortal(t)
+
+	out, err := runCLI(t, "mod", "search", "--json")
+	require.NoError(t, err)
+	assert.Contains(t, out, `"name": "alpha-mod"`)
+}
+
+func TestMODInstallAgainstMockPortal(t *testing.T) {
+	s := baseSandbox(t)
+	s.writeMODList(t, modListEntry{name: "base", enabled: true})
+	release := portalRelease{
+		// SHA1 left blank: the downloader skips digest verification when
+		// it's empty, and the fixture content's real digest isn't worth
+		// wiring through here.
+		Version: "1.2.0", FileName: "some-mod_1.2.0.zip",
+		DownloadURL: "/download/some-mod_1.2.0.zip",
+		InfoJSON:    portalInfoJSON{FactorioVersion: "2.0"},
+	}
+	portal := newMockPortal(t, portalMOD{
+		Name: "some-mod", Title: "Some MOD", Owner: "alice",
+		// mod install hits /full, which never carries latest_release; it
+		// resolves "@latest" from Releases by release date.
+		Releases: []portalRelease{release},
+	})
+	portal.withPortal(t)
+
+	out, err := runCLI(t, "mod", "install", "some-mod", "-y")
+	require.NoError(t, err)
+	assert.Contains(t, out, "Installed 1 MOD(s)")
+
+	installedPath := filepath.Join(s.root, "factorio", "mods", "some-mod_1.2.0.zip")
+	assert.FileExists(t, installedPath)
+	assert.Equal(t, []string{"/download/some-mod_1.2.0.zip?token=test-token&username=test-user"}, portal.downloads)
+
+	states := s.readMODList(t)
+	assert.True(t, states["some-mod"])
+}
+
+func TestMODInstallNotOnPortal(t *testing.T) {
+	s := baseSandbox(t)
+	s.writeMODList(t, modListEntry{name: "base", enabled: true})
+	portal := newMockPortal(t)
+	portal.withPortal(t)
+	_ = s
+
+	_, err := runCLI(t, "mod", "install", "missing-mod", "-y")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "MOD not found on portal")
+}

--- a/internal/cli/portal_mock_test.go
+++ b/internal/cli/portal_mock_test.go
@@ -1,0 +1,150 @@
+package cli
+
+import (
+	"crypto/x509"
+	"encoding/json"
+	"net/http"
+	"net/http/httptest"
+	"strings"
+	"testing"
+
+	"github.com/sakuro/factorix/internal/httpx"
+)
+
+// portalMOD is a fixture MOD served by mockPortal. Handlers respond with
+// the same JSON at both the short (/api/mods/<name>) and full
+// (/api/mods/<name>/full) endpoints — real Factorix commands only need the
+// fields relevant to what they're testing.
+type portalMOD struct {
+	Name          string          `json:"name"`
+	Title         string          `json:"title"`
+	Owner         string          `json:"owner"`
+	Summary       string          `json:"summary,omitempty"`
+	Category      string          `json:"category,omitempty"`
+	LatestRelease *portalRelease  `json:"latest_release,omitempty"`
+	Releases      []portalRelease `json:"releases,omitempty"`
+}
+
+type portalRelease struct {
+	Version     string `json:"version"`
+	DownloadURL string `json:"download_url,omitempty"`
+	FileName    string `json:"file_name,omitempty"`
+	SHA1        string `json:"sha1,omitempty"`
+	// ReleasedAt defaults to a fixed timestamp (not omitted) since
+	// api.Release always decodes it as time.Time — an absent or empty
+	// value fails to parse, unlike the other fields here.
+	ReleasedAt string         `json:"released_at"`
+	InfoJSON   portalInfoJSON `json:"info_json"`
+}
+
+type portalInfoJSON struct {
+	FactorioVersion string   `json:"factorio_version"`
+	Dependencies    []string `json:"dependencies"`
+}
+
+// mockPortal is an httptest server standing in for mods.factorio.com. Its
+// URL must be set as FACTORIX_MODS_PORTAL_URL for a command under test to
+// reach it (see withPortal).
+type mockPortal struct {
+	server *httptest.Server
+	mods   map[string]portalMOD
+	// downloads records requested download paths (the part after
+	// BaseURL), so tests can assert what was fetched.
+	downloads []string
+	// fileContent is served for any /download/... path not in downloads.
+	fileContent []byte
+}
+
+func newMockPortal(t *testing.T, mods ...portalMOD) *mockPortal {
+	t.Helper()
+	p := &mockPortal{mods: map[string]portalMOD{}, fileContent: []byte("fake-mod-zip-content")}
+	for _, m := range mods {
+		fillReleaseDefaults(&m)
+		p.mods[m.Name] = m
+	}
+	p.server = httptest.NewTLSServer(http.HandlerFunc(p.handle))
+	t.Cleanup(p.server.Close)
+	return p
+}
+
+// fillReleaseDefaults sets ReleasedAt on the MOD's releases when the
+// fixture left it blank, since api.Release requires a parseable
+// timestamp regardless of whether the test cares about it.
+func fillReleaseDefaults(m *portalMOD) {
+	const defaultReleasedAt = "2026-01-01T00:00:00Z"
+	if m.LatestRelease != nil && m.LatestRelease.ReleasedAt == "" {
+		m.LatestRelease.ReleasedAt = defaultReleasedAt
+	}
+	for i := range m.Releases {
+		if m.Releases[i].ReleasedAt == "" {
+			m.Releases[i].ReleasedAt = defaultReleasedAt
+		}
+	}
+}
+
+func (p *mockPortal) handle(w http.ResponseWriter, r *http.Request) {
+	switch {
+	case strings.HasPrefix(r.URL.Path, "/api/mods/") && strings.HasSuffix(r.URL.Path, "/full"):
+		name := strings.TrimSuffix(strings.TrimPrefix(r.URL.Path, "/api/mods/"), "/full")
+		p.writeMOD(w, name, true)
+	case strings.HasPrefix(r.URL.Path, "/api/mods/"):
+		name := strings.TrimPrefix(r.URL.Path, "/api/mods/")
+		p.writeMOD(w, name, false)
+	case r.URL.Path == "/api/mods":
+		p.writeList(w)
+	case strings.HasPrefix(r.URL.Path, "/download/"):
+		p.downloads = append(p.downloads, r.URL.Path+"?"+r.URL.RawQuery)
+		w.Header().Set("Content-Type", "application/octet-stream")
+		_, _ = w.Write(p.fileContent)
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+// writeMOD serves a MOD's info. The real Portal's /full endpoint carries
+// the full Releases list but never latest_release (confirmed against the
+// live API) — it would be redundant, since the caller can derive "latest"
+// from Releases itself. Only the short endpoint and the /api/mods list
+// endpoint (without namelist) include latest_release.
+func (p *mockPortal) writeMOD(w http.ResponseWriter, name string, full bool) {
+	m, ok := p.mods[name]
+	if !ok {
+		w.WriteHeader(http.StatusNotFound)
+		_ = json.NewEncoder(w).Encode(map[string]string{"message": "MOD not found"})
+		return
+	}
+	if full {
+		m.LatestRelease = nil
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(m)
+}
+
+func (p *mockPortal) writeList(w http.ResponseWriter) {
+	results := make([]portalMOD, 0, len(p.mods))
+	for _, m := range p.mods {
+		results = append(results, m)
+	}
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(map[string]any{
+		"pagination": map[string]int{"count": len(results), "page": 1, "page_count": 1, "page_size": len(results)},
+		"results":    results,
+	})
+}
+
+// withPortal points FACTORIX_MODS_PORTAL_URL at the mock for the duration
+// of the test, and makes commands trust its self-signed certificate (real
+// download/portal requests are enforced HTTPS-only) and authenticate
+// downloads with fake, valid-looking credentials.
+func (p *mockPortal) withPortal(t *testing.T) {
+	t.Helper()
+	t.Setenv("FACTORIX_MODS_PORTAL_URL", p.server.URL)
+	t.Setenv("FACTORIO_USERNAME", "test-user")
+	t.Setenv("FACTORIO_TOKEN", "test-token")
+
+	pool := x509.NewCertPool()
+	pool.AddCert(p.server.Certificate())
+	original := httpx.TestRootCAs
+	httpx.TestRootCAs = pool
+	t.Cleanup(func() { httpx.TestRootCAs = original })
+}

--- a/internal/httpx/client.go
+++ b/internal/httpx/client.go
@@ -5,6 +5,8 @@ package httpx
 
 import (
 	"context"
+	"crypto/tls"
+	"crypto/x509"
 	"encoding/json"
 	"io"
 	"log/slog"
@@ -14,6 +16,15 @@ import (
 	"strings"
 	"time"
 )
+
+// TestRootCAs is the trust store used for every transport NewBaseTransport
+// builds, instead of the OS certificate store, whenever it is non-nil. It
+// exists so integration tests can point commands at an httptest TLS server
+// without weakening HTTPS enforcement itself; production code never sets
+// it. RootCAs is an in-memory, cross-platform trust list, unlike the
+// SSL_CERT_FILE environment variable Go's system pool loader only honors on
+// some platforms (not macOS).
+var TestRootCAs *x509.CertPool
 
 const maxRedirects = 10
 
@@ -51,13 +62,17 @@ type Client struct {
 // wait for response headers. Go has no discrete write timeout — in-flight
 // requests are bounded by the request context instead.
 func NewBaseTransport(connectTimeout, readTimeout time.Duration) *http.Transport {
-	return &http.Transport{
+	t := &http.Transport{
 		Proxy:                 http.ProxyFromEnvironment,
 		DialContext:           (&net.Dialer{Timeout: connectTimeout}).DialContext,
 		TLSHandshakeTimeout:   connectTimeout,
 		ResponseHeaderTimeout: readTimeout,
 		ForceAttemptHTTP2:     true,
 	}
+	if TestRootCAs != nil {
+		t.TLSClientConfig = &tls.Config{RootCAs: TestRootCAs}
+	}
+	return t
 }
 
 // NewClient builds a Client.


### PR DESCRIPTION
## Summary
First slice of httptest-based integration tests for Portal-backed CLI commands, covering `mod show`, `mod search`, and `mod install`. Establishes the pattern; remaining commands (`download`/`update`/`uninstall`/`sync`/`upload`/`edit`/`image`) are follow-up work.

## Changes
- `internal/cli/portal_mock_test.go`: an `httptest.NewTLSServer` stand-in for mods.factorio.com, wired via `FACTORIX_MODS_PORTAL_URL`. Covers the seams unit tests miss — request construction, JSON decoding, error mapping — for commands that actually talk to the portal
- `httpx.TestRootCAs`: a test-only trust-store override for `NewBaseTransport`. Commands build their HTTP client deep inside `App` with no injection point, and httptest's self-signed cert needs an explicit `RootCAs` pool rather than `InsecureSkipVerify` (which disables all verification, not just trust of one known test cert). `SSL_CERT_FILE` was tried first, but Go's system pool loader ignores it on macOS, so it isn't portable across the dev machine and CI
- Building the mock surfaced a real finding, confirmed against the live API: `GetMODFull`'s response never carries `latest_release` (nil). The Portal API wiki's `latest_release` field belongs to the search/list endpoint's (`/api/mods`) Result Entry schema, not the single-MOD full endpoint's — `mockPortal` now omits it from `/full` responses to match, and doc comments on `GetMODFull`/`findRelease`/`findSyncRelease` explain why "latest" is always computed from `Releases` for install/show. Also fixed a stale comment on `findSyncRelease` that cited a nonexistent `Portal#upload`; the real source is `mod/sync.rb#fetch_single_mod_info`, whose `latest_release`-first behavior is a pre-existing Ruby-vs-Ruby inconsistency, kept as-is

## Test Plan
- `mise run default` (test + e2e + vet + lint + fmt-check) passes; 8 new integration tests cover successful show/search/install, "not on portal" errors, an installed-with-update-available display case, and JSON output for show/search
