### PR TITLE
:white_check_mark: Extend httptest integration tests to remaining Portal commands

### DIFF
--- a/doc/go-migration-roadmap.md
+++ b/doc/go-migration-roadmap.md
@@ -471,7 +471,9 @@ than one pass over the full list below.
       the branch is the Ruby-vs-Go parity check
 - [x] Reuse the Ruby fixtures (`spec/fixtures`: `test-save.zip`, mod-list, changelog samples)
       as golden files for unit tests
-- [ ] Integration tests for CLI commands using `httptest` for portal API
+- [x] Integration tests for CLI commands using `httptest` for portal API
+  (`internal/cli/portal_mock_test.go` + `portal_integration_*_test.go`;
+  covers show/search/install/download/update/upload/edit/image/sync)
 - [x] `staticcheck` / `golangci-lint` in CI
 - [x] `.goreleaser.yaml`
   - Targets: `linux/amd64`, `linux/arm64`, `darwin/amd64`, `darwin/arm64`, `windows/amd64`

--- a/internal/cli/portal_integration_download_test.go
+++ b/internal/cli/portal_integration_download_test.go
@@ -1,0 +1,96 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMODDownloadAgainstMockPortal(t *testing.T) {
+	s := baseSandbox(t)
+	dir := filepath.Join(s.root, "downloads")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	portal := newMockPortal(t, portalMOD{
+		Name: "some-mod", Title: "Some MOD", Owner: "alice",
+		Releases: []portalRelease{{
+			Version: "1.0.0", FileName: "some-mod_1.0.0.zip", DownloadURL: "/download/some-mod_1.0.0.zip",
+			InfoJSON: portalInfoJSON{FactorioVersion: "2.0"},
+		}},
+	})
+	portal.withPortal(t)
+
+	out, err := runCLI(t, "mod", "download", "some-mod", "-d", dir)
+	require.NoError(t, err)
+	assert.Contains(t, out, "Downloaded 1 MOD(s)")
+	assert.FileExists(t, filepath.Join(dir, "some-mod_1.0.0.zip"))
+}
+
+func TestMODDownloadRecursiveAgainstMockPortal(t *testing.T) {
+	s := baseSandbox(t)
+	dir := filepath.Join(s.root, "downloads")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	portal := newMockPortal(t,
+		portalMOD{
+			Name: "top-mod", Title: "Top MOD", Owner: "alice",
+			Releases: []portalRelease{{
+				Version: "1.0.0", FileName: "top-mod_1.0.0.zip", DownloadURL: "/download/top-mod_1.0.0.zip",
+				InfoJSON: portalInfoJSON{FactorioVersion: "2.0", Dependencies: []string{"base", "dep-mod >= 1.0.0"}},
+			}},
+		},
+		portalMOD{
+			Name: "dep-mod", Title: "Dep MOD", Owner: "bob",
+			Releases: []portalRelease{{
+				Version: "1.2.0", FileName: "dep-mod_1.2.0.zip", DownloadURL: "/download/dep-mod_1.2.0.zip",
+				InfoJSON: portalInfoJSON{FactorioVersion: "2.0"},
+			}},
+		},
+	)
+	portal.withPortal(t)
+
+	out, err := runCLI(t, "mod", "download", "top-mod", "-d", dir, "-r")
+	require.NoError(t, err)
+	assert.Contains(t, out, "Downloaded 2 MOD(s)")
+	assert.FileExists(t, filepath.Join(dir, "top-mod_1.0.0.zip"))
+	assert.FileExists(t, filepath.Join(dir, "dep-mod_1.2.0.zip"))
+}
+
+func TestMODDownloadRecursiveSkipsIncompatibleDependency(t *testing.T) {
+	s := baseSandbox(t)
+	dir := filepath.Join(s.root, "downloads")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	portal := newMockPortal(t,
+		portalMOD{
+			Name: "top-mod", Title: "Top MOD", Owner: "alice",
+			Releases: []portalRelease{{
+				Version: "1.0.0", FileName: "top-mod_1.0.0.zip", DownloadURL: "/download/top-mod_1.0.0.zip",
+				InfoJSON: portalInfoJSON{FactorioVersion: "2.0", Dependencies: []string{"dep-mod >= 9.0.0"}},
+			}},
+		},
+		portalMOD{
+			Name: "dep-mod", Title: "Dep MOD", Owner: "bob",
+			Releases: []portalRelease{{Version: "1.0.0", FileName: "dep-mod_1.0.0.zip", DownloadURL: "/download/dep-mod_1.0.0.zip"}},
+		},
+	)
+	portal.withPortal(t)
+
+	out, err := runCLI(t, "mod", "download", "top-mod", "-d", dir, "-r")
+	require.NoError(t, err)
+	assert.Contains(t, out, "Downloaded 1 MOD(s)")
+	assert.FileExists(t, filepath.Join(dir, "top-mod_1.0.0.zip"))
+	assert.NoFileExists(t, filepath.Join(dir, "dep-mod_1.0.0.zip"))
+}
+
+func TestMODDownloadNotOnPortal(t *testing.T) {
+	s := baseSandbox(t)
+	dir := filepath.Join(s.root, "downloads")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	portal := newMockPortal(t)
+	portal.withPortal(t)
+
+	_, err := runCLI(t, "mod", "download", "missing-mod", "-d", dir)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "MOD not found on portal")
+}

