### PR TITLE
:sparkles: Handle recommended dependencies in mod enable

### DIFF
--- a/internal/cli/mod_enable_disable_test.go
+++ b/internal/cli/mod_enable_disable_test.go
@@ -43,6 +43,45 @@ func TestMODEnableSimple(t *testing.T) {
 	assert.True(t, states["lib"])
 }
 
+func TestMODEnablePullsInInstalledRecommendedDep(t *testing.T) {
+	s := baseSandbox(t)
+	s.writeInstalledMOD(t, "app", "1.0.0", []string{"+ lib"})
+	s.writeInstalledMOD(t, "lib", "1.0.0", nil)
+	s.writeMODList(t,
+		modListEntry{name: "base", enabled: true},
+		modListEntry{name: "app", enabled: false},
+		modListEntry{name: "lib", enabled: false},
+	)
+
+	out, err := runCLI(t, "mod", "enable", "app", "-y")
+	require.NoError(t, err)
+	assert.Equal(t, "ℹ Planning to enable 2 MOD(s):\n"+
+		"  - app\n"+
+		"  - lib\n"+
+		"✓ Enabled app\n"+
+		"✓ Enabled lib\n"+
+		"✓ Enabled 2 MOD(s)\n"+
+		"✓ Saved mod-list.json\n", out)
+
+	states := s.readMODList(t)
+	assert.True(t, states["app"])
+	assert.True(t, states["lib"])
+}
+
+func TestMODEnableSkipsUninstalledRecommendedDep(t *testing.T) {
+	s := baseSandbox(t)
+	s.writeInstalledMOD(t, "app", "1.0.0", []string{"+ ghost"})
+	s.writeMODList(t, modListEntry{name: "base", enabled: true}, modListEntry{name: "app", enabled: false})
+
+	out, err := runCLI(t, "mod", "enable", "app", "-y")
+	require.NoError(t, err)
+	assert.Equal(t, "ℹ Planning to enable 1 MOD(s):\n"+
+		"  - app\n"+
+		"✓ Enabled app\n"+
+		"✓ Enabled 1 MOD(s)\n"+
+		"✓ Saved mod-list.json\n", out)
+}
+
 func TestMODEnableCustomBackupExtension(t *testing.T) {
 	s := baseSandbox(t)
 	s.writeInstalledMOD(t, "app", "1.0.0", nil)

--- a/internal/dependency/plan.go
+++ b/internal/dependency/plan.go
@@ -14,7 +14,12 @@ var (
 )
 
 // PlanEnable computes the MODs to enable when enabling targets, pulling in
-// required dependencies (BFS discovery order). The base MOD is always
+// required dependencies (BFS discovery order). Recommended dependencies are
+// pulled in the same way when already installed with a satisfied version;
+// unlike required dependencies, a missing or version-mismatched recommended
+// dependency is silently skipped rather than rejected, since it's off by
+// default only by the user's own choice not to install it (fetching it from
+// the Portal is out of scope here, see #91). The base MOD is always
 // available and is never pulled in as a dependency. Targets already
 // installed are assumed to exist in the graph; the caller validates that
 // before calling PlanEnable.
@@ -35,19 +40,30 @@ func PlanEnable(g *Graph, targets []mod.MOD) ([]mod.MOD, error) {
 		order = append(order, m)
 
 		for _, edge := range g.EdgesFrom(m) {
-			if edge.Type != TypeRequired || edge.To.IsBase() {
+			if edge.To.IsBase() {
 				continue
 			}
-			depNode, ok := g.Node(edge.To)
-			if !ok {
-				return nil, fmt.Errorf("%w: MOD '%s' requires '%s' which is not installed", ErrDependencyMissing, m, edge.To)
-			}
-			if !edge.SatisfiedBy(depNode.Version) {
-				return nil, fmt.Errorf("%w: cannot enable %s: dependency %s version requirement not satisfied (required: %s, installed: %s)",
-					ErrDependencyVersion, m, edge.To, edge.Requirement, depNode.Version)
-			}
-			if !depNode.Enabled && !planned[edge.To] {
-				queue = append(queue, edge.To)
+			switch edge.Type {
+			case TypeRequired:
+				depNode, ok := g.Node(edge.To)
+				if !ok {
+					return nil, fmt.Errorf("%w: MOD '%s' requires '%s' which is not installed", ErrDependencyMissing, m, edge.To)
+				}
+				if !edge.SatisfiedBy(depNode.Version) {
+					return nil, fmt.Errorf("%w: cannot enable %s: dependency %s version requirement not satisfied (required: %s, installed: %s)",
+						ErrDependencyVersion, m, edge.To, edge.Requirement, depNode.Version)
+				}
+				if !depNode.Enabled && !planned[edge.To] {
+					queue = append(queue, edge.To)
+				}
+			case TypeRecommended:
+				depNode, ok := g.Node(edge.To)
+				if !ok || !edge.SatisfiedBy(depNode.Version) {
+					continue
+				}
+				if !depNode.Enabled && !planned[edge.To] {
+					queue = append(queue, edge.To)
+				}
 			}
 		}
 	}

--- a/internal/dependency/plan_test.go
+++ b/internal/dependency/plan_test.go
@@ -59,6 +59,41 @@ func TestPlanEnableVersionMismatch(t *testing.T) {
 	require.ErrorIs(t, err, ErrDependencyVersion)
 }
 
+func TestPlanEnablePullsInInstalledRecommendedDeps(t *testing.T) {
+	g := NewGraph()
+	disabledNode(t, g, "app")
+	disabledNode(t, g, "lib")
+	requireEdge(t, g, "app", "lib", TypeRecommended)
+
+	planned, err := PlanEnable(g, []mod.MOD{testMOD("app")})
+	require.NoError(t, err)
+	assert.Equal(t, []mod.MOD{testMOD("app"), testMOD("lib")}, planned)
+}
+
+func TestPlanEnableSkipsUninstalledRecommendedDep(t *testing.T) {
+	g := NewGraph()
+	disabledNode(t, g, "app")
+	requireEdge(t, g, "app", "ghost", TypeRecommended)
+
+	planned, err := PlanEnable(g, []mod.MOD{testMOD("app")})
+	require.NoError(t, err)
+	assert.Equal(t, []mod.MOD{testMOD("app")}, planned)
+}
+
+func TestPlanEnableSkipsVersionMismatchedRecommendedDep(t *testing.T) {
+	g := NewGraph()
+	disabledNode(t, g, "app")
+	disabledNode(t, g, "lib") // version 1
+	require.NoError(t, g.AddEdge(Edge{
+		From: testMOD("app"), To: testMOD("lib"), Type: TypeRecommended,
+		Requirement: &VersionRequirement{Operator: OpGreaterEqual, Version: mod.MODVersion{Major: 2}},
+	}))
+
+	planned, err := PlanEnable(g, []mod.MOD{testMOD("app")})
+	require.NoError(t, err)
+	assert.Equal(t, []mod.MOD{testMOD("app")}, planned)
+}
+
 func TestValidateNoConflictsWithEnabled(t *testing.T) {
 	g := NewGraph()
 	disabledNode(t, g, "app")


### PR DESCRIPTION
## Summary
A recommended (`+`) dependency is on by default, but `mod enable` previously only pulled in required dependencies when enabling a MOD, leaving recommended ones ignored.

## Changes
- `PlanEnable` now follows recommended edges the same way as required ones (BFS), enabling installed recommended dependencies alongside required ones
- Unlike required dependencies, a missing or version-mismatched recommended dependency is silently skipped rather than rejected — it's off by default only because the user hasn't installed it; fetching it from the Portal is out of scope here (#91)
- Added unit tests in `internal/dependency/plan_test.go` and CLI-level integration tests in `internal/cli/mod_enable_disable_test.go`

## Test Plan
- [x] `mise run default` passes

Fixes #92
