### PR TITLE
:bug: Add a Recommended Dependencies section to mod show

### DIFF
--- a/internal/cli/mod_show.go
+++ b/internal/cli/mod_show.go
@@ -155,11 +155,18 @@ func displayShow(p *printer, info *api.MODInfo, status localMODStatus) error {
 	if latest == nil {
 		return nil
 	}
-	required, optional, incompatibleDeps := classifyDependencies(latest.InfoJSON.Dependencies)
+	required, optional, recommended, incompatibleDeps := classifyDependencies(latest.InfoJSON.Dependencies)
 
 	if len(required) > 0 {
 		p.Println(header.Sprint("Dependencies"))
 		for _, d := range required {
+			p.Println("  " + d)
+		}
+		p.Println()
+	}
+	if len(recommended) > 0 {
+		p.Println(header.Sprint("Recommended Dependencies"))
+		for _, d := range recommended {
 			p.Println("  " + d)
 		}
 		p.Println()
@@ -242,13 +249,13 @@ func formatLicense(info *api.MODInfo) string {
 	return info.License.Title
 }
 
-// classifyDependencies splits raw dependency strings into required, optional,
-// and incompatible dependencies using dependency.Parse, so classification
-// agrees with the rest of the codebase (recommended-dependency handling is
-// tracked separately in #90). Malformed entries from the Portal API are
-// skipped rather than failing the whole display — this command only
-// displays dependencies, it never resolves them.
-func classifyDependencies(raw []string) (required, optional, incompatible []string) {
+// classifyDependencies splits raw dependency strings into required,
+// optional, recommended, and incompatible dependencies using
+// dependency.Parse, so classification agrees with the rest of the
+// codebase. Malformed entries from the Portal API are skipped rather than
+// failing the whole display — this command only displays dependencies, it
+// never resolves them.
+func classifyDependencies(raw []string) (required, optional, recommended, incompatible []string) {
 	for _, dep := range raw {
 		entry, err := dependency.Parse(dep)
 		if err != nil {
@@ -265,13 +272,15 @@ func classifyDependencies(raw []string) (required, optional, incompatible []stri
 			required = append(required, s)
 		case dependency.TypeOptional, dependency.TypeHiddenOptional:
 			optional = append(optional, s)
+		case dependency.TypeRecommended:
+			recommended = append(recommended, s)
 		case dependency.TypeIncompatible:
 			incompatible = append(incompatible, s)
-		case dependency.TypeLoadNeutral, dependency.TypeRecommended:
-			// No display section yet for these buckets (see #90).
+		case dependency.TypeLoadNeutral:
+			// show.rb never displayed this bucket; kept parsed and discarded.
 		}
 	}
-	return required, optional, incompatible
+	return required, optional, recommended, incompatible
 }
 
 func outputShowJSON(p *printer, info *api.MODInfo, status localMODStatus) error {

--- a/internal/cli/mod_show_test.go
+++ b/internal/cli/mod_show_test.go
@@ -22,25 +22,27 @@ func sampleShowMODInfo() *api.MODInfo {
 			Version: v,
 			InfoJSON: api.ReleaseInfoJSON{
 				FactorioVersion: "2.0",
-				Dependencies:    []string{"base", "lib >= 1.0", "? optional-lib", "! bad-mod", "~ neutral-mod", "+ recommended-mod"},
+				Dependencies:    []string{"base", "lib >= 1.0", "? optional-lib", "! bad-mod", "~ neutral-mod", "+ recommended-mod >= 2.1.0"},
 			},
 		},
 	}
 }
 
 func TestClassifyDependencies(t *testing.T) {
-	required, optional, incompatible := classifyDependencies([]string{
-		"base", "lib >= 1.0", "? optional-lib", "(?) hidden-lib", "! bad-mod", "~ neutral-mod", "+ recommended-mod",
+	required, optional, recommended, incompatible := classifyDependencies([]string{
+		"base", "lib >= 1.0", "? optional-lib", "(?) hidden-lib", "! bad-mod", "~ neutral-mod", "+ recommended-mod >= 2.1.0",
 	})
 	assert.Equal(t, []string{"base", "lib >= 1.0.0"}, required)
 	assert.Equal(t, []string{"optional-lib", "hidden-lib"}, optional)
+	assert.Equal(t, []string{"recommended-mod >= 2.1.0"}, recommended)
 	assert.Equal(t, []string{"bad-mod"}, incompatible)
 }
 
 func TestClassifyDependenciesMalformed(t *testing.T) {
-	required, optional, incompatible := classifyDependencies([]string{"base", ">= 1.0"})
+	required, optional, recommended, incompatible := classifyDependencies([]string{"base", ">= 1.0"})
 	assert.Equal(t, []string{"base"}, required)
 	assert.Empty(t, optional)
+	assert.Empty(t, recommended)
 	assert.Empty(t, incompatible)
 }
 
@@ -73,12 +75,13 @@ func TestDisplayShow(t *testing.T) {
 	assert.Contains(t, out, "Source: https://example.com/src")
 	assert.Contains(t, out, "Dependencies")
 	assert.Contains(t, out, "  base")
+	assert.Contains(t, out, "Recommended Dependencies")
+	assert.Contains(t, out, "recommended-mod >= 2.1.0")
 	assert.Contains(t, out, "Optional Dependencies")
 	assert.Contains(t, out, "optional-lib")
 	assert.Contains(t, out, "Incompatibilities")
 	assert.Contains(t, out, "bad-mod")
-	assert.NotContains(t, out, "neutral-mod")     // load-neutral is parsed and discarded
-	assert.NotContains(t, out, "recommended-mod") // no display section yet (see #90)
+	assert.NotContains(t, out, "neutral-mod") // load-neutral is parsed and discarded
 }
 
 func TestDisplayShowUpdateAvailable(t *testing.T) {


### PR DESCRIPTION
## Summary
`mod show` misclassified recommended (`+`) dependencies as required, leaking the `+` prefix into the displayed MOD name and giving them no dedicated section.

## Changes
- `classifyDependencies` now returns a fourth `recommended` bucket, backed by `dependency.Parse`'s `TypeRecommended` (already correctly identified since #95, just not surfaced)
- `displayShow` renders a **Recommended Dependencies** section, placed after Dependencies and before Optional Dependencies
- Updated tests to cover a `+` dependency with a version requirement, both in `classifyDependencies` and the rendered `mod show` output

## Test Plan
- [x] `mise run default` passes
- [x] `TestClassifyDependencies` / `TestDisplayShow` cover the new recommended bucket

Fixes #90