--- a/internal/cli/portal_integration_sync_test.go
+++ b/internal/cli/portal_integration_sync_test.go
@@ -1,0 +1,67 @@
+package cli
+
+import (
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sakuro/factorix/internal/save"
+)
+
+func TestMODSyncInstallsMissingMODAgainstMockPortal(t *testing.T) {
+	s, savePath := syncSandbox(t, []save.MODEntry{{Name: "some-mod", Version: mustVersion(t, "1.0.0")}}, nil)
+	s.writeMODList(t, modListEntry{name: "base", enabled: true})
+	portal := newMockPortal(t, portalMOD{
+		Name: "some-mod", Title: "Some MOD", Owner: "alice",
+		// mod sync (unlike install/download) trusts latest_release first
+		// (see findSyncRelease) — set both so the test exercises the real
+		// full-endpoint shape either way.
+		Releases: []portalRelease{{
+			Version: "1.0.0", FileName: "some-mod_1.0.0.zip", DownloadURL: "/download/some-mod_1.0.0.zip",
+		}},
+	})
+	portal.withPortal(t)
+
+	out, err := runCLI(t, "mod", "sync", savePath, "-y")
+	require.NoError(t, err)
+	assert.Contains(t, out, "Installed 1 MOD(s)")
+	assert.FileExists(t, filepath.Join(s.root, "factorio", "mods", "some-mod_1.0.0.zip"))
+
+	states := s.readMODList(t)
+	assert.True(t, states["some-mod"])
+}
+
+func TestMODSyncStrictVersionAgainstMockPortal(t *testing.T) {
+	s, savePath := syncSandbox(t, []save.MODEntry{{Name: "some-mod", Version: mustVersion(t, "1.0.0")}}, nil)
+	s.writeMODList(t, modListEntry{name: "base", enabled: true})
+	portal := newMockPortal(t, portalMOD{
+		Name: "some-mod", Title: "Some MOD", Owner: "alice",
+		Releases: []portalRelease{
+			{Version: "1.0.0", FileName: "some-mod_1.0.0.zip", DownloadURL: "/download/some-mod_1.0.0.zip"},
+			{Version: "2.0.0", FileName: "some-mod_2.0.0.zip", DownloadURL: "/download/some-mod_2.0.0.zip"},
+		},
+	})
+	portal.withPortal(t)
+
+	out, err := runCLI(t, "mod", "sync", savePath, "-y", "--strict-version")
+	require.NoError(t, err)
+	assert.Contains(t, out, "Installed 1 MOD(s)")
+	assert.FileExists(t, filepath.Join(s.root, "factorio", "mods", "some-mod_1.0.0.zip"))
+	assert.NoFileExists(t, filepath.Join(s.root, "factorio", "mods", "some-mod_2.0.0.zip"))
+}
+
+func TestMODSyncMissingReleaseFails(t *testing.T) {
+	s, savePath := syncSandbox(t, []save.MODEntry{{Name: "some-mod", Version: mustVersion(t, "1.0.0")}}, nil)
+	s.writeMODList(t, modListEntry{name: "base", enabled: true})
+	portal := newMockPortal(t, portalMOD{
+		Name: "some-mod", Title: "Some MOD", Owner: "alice",
+		Releases: []portalRelease{{Version: "9.9.9", FileName: "some-mod_9.9.9.zip"}},
+	})
+	portal.withPortal(t)
+
+	_, err := runCLI(t, "mod", "sync", savePath, "-y", "--strict-version")
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "Release not found for some-mod@1.0.0")
+}

