### PR TITLE
:recycle: Replace mod show's local dependency classifier with dependency.Parse

### DIFF
--- a/internal/cli/mod_show.go
+++ b/internal/cli/mod_show.go
@@ -4,13 +4,13 @@ import (
 	"bytes"
 	"encoding/json"
 	"fmt"
-	"strings"
 
 	"github.com/fatih/color"
 	"github.com/spf13/cobra"
 
 	"github.com/sakuro/factorix/internal/api"
 	"github.com/sakuro/factorix/internal/app"
+	"github.com/sakuro/factorix/internal/dependency"
 	"github.com/sakuro/factorix/internal/mod"
 )
 
@@ -242,26 +242,33 @@ func formatLicense(info *api.MODInfo) string {
 	return info.License.Title
 }
 
-// classifyDependencies splits raw dependency strings by prefix, matching
-// Ruby's own regex-based classification in mod/show.rb (not
-// internal/dependency.Parse's Type, so a malformed entry here is simply
-// treated as required rather than rejected — this command only displays
-// dependencies, it never resolves them).
+// classifyDependencies splits raw dependency strings into required, optional,
+// and incompatible dependencies using dependency.Parse, so classification
+// agrees with the rest of the codebase (recommended-dependency handling is
+// tracked separately in #90). Malformed entries from the Portal API are
+// skipped rather than failing the whole display — this command only
+// displays dependencies, it never resolves them.
 func classifyDependencies(raw []string) (required, optional, incompatible []string) {
 	for _, dep := range raw {
-		trimmed := strings.TrimSpace(dep)
-		switch {
-		case strings.HasPrefix(trimmed, "!"):
-			incompatible = append(incompatible, strings.TrimSpace(strings.TrimPrefix(trimmed, "!")))
-		case strings.HasPrefix(trimmed, "(?)"):
-			optional = append(optional, strings.TrimSpace(strings.TrimPrefix(trimmed, "(?)")))
-		case strings.HasPrefix(trimmed, "?"):
-			optional = append(optional, strings.TrimSpace(strings.TrimPrefix(trimmed, "?")))
-		case strings.HasPrefix(trimmed, "~"):
-			// load-neutral: Ruby's parse_dependency tags it but show.rb never
-			// displays this bucket, so it's parsed and discarded here too.
-		default:
-			required = append(required, trimmed)
+		entry, err := dependency.Parse(dep)
+		if err != nil {
+			continue
+		}
+
+		s := entry.MOD.Name
+		if entry.Requirement != nil {
+			s += " " + entry.Requirement.String()
+		}
+
+		switch entry.Type {
+		case dependency.TypeRequired:
+			required = append(required, s)
+		case dependency.TypeOptional, dependency.TypeHiddenOptional:
+			optional = append(optional, s)
+		case dependency.TypeIncompatible:
+			incompatible = append(incompatible, s)
+		case dependency.TypeLoadNeutral, dependency.TypeRecommended:
+			// No display section yet for these buckets (see #90).
 		}
 	}
 	return required, optional, incompatible

--- a/internal/cli/mod_show_test.go
+++ b/internal/cli/mod_show_test.go
@@ -22,7 +22,7 @@ func sampleShowMODInfo() *api.MODInfo {
 			Version: v,
 			InfoJSON: api.ReleaseInfoJSON{
 				FactorioVersion: "2.0",
-				Dependencies:    []string{"base", "lib >= 1.0", "? optional-lib", "! bad-mod", "~ neutral-mod"},
+				Dependencies:    []string{"base", "lib >= 1.0", "? optional-lib", "! bad-mod", "~ neutral-mod", "+ recommended-mod"},
 			},
 		},
 	}
@@ -30,11 +30,18 @@ func sampleShowMODInfo() *api.MODInfo {
 
 func TestClassifyDependencies(t *testing.T) {
 	required, optional, incompatible := classifyDependencies([]string{
-		"base", "lib >= 1.0", "? optional-lib", "(?) hidden-lib", "! bad-mod", "~ neutral-mod",
+		"base", "lib >= 1.0", "? optional-lib", "(?) hidden-lib", "! bad-mod", "~ neutral-mod", "+ recommended-mod",
 	})
-	assert.Equal(t, []string{"base", "lib >= 1.0"}, required)
+	assert.Equal(t, []string{"base", "lib >= 1.0.0"}, required)
 	assert.Equal(t, []string{"optional-lib", "hidden-lib"}, optional)
 	assert.Equal(t, []string{"bad-mod"}, incompatible)
+}
+
+func TestClassifyDependenciesMalformed(t *testing.T) {
+	required, optional, incompatible := classifyDependencies([]string{"base", ">= 1.0"})
+	assert.Equal(t, []string{"base"}, required)
+	assert.Empty(t, optional)
+	assert.Empty(t, incompatible)
 }
 
 func TestFormatLocalStatus(t *testing.T) {
@@ -70,7 +77,8 @@ func TestDisplayShow(t *testing.T) {
 	assert.Contains(t, out, "optional-lib")
 	assert.Contains(t, out, "Incompatibilities")
 	assert.Contains(t, out, "bad-mod")
-	assert.NotContains(t, out, "neutral-mod") // load-neutral is parsed and discarded
+	assert.NotContains(t, out, "neutral-mod")     // load-neutral is parsed and discarded
+	assert.NotContains(t, out, "recommended-mod") // no display section yet (see #90)
 }
 
 func TestDisplayShowUpdateAvailable(t *testing.T) {


### PR DESCRIPTION
## Summary

`mod show`'s `classifyDependencies` reimplemented dependency-string parsing with ad-hoc prefix checks, duplicating `internal/dependency.Parse` (carried over verbatim from Ruby's `show.rb#parse_dependency`). Replace it with calls to `dependency.Parse`, skipping malformed entries instead of misclassifying them as required, since `mod show` only displays dependencies and never resolves them.

Recommended (`+`) and load-neutral (`~`) dependencies still have no display section, so they're silently dropped for now; the classifier now distinguishes them correctly rather than leaking the `+` prefix into the required list — display support is tracked separately in #90.

Fixes #95

## Test plan

- [x] Added `TestClassifyDependenciesMalformed` to cover the skip-on-error path
- [x] Updated `TestDisplayShow`/`TestClassifyDependencies` for the normalized version format (`dependency.Parse` renders `1.0` as `1.0.0`) and to assert recommended deps stay hidden
- [x] `mise run default` passes