### PR TITLE
:sparkles: Handle recommended dependencies in mod install

### DIFF
--- a/internal/cli/mod_install.go
+++ b/internal/cli/mod_install.go
@@ -200,10 +200,12 @@ func planInstall(ctx context.Context, application *app.App, graph *dependency.Gr
 	return targets, nil
 }
 
-// resolveInstallDependencies walks the required edges of newly-added graph
-// nodes and fetches MODs not yet in the graph, extending it recursively.
-// A dependency that cannot be fetched or has no compatible release is
-// skipped with a warning rather than failing the install.
+// resolveInstallDependencies walks the required and recommended edges of
+// newly-added graph nodes and fetches MODs not yet in the graph, extending
+// it recursively. Recommended dependencies are on by default, so they're
+// fetched the same as required ones. A dependency that cannot be fetched or
+// has no compatible release is skipped with a warning rather than failing
+// the install.
 func resolveInstallDependencies(ctx context.Context, application *app.App, graph *dependency.Graph, releases map[mod.MOD]api.Release, frontier []mod.MOD, jobs int) error {
 	portalAPI, err := application.PortalAPI()
 	if err != nil {
@@ -224,7 +226,10 @@ func resolveInstallDependencies(ctx context.Context, application *app.App, graph
 			}
 			processed[m] = true
 			for _, edge := range graph.EdgesFrom(m) {
-				if edge.Type != dependency.TypeRequired || graph.Contains(edge.To) {
+				if edge.Type != dependency.TypeRequired && edge.Type != dependency.TypeRecommended {
+					continue
+				}
+				if graph.Contains(edge.To) {
 					continue
 				}
 				missing = append(missing, missingDep{mod: edge.To, requirement: edge.Requirement, requiredBy: m})

--- a/internal/cli/portal_integration_test.go
+++ b/internal/cli/portal_integration_test.go
@@ -130,6 +130,56 @@ func TestMODInstallAgainstMockPortal(t *testing.T) {
 	assert.True(t, states["some-mod"])
 }
 
+func TestMODInstallPullsInRecommendedDependency(t *testing.T) {
+	s := baseSandbox(t)
+	s.writeMODList(t, modListEntry{name: "base", enabled: true})
+	mainRelease := portalRelease{
+		Version: "1.0.0", FileName: "some-mod_1.0.0.zip",
+		DownloadURL: "/download/some-mod_1.0.0.zip",
+		InfoJSON:    portalInfoJSON{FactorioVersion: "2.0", Dependencies: []string{"+ lib-mod"}},
+	}
+	libRelease := portalRelease{
+		Version: "2.0.0", FileName: "lib-mod_2.0.0.zip",
+		DownloadURL: "/download/lib-mod_2.0.0.zip",
+		InfoJSON:    portalInfoJSON{FactorioVersion: "2.0"},
+	}
+	portal := newMockPortal(t,
+		portalMOD{Name: "some-mod", Title: "Some MOD", Owner: "alice", Releases: []portalRelease{mainRelease}},
+		portalMOD{Name: "lib-mod", Title: "Lib MOD", Owner: "alice", Releases: []portalRelease{libRelease}},
+	)
+	portal.withPortal(t)
+
+	out, err := runCLI(t, "mod", "install", "some-mod", "-y")
+	require.NoError(t, err)
+	assert.Contains(t, out, "Installed 2 MOD(s)")
+
+	states := s.readMODList(t)
+	assert.True(t, states["some-mod"])
+	assert.True(t, states["lib-mod"])
+}
+
+func TestMODInstallEnablesDisabledRecommendedDependency(t *testing.T) {
+	s := baseSandbox(t)
+	s.writeInstalledMOD(t, "lib-mod", "1.0.0", nil)
+	s.writeMODList(t, modListEntry{name: "base", enabled: true}, modListEntry{name: "lib-mod", enabled: false})
+	release := portalRelease{
+		Version: "1.0.0", FileName: "some-mod_1.0.0.zip",
+		DownloadURL: "/download/some-mod_1.0.0.zip",
+		InfoJSON:    portalInfoJSON{FactorioVersion: "2.0", Dependencies: []string{"+ lib-mod"}},
+	}
+	portal := newMockPortal(t, portalMOD{Name: "some-mod", Title: "Some MOD", Owner: "alice", Releases: []portalRelease{release}})
+	portal.withPortal(t)
+
+	out, err := runCLI(t, "mod", "install", "some-mod", "-y")
+	require.NoError(t, err)
+	assert.Contains(t, out, "Installed 1 MOD(s)")
+	assert.Contains(t, out, "Enabled 1 disabled dependency MOD(s)")
+
+	states := s.readMODList(t)
+	assert.True(t, states["some-mod"])
+	assert.True(t, states["lib-mod"])
+}
+
 func TestMODInstallNotOnPortal(t *testing.T) {
 	s := baseSandbox(t)
 	s.writeMODList(t, modListEntry{name: "base", enabled: true})

--- a/internal/dependency/plan.go
+++ b/internal/dependency/plan.go
@@ -110,10 +110,12 @@ func checkConflict(g *Graph, m, other mod.MOD, plannedSet map[mod.MOD]bool) erro
 	return nil
 }
 
-// MarkDisabledDependenciesForEnable walks the required dependencies of
-// every node planned for install or enable and marks installed-but-disabled
-// dependencies for enabling (recursively), so installing a MOD also turns
-// its already-present dependency chain back on.
+// MarkDisabledDependenciesForEnable walks the required and recommended
+// dependencies of every node planned for install or enable and marks
+// installed-but-disabled dependencies for enabling (recursively), so
+// installing a MOD also turns its already-present dependency chain back
+// on. Recommended dependencies are on by default, so they're treated the
+// same as required ones here.
 func MarkDisabledDependenciesForEnable(g *Graph) {
 	var queue []mod.MOD
 	for _, node := range g.Nodes() {
@@ -132,7 +134,7 @@ func MarkDisabledDependenciesForEnable(g *Graph) {
 		processed[m] = true
 
 		for _, edge := range g.EdgesFrom(m) {
-			if edge.Type != TypeRequired {
+			if edge.Type != TypeRequired && edge.Type != TypeRecommended {
 				continue
 			}
 			depNode, ok := g.Node(edge.To)

--- a/internal/dependency/plan_test.go
+++ b/internal/dependency/plan_test.go
@@ -203,6 +203,17 @@ func TestMarkDisabledDependenciesForEnable(t *testing.T) {
 	assert.Equal(t, OpNone, optional.Operation)
 }
 
+func TestMarkDisabledDependenciesForEnableRecommended(t *testing.T) {
+	g := NewGraph()
+	require.NoError(t, g.AddUninstalledMOD(testMOD("new-mod"), mod.MODVersion{Major: 1}, []string{"+ lib"}))
+	disabledNode(t, g, "lib")
+
+	MarkDisabledDependenciesForEnable(g)
+
+	lib, _ := g.Node(testMOD("lib"))
+	assert.Equal(t, OpEnable, lib.Operation)
+}
+
 func TestValidateInstallGraphCycle(t *testing.T) {
 	g := NewGraph()
 	require.NoError(t, g.AddUninstalledMOD(testMOD("a"), mod.MODVersion{Major: 1}, []string{"b"}))


### PR DESCRIPTION
## Summary
A recommended (`+`) dependency is on by default, but `mod install` previously only resolved required dependencies, leaving recommended ones untouched.

## Changes
- `resolveInstallDependencies` now fetches uninstalled recommended dependencies from the Portal and adds them to the install plan, same as required ones
- `MarkDisabledDependenciesForEnable` now marks installed-but-disabled recommended dependencies for re-enabling, same as required ones
- Added a unit test for the enable-marking change and two CLI-level integration tests against the mock Portal (fetching a new recommended dependency, re-enabling an already-installed-but-disabled one)

## Test Plan
- [x] `mise run default` passes

Fixes #91