--- a/internal/cli/portal_integration_update_test.go
+++ b/internal/cli/portal_integration_update_test.go
@@ -1,0 +1,56 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMODUpdateAgainstMockPortal(t *testing.T) {
+	s := baseSandbox(t)
+	s.writeInstalledMOD(t, "some-mod", "1.0.0", nil)
+	s.writeMODList(t, modListEntry{name: "base", enabled: true}, modListEntry{name: "some-mod", enabled: true})
+	portal := newMockPortal(t, portalMOD{
+		Name: "some-mod", Title: "Some MOD", Owner: "alice",
+		Releases: []portalRelease{{
+			Version: "1.1.0", FileName: "some-mod_1.1.0.zip", DownloadURL: "/download/some-mod_1.1.0.zip",
+			InfoJSON: portalInfoJSON{FactorioVersion: "2.0"},
+		}},
+	})
+	portal.withPortal(t)
+
+	out, err := runCLI(t, "mod", "update", "-y")
+	require.NoError(t, err)
+	assert.Contains(t, out, "Updated 1 MOD(s)")
+
+	states := s.readMODList(t)
+	assert.True(t, states["some-mod"])
+}
+
+func TestMODUpdateAlreadyUpToDate(t *testing.T) {
+	s := baseSandbox(t)
+	s.writeInstalledMOD(t, "some-mod", "1.1.0", nil)
+	s.writeMODList(t, modListEntry{name: "base", enabled: true}, modListEntry{name: "some-mod", enabled: true})
+	portal := newMockPortal(t, portalMOD{
+		Name: "some-mod", Title: "Some MOD", Owner: "alice",
+		Releases: []portalRelease{{Version: "1.1.0", FileName: "some-mod_1.1.0.zip"}},
+	})
+	portal.withPortal(t)
+
+	out, err := runCLI(t, "mod", "update", "-y")
+	require.NoError(t, err)
+	assert.Contains(t, out, "All MOD(s) are up to date")
+}
+
+func TestMODUpdateSkipsMODMissingFromPortal(t *testing.T) {
+	s := baseSandbox(t)
+	s.writeInstalledMOD(t, "removed-mod", "1.0.0", nil)
+	s.writeMODList(t, modListEntry{name: "base", enabled: true}, modListEntry{name: "removed-mod", enabled: true})
+	portal := newMockPortal(t) // removed-mod no longer exists on the portal
+	portal.withPortal(t)
+
+	out, err := runCLI(t, "mod", "update", "-y")
+	require.NoError(t, err)
+	assert.Contains(t, out, "All MOD(s) are up to date")
+}

