### PR TITLE
:sparkles: Warn about disabled recommended dependencies in mod check

### DIFF
--- a/internal/dependency/validation_result.go
+++ b/internal/dependency/validation_result.go
@@ -19,6 +19,7 @@ type WarningType uint8
 const (
 	WarningMODInListNotInstalled WarningType = iota
 	WarningMODInstalledNotInList
+	WarningRecommendedDependencyDisabled
 )
 
 // ValidationError is an error found during dependency validation.

--- a/internal/dependency/validator.go
+++ b/internal/dependency/validator.go
@@ -21,6 +21,7 @@ func (v *Validator) Validate() *ValidationResult {
 	result := &ValidationResult{}
 	v.validateCircularDependencies(result)
 	v.validateDependencies(result)
+	v.validateRecommendedDependencies(result)
 	v.validateConflicts(result)
 	v.validateMODList(result)
 	return result
@@ -90,6 +91,34 @@ func (v *Validator) validateRequiredDependency(node Node, edge Edge, result *Val
 		Dependency: edge.To,
 	})
 	v.suggestAlternativeVersions(edge, result)
+}
+
+// validateRecommendedDependencies warns about recommended dependencies that
+// are installed but disabled. A recommended dependency is on by default, so
+// this is a deviation from the MOD author's default configuration — unlike
+// a required dependency, it does not break the MOD and is a warning, not an
+// error. A recommended dependency that is not installed at all is not
+// reported here (see #91 for resolving recommended dependencies).
+func (v *Validator) validateRecommendedDependencies(result *ValidationResult) {
+	for _, node := range v.Graph.Nodes() {
+		if !node.Enabled {
+			continue
+		}
+		for _, edge := range v.Graph.EdgesFrom(node.MOD) {
+			if edge.Type != TypeRecommended {
+				continue
+			}
+			depNode, ok := v.Graph.Node(edge.To)
+			if !ok || depNode.Enabled {
+				continue
+			}
+			result.Warnings = append(result.Warnings, ValidationWarning{
+				Type:    WarningRecommendedDependencyDisabled,
+				Message: fmt.Sprintf("MOD '%s@%s' recommends '%s' which is not enabled", node.MOD, node.Version, edge.To),
+				MOD:     node.MOD,
+			})
+		}
+	}
 }
 
 func (v *Validator) validateConflicts(result *ValidationResult) {

--- a/internal/dependency/validator_test.go
+++ b/internal/dependency/validator_test.go
@@ -17,6 +17,14 @@ func errorTypes(result *ValidationResult) []ErrorType {
 	return types
 }
 
+func warningTypes(result *ValidationResult) []WarningType {
+	types := make([]WarningType, len(result.Warnings))
+	for i, w := range result.Warnings {
+		types[i] = w.Type
+	}
+	return types
+}
+
 func TestValidatorValid(t *testing.T) {
 	g := NewGraph()
 	addNodes(t, g, "app", "lib")
@@ -48,6 +56,27 @@ func TestValidatorDisabledDependency(t *testing.T) {
 
 	result := (&Validator{Graph: g, MODList: mod.NewMODList()}).Validate()
 	assert.Contains(t, errorTypes(result), ErrorDisabledDependency)
+}
+
+func TestValidatorRecommendedDependencyDisabled(t *testing.T) {
+	g := NewGraph()
+	addNodes(t, g, "app")
+	require.NoError(t, g.AddNode(Node{MOD: testMOD("lib"), Version: mod.MODVersion{Major: 1}, Enabled: false, Installed: true}))
+	requireEdge(t, g, "app", "lib", TypeRecommended)
+
+	result := (&Validator{Graph: g, MODList: mod.NewMODList()}).Validate()
+	assert.True(t, result.Valid()) // a disabled recommended dependency is a warning, not an error
+	assert.Contains(t, warningTypes(result), WarningRecommendedDependencyDisabled)
+}
+
+func TestValidatorRecommendedDependencyNotInstalled(t *testing.T) {
+	g := NewGraph()
+	addNodes(t, g, "app")
+	requireEdge(t, g, "app", "ghost", TypeRecommended)
+
+	result := (&Validator{Graph: g, MODList: mod.NewMODList()}).Validate()
+	assert.True(t, result.Valid())
+	assert.NotContains(t, warningTypes(result), WarningRecommendedDependencyDisabled)
 }
 
 func TestValidatorVersionMismatchWithSuggestion(t *testing.T) {


### PR DESCRIPTION
## Summary
A recommended (`+`) dependency is on by default, so an installed-but-disabled recommended dependency is a deviation from the MOD author's default configuration. `mod check` previously gave no visibility into this.

## Changes
- Add `WarningRecommendedDependencyDisabled` to `internal/dependency`
- Add `Validator.validateRecommendedDependencies`, wired into `Validate()`: warns when an enabled MOD's recommended dependency is installed but disabled (unlike a required dependency, this doesn't break the MOD, so it's a warning, not an error)
- A recommended dependency that isn't installed at all is intentionally not reported here — resolving it is #91's job

`mod check`'s CLI layer already renders `result.Warnings` generically, so no changes were needed there.

## Test Plan
- [x] Added `TestValidatorRecommendedDependencyDisabled` and `TestValidatorRecommendedDependencyNotInstalled`
- [x] `mise run default` passes

Fixes #93