--- a/internal/cli/portal_integration_upload_test.go
+++ b/internal/cli/portal_integration_upload_test.go
@@ -1,0 +1,128 @@
+package cli
+
+import (
+	"os"
+	"path/filepath"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMODUploadNewMODAgainstMockPortal(t *testing.T) {
+	newSandbox(t)
+	portal := newMockPortal(t) // new-mod does not exist on the portal
+	portal.withPortal(t)
+
+	zipPath := filepath.Join(t.TempDir(), "new-mod_1.0.0.zip")
+	writeMODZip(t, zipPath, "new-mod", "1.0.0")
+
+	out, err := runCLI(t, "mod", "upload", zipPath, "--category", "content")
+	require.NoError(t, err)
+	assert.Contains(t, out, "Upload completed successfully!")
+
+	// New MOD: init_publish, then finish-upload with metadata included
+	// (no separate edit_details call).
+	require.Len(t, portal.managementCalls, 1)
+	assert.Equal(t, "/api/v2/mods/init_publish", portal.managementCalls[0].Path)
+	assert.Equal(t, "new-mod", portal.managementCalls[0].MODArg)
+	assert.Equal(t, "Bearer test-api-key", portal.managementCalls[0].Auth)
+}
+
+func TestMODUploadExistingMODAgainstMockPortal(t *testing.T) {
+	newSandbox(t)
+	portal := newMockPortal(t, portalMOD{Name: "existing-mod", Title: "Existing MOD", Owner: "alice"})
+	portal.withPortal(t)
+
+	zipPath := filepath.Join(t.TempDir(), "existing-mod_2.0.0.zip")
+	writeMODZip(t, zipPath, "existing-mod", "2.0.0")
+
+	out, err := runCLI(t, "mod", "upload", zipPath, "--category", "content")
+	require.NoError(t, err)
+	assert.Contains(t, out, "Upload completed successfully!")
+
+	// Existing MOD: init_upload for the release, then a separate
+	// edit_details call for the metadata.
+	require.Len(t, portal.managementCalls, 2)
+	assert.Equal(t, "/api/v2/mods/releases/init_upload", portal.managementCalls[0].Path)
+	assert.Equal(t, "/api/v2/mods/edit_details", portal.managementCalls[1].Path)
+	assert.Equal(t, []string{"content"}, portal.managementCalls[1].Form["category"])
+}
+
+func TestMODUploadRequiresAPIKey(t *testing.T) {
+	newSandbox(t)
+	portal := newMockPortal(t)
+	portal.withPortal(t)
+	t.Setenv("FACTORIO_API_KEY", "")
+
+	zipPath := filepath.Join(t.TempDir(), "new-mod_1.0.0.zip")
+	writeMODZip(t, zipPath, "new-mod", "1.0.0")
+
+	_, err := runCLI(t, "mod", "upload", zipPath)
+	require.Error(t, err)
+	assert.Contains(t, err.Error(), "FACTORIO_API_KEY")
+}
+
+func TestMODEditAgainstMockPortal(t *testing.T) {
+	newSandbox(t)
+	portal := newMockPortal(t, portalMOD{Name: "some-mod", Title: "Some MOD", Owner: "alice"})
+	portal.withPortal(t)
+
+	out, err := runCLI(t, "mod", "edit", "some-mod", "--title", "New Title", "--summary", "New summary")
+	require.NoError(t, err)
+	assert.Contains(t, out, "Metadata updated successfully!")
+
+	require.Len(t, portal.managementCalls, 1)
+	call := portal.managementCalls[0]
+	assert.Equal(t, "/api/v2/mods/edit_details", call.Path)
+	assert.Equal(t, []string{"some-mod"}, call.Form["mod"])
+	assert.Equal(t, []string{"New Title"}, call.Form["title"])
+	assert.Equal(t, []string{"New summary"}, call.Form["summary"])
+}
+
+func TestMODImageListAgainstMockPortal(t *testing.T) {
+	newSandbox(t)
+	portal := newMockPortal(t, portalMOD{
+		Name: "some-mod", Title: "Some MOD", Owner: "alice",
+		Images: []portalImage{{ID: "abc123", Thumbnail: "https://example.com/thumb.png", URL: "https://example.com/full.png"}},
+	})
+	portal.withPortal(t)
+
+	out, err := runCLI(t, "mod", "image", "list", "some-mod")
+	require.NoError(t, err)
+	assert.Contains(t, out, "abc123")
+	assert.Contains(t, out, "https://example.com/thumb.png")
+}
+
+func TestMODImageAddAgainstMockPortal(t *testing.T) {
+	s := newSandbox(t)
+	portal := newMockPortal(t)
+	portal.imageUploadResponse = portalImage{ID: "new-img-id", Thumbnail: "https://example.com/t.png", URL: "https://example.com/f.png"}
+	portal.withPortal(t)
+
+	imagePath := filepath.Join(s.root, "screenshot.png")
+	require.NoError(t, os.WriteFile(imagePath, []byte("fake-png-content"), 0o644))
+
+	out, err := runCLI(t, "mod", "image", "add", "some-mod", imagePath)
+	require.NoError(t, err)
+	assert.Contains(t, out, "Image added successfully!")
+	assert.Contains(t, out, "new-img-id")
+
+	require.Len(t, portal.managementCalls, 1)
+	assert.Equal(t, "/api/v2/mods/images/add", portal.managementCalls[0].Path)
+}
+
+func TestMODImageEditAgainstMockPortal(t *testing.T) {
+	newSandbox(t)
+	portal := newMockPortal(t)
+	portal.withPortal(t)
+
+	out, err := runCLI(t, "mod", "image", "edit", "some-mod", "img1", "img2")
+	require.NoError(t, err)
+	assert.Contains(t, out, "Image list updated successfully!")
+
+	require.Len(t, portal.managementCalls, 1)
+	call := portal.managementCalls[0]
+	assert.Equal(t, "/api/v2/mods/images/edit", call.Path)
+	assert.Equal(t, []string{"img1,img2"}, call.Form["images"])
+}

--- a/internal/cli/portal_mock_test.go
+++ b/internal/cli/portal_mock_test.go
@@ -23,6 +23,7 @@ type portalMOD struct {
 	Category      string          `json:"category,omitempty"`
 	LatestRelease *portalRelease  `json:"latest_release,omitempty"`
 	Releases      []portalRelease `json:"releases,omitempty"`
+	Images        []portalImage   `json:"images,omitempty"`
 }
 
 type portalRelease struct {
@@ -53,6 +54,27 @@ type mockPortal struct {
 	downloads []string
 	// fileContent is served for any /download/... path not in downloads.
 	fileContent []byte
+
+	// managementCalls records every /api/v2/mods/... request received, in
+	// order, for assertions on what a management command actually sent.
+	managementCalls []managementCall
+	// imageUploadResponse is returned by finish-upload for an image
+	// upload; tests set the ID/Thumbnail/URL they expect back.
+	imageUploadResponse portalImage
+}
+
+// managementCall is one recorded request to a management (API-key) endpoint.
+type managementCall struct {
+	Path   string
+	Auth   string
+	Form   map[string][]string // parsed application/x-www-form-urlencoded body
+	MODArg string              // convenience: Form["mod"][0], when present
+}
+
+type portalImage struct {
+	ID        string `json:"id"`
+	Thumbnail string `json:"thumbnail"`
+	URL       string `json:"url"`
 }
 
 func newMockPortal(t *testing.T, mods ...portalMOD) *mockPortal {
@@ -96,9 +118,47 @@ func (p *mockPortal) handle(w http.ResponseWriter, r *http.Request) {
 		p.downloads = append(p.downloads, r.URL.Path+"?"+r.URL.RawQuery)
 		w.Header().Set("Content-Type", "application/octet-stream")
 		_, _ = w.Write(p.fileContent)
+	case strings.HasPrefix(r.URL.Path, "/api/v2/mods/"):
+		p.handleManagement(w, r)
+	case r.URL.Path == "/finish-upload":
+		p.handleFinishUpload(w, r)
 	default:
 		http.NotFound(w, r)
 	}
+}
+
+// handleManagement serves every /api/v2/mods/... endpoint (init_publish,
+// releases/init_upload, edit_details, images/add, images/edit): it records
+// the call and, for the init_* endpoints, hands back an upload_url pointing
+// at this same server's /finish-upload.
+func (p *mockPortal) handleManagement(w http.ResponseWriter, r *http.Request) {
+	_ = r.ParseForm()
+	call := managementCall{Path: r.URL.Path, Auth: r.Header.Get("Authorization"), Form: map[string][]string(r.PostForm)}
+	if mod := r.PostForm.Get("mod"); mod != "" {
+		call.MODArg = mod
+	}
+	p.managementCalls = append(p.managementCalls, call)
+
+	w.Header().Set("Content-Type", "application/json")
+	switch r.URL.Path {
+	case "/api/v2/mods/init_publish", "/api/v2/mods/releases/init_upload", "/api/v2/mods/images/add":
+		_ = json.NewEncoder(w).Encode(map[string]string{"upload_url": p.server.URL + "/finish-upload"})
+	case "/api/v2/mods/edit_details", "/api/v2/mods/images/edit":
+		_ = json.NewEncoder(w).Encode(map[string]bool{"success": true})
+	default:
+		http.NotFound(w, r)
+	}
+}
+
+// handleFinishUpload serves the URL init_publish/init_upload/images/add
+// point at. It doesn't need to distinguish a MOD-file upload from an image
+// upload by content — FinishUpload ignores the response body, and
+// FinishImageUpload always decodes an Image, so returning imageUploadResponse
+// unconditionally satisfies both.
+func (p *mockPortal) handleFinishUpload(w http.ResponseWriter, r *http.Request) {
+	_ = r.ParseMultipartForm(32 << 20)
+	w.Header().Set("Content-Type", "application/json")
+	_ = json.NewEncoder(w).Encode(p.imageUploadResponse)
 }
 
 // writeMOD serves a MOD's info. The real Portal's /full endpoint carries
@@ -141,6 +201,7 @@ func (p *mockPortal) withPortal(t *testing.T) {
 	t.Setenv("FACTORIX_MODS_PORTAL_URL", p.server.URL)
 	t.Setenv("FACTORIO_USERNAME", "test-user")
 	t.Setenv("FACTORIO_TOKEN", "test-token")
+	t.Setenv("FACTORIO_API_KEY", "test-api-key")
 
 	pool := x509.NewCertPool()
 	pool.AddCert(p.server.Certificate())


### PR DESCRIPTION
## Summary
Second slice of httptest integration tests, completing the roadmap item started in #140. Every Portal-backed command now has coverage: `mod show`/`search`/`install` (done previously), `download`/`update`/`upload`/`edit`/`image`/`sync` (this PR).

## Changes
- `mockPortal` gains management-API support: `/api/v2/mods/init_publish`, `releases/init_upload`, `edit_details`, `images/add`, `images/edit` (all requiring the `Authorization` header) plus a `/finish-upload` endpoint the `init_*` calls point uploads at. Calls are recorded (path, auth header, parsed form body) for assertions
- `withPortal` now also sets `FACTORIO_API_KEY`, alongside the existing `FACTORIO_USERNAME`/`FACTORIO_TOKEN`
- `mod download`: basic download, recursive dependency resolution, and skipping an incompatible dependency with a warning (not failing the whole command)
- `mod update`: applies an available update, reports up-to-date, and skips a MOD removed from the portal
- `mod upload`: both paths — new MOD via `init_publish`, existing MOD via `init_upload` + a separate `edit_details` — distinguished by asserting the recorded call sequence; also a missing-API-key failure
- `mod edit`/`mod image list/add/edit`: metadata edit, gallery listing, image upload, and image reordering
- `mod sync`: install-missing-MOD and `--strict-version` paths against the mock, plus a missing-release failure. Fixtures set only `Releases` (never `latest_release`), matching `mod_sync.go`'s documented Ruby-inherited quirk (`findSyncRelease` prefers `latest_release` when present, but the real `/full` endpoint never sends it)

## Test Plan
- `mise run default` (test + e2e + vet + lint + fmt-check) passes; 20 new integration tests across 4 new files
