### PR TITLE
:sparkles: Add --ignore-recommended flag to check/install/enable/sync

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -8,7 +8,7 @@ single, self-contained binary — no Ruby, Bundler, or gem install required.
 
 - Add `rcon exec` and `rcon eval` commands to execute a console command or evaluate a Lua script on a running Factorio server via RCon
 - Add PowerShell completion support
-- Add recommended dependency type (`+` prefix) support in MOD dependency parsing
+- Recognize recommended (`+` prefix) dependencies across `mod show`, `mod install`, `mod enable`, `mod sync`, and `mod check`: `mod show` lists them in a dedicated section, `mod install`/`mod enable`/`mod sync` resolve and enable them automatically like required dependencies, and `mod check` warns when one is installed but disabled; opt out with `--ignore-recommended`
 
 ### Changed
 

--- a/internal/cli/mod_check.go
+++ b/internal/cli/mod_check.go
@@ -5,12 +5,16 @@ import (
 	"fmt"
 
 	"github.com/spf13/cobra"
+
+	"github.com/sakuro/factorix/internal/dependency"
 )
 
 var errValidationFailed = errors.New("MOD dependency validation failed")
 
 func newMODCheckCommand(c *cli) *cobra.Command {
-	return &cobra.Command{
+	var ignoreRecommended bool
+
+	cmd := &cobra.Command{
 		Use:   "check",
 		Short: "Validate MOD dependencies",
 		Args:  cobra.NoArgs,
@@ -26,6 +30,9 @@ func newMODCheckCommand(c *cli) *cobra.Command {
 
 			p := c.printer(cmd)
 			result := state.validation
+			if ignoreRecommended {
+				result = withoutRecommendedWarnings(result)
+			}
 			p.Info("Validating MOD dependencies...")
 
 			if result.Valid() && len(result.Warnings) == 0 {
@@ -73,6 +80,21 @@ func newMODCheckCommand(c *cli) *cobra.Command {
 			return nil
 		},
 	}
+	cmd.Flags().BoolVar(&ignoreRecommended, "ignore-recommended", false, "Do not warn about disabled recommended dependencies")
+	return cmd
+}
+
+// withoutRecommendedWarnings returns a copy of result with
+// WarningRecommendedDependencyDisabled entries removed, leaving the
+// original untouched.
+func withoutRecommendedWarnings(result *dependency.ValidationResult) *dependency.ValidationResult {
+	filtered := make([]dependency.ValidationWarning, 0, len(result.Warnings))
+	for _, w := range result.Warnings {
+		if w.Type != dependency.WarningRecommendedDependencyDisabled {
+			filtered = append(filtered, w)
+		}
+	}
+	return &dependency.ValidationResult{Errors: result.Errors, Warnings: filtered, Suggestions: result.Suggestions}
 }
 
 func pluralSuffix(n int) string {

--- a/internal/cli/mod_check_test.go
+++ b/internal/cli/mod_check_test.go
@@ -1,0 +1,56 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMODCheckAllSatisfied(t *testing.T) {
+	s := baseSandbox(t)
+	s.writeInstalledMOD(t, "app", "1.0.0", []string{"lib"})
+	s.writeInstalledMOD(t, "lib", "1.0.0", nil)
+	s.writeMODList(t,
+		modListEntry{name: "base", enabled: true},
+		modListEntry{name: "app", enabled: true},
+		modListEntry{name: "lib", enabled: true},
+	)
+
+	out, err := runCLI(t, "mod", "check")
+	require.NoError(t, err)
+	assert.Contains(t, out, "All enabled MOD(s) have their required dependencies satisfied")
+	assert.NotContains(t, out, "Warnings:")
+}
+
+func TestMODCheckWarnsAboutDisabledRecommendedDependency(t *testing.T) {
+	s := baseSandbox(t)
+	s.writeInstalledMOD(t, "app", "1.0.0", []string{"+ lib"})
+	s.writeInstalledMOD(t, "lib", "1.0.0", nil)
+	s.writeMODList(t,
+		modListEntry{name: "base", enabled: true},
+		modListEntry{name: "app", enabled: true},
+		modListEntry{name: "lib", enabled: false},
+	)
+
+	out, err := runCLI(t, "mod", "check")
+	require.NoError(t, err)
+	assert.Contains(t, out, "Warnings:")
+	assert.Contains(t, out, "recommends 'lib' which is not enabled")
+}
+
+func TestMODCheckIgnoresRecommendedWarningWithFlag(t *testing.T) {
+	s := baseSandbox(t)
+	s.writeInstalledMOD(t, "app", "1.0.0", []string{"+ lib"})
+	s.writeInstalledMOD(t, "lib", "1.0.0", nil)
+	s.writeMODList(t,
+		modListEntry{name: "base", enabled: true},
+		modListEntry{name: "app", enabled: true},
+		modListEntry{name: "lib", enabled: false},
+	)
+
+	out, err := runCLI(t, "mod", "check", "--ignore-recommended")
+	require.NoError(t, err)
+	assert.NotContains(t, out, "Warnings:")
+	assert.NotContains(t, out, "recommends 'lib' which is not enabled")
+}

--- a/internal/cli/mod_enable.go
+++ b/internal/cli/mod_enable.go
@@ -11,7 +11,7 @@ import (
 )
 
 func newMODEnableCommand(c *cli) *cobra.Command {
-	var yes bool
+	var yes, ignoreRecommended bool
 	var backupExtension string
 
 	cmd := &cobra.Command{
@@ -44,7 +44,7 @@ func newMODEnableCommand(c *cli) *cobra.Command {
 				}
 			}
 
-			planned, err := dependency.PlanEnable(state.graph, targets)
+			planned, err := dependency.PlanEnable(state.graph, targets, !ignoreRecommended)
 			if err != nil {
 				return err
 			}
@@ -74,6 +74,7 @@ func newMODEnableCommand(c *cli) *cobra.Command {
 		},
 	}
 	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "Skip confirmation prompts")
+	cmd.Flags().BoolVar(&ignoreRecommended, "ignore-recommended", false, "Do not enable recommended dependencies")
 	cmd.Flags().StringVar(&backupExtension, "backup-extension", defaultBackupExtension, "Backup file extension")
 	return cmd
 }

--- a/internal/cli/mod_enable_disable_test.go
+++ b/internal/cli/mod_enable_disable_test.go
@@ -68,6 +68,29 @@ func TestMODEnablePullsInInstalledRecommendedDep(t *testing.T) {
 	assert.True(t, states["lib"])
 }
 
+func TestMODEnableIgnoresRecommendedDepWithFlag(t *testing.T) {
+	s := baseSandbox(t)
+	s.writeInstalledMOD(t, "app", "1.0.0", []string{"+ lib"})
+	s.writeInstalledMOD(t, "lib", "1.0.0", nil)
+	s.writeMODList(t,
+		modListEntry{name: "base", enabled: true},
+		modListEntry{name: "app", enabled: false},
+		modListEntry{name: "lib", enabled: false},
+	)
+
+	out, err := runCLI(t, "mod", "enable", "app", "-y", "--ignore-recommended")
+	require.NoError(t, err)
+	assert.Equal(t, "ℹ Planning to enable 1 MOD(s):\n"+
+		"  - app\n"+
+		"✓ Enabled app\n"+
+		"✓ Enabled 1 MOD(s)\n"+
+		"✓ Saved mod-list.json\n", out)
+
+	states := s.readMODList(t)
+	assert.True(t, states["app"])
+	assert.False(t, states["lib"])
+}
+
 func TestMODEnableSkipsUninstalledRecommendedDep(t *testing.T) {
 	s := baseSandbox(t)
 	s.writeInstalledMOD(t, "app", "1.0.0", []string{"+ ghost"})

--- a/internal/cli/mod_install.go
+++ b/internal/cli/mod_install.go
@@ -25,7 +25,7 @@ type installTarget struct {
 
 func newMODInstallCommand(c *cli) *cobra.Command {
 	var jobs int
-	var yes bool
+	var yes, ignoreRecommended bool
 	var backupExtension string
 
 	cmd := &cobra.Command{
@@ -62,7 +62,7 @@ func newMODInstallCommand(c *cli) *cobra.Command {
 				specs[i] = spec
 			}
 
-			targets, err := planInstall(cmd.Context(), application, state.graph, specs, jobs)
+			targets, err := planInstall(cmd.Context(), application, state.graph, specs, jobs, !ignoreRecommended)
 			if err != nil {
 				return err
 			}
@@ -122,6 +122,7 @@ func newMODInstallCommand(c *cli) *cobra.Command {
 	}
 	cmd.Flags().IntVarP(&jobs, "jobs", "j", 4, "Number of parallel downloads")
 	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "Skip confirmation prompts")
+	cmd.Flags().BoolVar(&ignoreRecommended, "ignore-recommended", false, "Do not resolve or enable recommended dependencies")
 	cmd.Flags().StringVar(&backupExtension, "backup-extension", defaultBackupExtension, "Backup file extension")
 	return cmd
 }
@@ -141,7 +142,7 @@ func splitInstallTargets(targets []installTarget) (installs, enables []installTa
 // with them and their required dependencies (recursively), marks disabled
 // installed dependencies for enabling, validates the result, and extracts
 // the actions to perform.
-func planInstall(ctx context.Context, application *app.App, graph *dependency.Graph, specs []modSpec, jobs int) ([]installTarget, error) {
+func planInstall(ctx context.Context, application *app.App, graph *dependency.Graph, specs []modSpec, jobs int, includeRecommended bool) ([]installTarget, error) {
 	portalAPI, err := application.PortalAPI()
 	if err != nil {
 		return nil, err
@@ -174,11 +175,11 @@ func planInstall(ctx context.Context, application *app.App, graph *dependency.Gr
 		frontier = append(frontier, info.MOD)
 	}
 
-	if err := resolveInstallDependencies(ctx, application, graph, releases, frontier, jobs); err != nil {
+	if err := resolveInstallDependencies(ctx, application, graph, releases, frontier, jobs, includeRecommended); err != nil {
 		return nil, err
 	}
 
-	dependency.MarkDisabledDependenciesForEnable(graph)
+	dependency.MarkDisabledDependenciesForEnable(graph, includeRecommended)
 	if err := dependency.ValidateInstallGraph(graph); err != nil {
 		return nil, err
 	}
@@ -200,13 +201,14 @@ func planInstall(ctx context.Context, application *app.App, graph *dependency.Gr
 	return targets, nil
 }
 
-// resolveInstallDependencies walks the required and recommended edges of
-// newly-added graph nodes and fetches MODs not yet in the graph, extending
-// it recursively. Recommended dependencies are on by default, so they're
-// fetched the same as required ones. A dependency that cannot be fetched or
-// has no compatible release is skipped with a warning rather than failing
-// the install.
-func resolveInstallDependencies(ctx context.Context, application *app.App, graph *dependency.Graph, releases map[mod.MOD]api.Release, frontier []mod.MOD, jobs int) error {
+// resolveInstallDependencies walks the required (and, when includeRecommended
+// is true, recommended) edges of newly-added graph nodes and fetches MODs
+// not yet in the graph, extending it recursively. Recommended dependencies
+// are on by default, so they're fetched the same as required ones unless
+// the caller opts out. A dependency that cannot be fetched or has no
+// compatible release is skipped with a warning rather than failing the
+// install.
+func resolveInstallDependencies(ctx context.Context, application *app.App, graph *dependency.Graph, releases map[mod.MOD]api.Release, frontier []mod.MOD, jobs int, includeRecommended bool) error {
 	portalAPI, err := application.PortalAPI()
 	if err != nil {
 		return err
@@ -226,7 +228,8 @@ func resolveInstallDependencies(ctx context.Context, application *app.App, graph
 			}
 			processed[m] = true
 			for _, edge := range graph.EdgesFrom(m) {
-				if edge.Type != dependency.TypeRequired && edge.Type != dependency.TypeRecommended {
+				relevant := edge.Type == dependency.TypeRequired || (includeRecommended && edge.Type == dependency.TypeRecommended)
+				if !relevant {
 					continue
 				}
 				if graph.Contains(edge.To) {

--- a/internal/cli/mod_sync.go
+++ b/internal/cli/mod_sync.go
@@ -20,7 +20,7 @@ import (
 
 func newMODSyncCommand(c *cli) *cobra.Command {
 	var jobs int
-	var keepUnlisted, strictVersion, yes bool
+	var keepUnlisted, strictVersion, yes, ignoreRecommended bool
 	var backupExtension string
 
 	cmd := &cobra.Command{
@@ -58,7 +58,7 @@ func newMODSyncCommand(c *cli) *cobra.Command {
 			var installTargets []syncInstallTarget
 			var dependencyEntries []save.MODEntry
 			if len(modsToInstall) > 0 {
-				installTargets, dependencyEntries, err = planSyncInstallation(cmd.Context(), application, state.graph, modsToInstall, modDir, jobs, strictVersion)
+				installTargets, dependencyEntries, err = planSyncInstallation(cmd.Context(), application, state.graph, modsToInstall, modDir, jobs, strictVersion, !ignoreRecommended)
 				if err != nil {
 					return err
 				}
@@ -159,6 +159,7 @@ func newMODSyncCommand(c *cli) *cobra.Command {
 	cmd.Flags().BoolVar(&keepUnlisted, "keep-unlisted", false, "Keep MOD(s) not listed in save file enabled")
 	cmd.Flags().BoolVar(&strictVersion, "strict-version", false, "Install exact MOD versions from save file")
 	cmd.Flags().BoolVarP(&yes, "yes", "y", false, "Skip confirmation prompts")
+	cmd.Flags().BoolVar(&ignoreRecommended, "ignore-recommended", false, "Do not resolve recommended dependencies")
 	cmd.Flags().StringVar(&backupExtension, "backup-extension", defaultBackupExtension, "Backup file extension")
 	return cmd
 }
@@ -234,14 +235,15 @@ func findMODsToDelete(saveMODs []save.MODEntry, installed []mod.InstalledMOD) []
 
 // planSyncInstallation fetches full portal info for each MOD to install,
 // extends the dependency graph with them (for conflict detection), resolves
-// their recommended (and, defensively, required) dependencies not yet
-// installed anywhere — the same way mod install does (#91) — and builds the
-// download targets. A save file always includes active required
-// dependencies transitively, so this mainly matters for a recommended
-// dependency the save's original author had disabled; an installed-but-
-// disabled recommended dependency is left untouched, since sync has no
-// mechanism to re-enable something the save file doesn't list.
-func planSyncInstallation(ctx context.Context, application *app.App, graph *dependency.Graph, entries []save.MODEntry, modDir string, jobs int, strict bool) ([]syncInstallTarget, []save.MODEntry, error) {
+// their required (and, when includeRecommended is true, recommended)
+// dependencies not yet installed anywhere — the same way mod install does
+// (#91) — and builds the download targets. A save file always includes
+// active required dependencies transitively, so includeRecommended mainly
+// matters for a recommended dependency the save's original author had
+// disabled; an installed-but-disabled recommended dependency is left
+// untouched, since sync has no mechanism to re-enable something the save
+// file doesn't list.
+func planSyncInstallation(ctx context.Context, application *app.App, graph *dependency.Graph, entries []save.MODEntry, modDir string, jobs int, strict bool, includeRecommended bool) ([]syncInstallTarget, []save.MODEntry, error) {
 	portal, err := application.PortalAPI()
 	if err != nil {
 		return nil, nil, err
@@ -281,7 +283,7 @@ func planSyncInstallation(ctx context.Context, application *app.App, graph *depe
 		known[info.MOD] = true
 	}
 
-	if err := resolveInstallDependencies(ctx, application, graph, releases, frontier, jobs); err != nil {
+	if err := resolveInstallDependencies(ctx, application, graph, releases, frontier, jobs, includeRecommended); err != nil {
 		return nil, nil, err
 	}
 

--- a/internal/cli/portal_integration_sync_test.go
+++ b/internal/cli/portal_integration_sync_test.go
@@ -64,6 +64,40 @@ func TestMODSyncPullsInRecommendedDependencyAgainstMockPortal(t *testing.T) {
 	assert.True(t, states["lib-mod"])
 }
 
+func TestMODSyncIgnoresRecommendedDependencyWithFlag(t *testing.T) {
+	s, savePath := syncSandbox(t, []save.MODEntry{{Name: "some-mod", Version: mustVersion(t, "1.0.0")}}, nil)
+	s.writeMODList(t, modListEntry{name: "base", enabled: true})
+	// lib-mod is registered and fetchable so this test proves the flag
+	// itself excludes it, not that the fetch would have failed anyway.
+	portal := newMockPortal(t,
+		portalMOD{
+			Name: "some-mod", Title: "Some MOD", Owner: "alice",
+			Releases: []portalRelease{{
+				Version: "1.0.0", FileName: "some-mod_1.0.0.zip", DownloadURL: "/download/some-mod_1.0.0.zip",
+				InfoJSON: portalInfoJSON{Dependencies: []string{"+ lib-mod"}},
+			}},
+		},
+		portalMOD{
+			Name: "lib-mod", Title: "Lib MOD", Owner: "alice",
+			Releases: []portalRelease{{
+				Version: "2.0.0", FileName: "lib-mod_2.0.0.zip", DownloadURL: "/download/lib-mod_2.0.0.zip",
+			}},
+		},
+	)
+	portal.withPortal(t)
+
+	out, err := runCLI(t, "mod", "sync", savePath, "-y", "--ignore-recommended")
+	require.NoError(t, err)
+	assert.Contains(t, out, "Installed 1 MOD(s)")
+	assert.FileExists(t, filepath.Join(s.root, "factorio", "mods", "some-mod_1.0.0.zip"))
+	assert.NoFileExists(t, filepath.Join(s.root, "factorio", "mods", "lib-mod_2.0.0.zip"))
+
+	states := s.readMODList(t)
+	assert.True(t, states["some-mod"])
+	_, listed := states["lib-mod"]
+	assert.False(t, listed)
+}
+
 func TestMODSyncStrictVersionAgainstMockPortal(t *testing.T) {
 	s, savePath := syncSandbox(t, []save.MODEntry{{Name: "some-mod", Version: mustVersion(t, "1.0.0")}}, nil)
 	s.writeMODList(t, modListEntry{name: "base", enabled: true})

--- a/internal/cli/portal_integration_test.go
+++ b/internal/cli/portal_integration_test.go
@@ -158,6 +158,38 @@ func TestMODInstallPullsInRecommendedDependency(t *testing.T) {
 	assert.True(t, states["lib-mod"])
 }
 
+func TestMODInstallIgnoresRecommendedDependencyWithFlag(t *testing.T) {
+	s := baseSandbox(t)
+	s.writeMODList(t, modListEntry{name: "base", enabled: true})
+	mainRelease := portalRelease{
+		Version: "1.0.0", FileName: "some-mod_1.0.0.zip",
+		DownloadURL: "/download/some-mod_1.0.0.zip",
+		InfoJSON:    portalInfoJSON{FactorioVersion: "2.0", Dependencies: []string{"+ lib-mod"}},
+	}
+	libRelease := portalRelease{
+		Version: "2.0.0", FileName: "lib-mod_2.0.0.zip",
+		DownloadURL: "/download/lib-mod_2.0.0.zip",
+		InfoJSON:    portalInfoJSON{FactorioVersion: "2.0"},
+	}
+	// lib-mod is registered and fetchable so this test proves the flag
+	// itself excludes it, not that the fetch would have failed anyway.
+	portal := newMockPortal(t,
+		portalMOD{Name: "some-mod", Title: "Some MOD", Owner: "alice", Releases: []portalRelease{mainRelease}},
+		portalMOD{Name: "lib-mod", Title: "Lib MOD", Owner: "alice", Releases: []portalRelease{libRelease}},
+	)
+	portal.withPortal(t)
+
+	out, err := runCLI(t, "mod", "install", "some-mod", "-y", "--ignore-recommended")
+	require.NoError(t, err)
+	assert.Contains(t, out, "Installed 1 MOD(s)")
+
+	states := s.readMODList(t)
+	assert.True(t, states["some-mod"])
+	_, listed := states["lib-mod"]
+	assert.False(t, listed)
+	assert.NoFileExists(t, filepath.Join(s.root, "factorio", "mods", "lib-mod_2.0.0.zip"))
+}
+
 func TestMODInstallEnablesDisabledRecommendedDependency(t *testing.T) {
 	s := baseSandbox(t)
 	s.writeInstalledMOD(t, "lib-mod", "1.0.0", nil)

--- a/internal/dependency/plan.go
+++ b/internal/dependency/plan.go
@@ -14,16 +14,18 @@ var (
 )
 
 // PlanEnable computes the MODs to enable when enabling targets, pulling in
-// required dependencies (BFS discovery order). Recommended dependencies are
-// pulled in the same way when already installed with a satisfied version;
-// unlike required dependencies, a missing or version-mismatched recommended
-// dependency is silently skipped rather than rejected, since it's off by
-// default only by the user's own choice not to install it (fetching it from
-// the Portal is out of scope here, see #91). The base MOD is always
-// available and is never pulled in as a dependency. Targets already
+// required dependencies (BFS discovery order). When includeRecommended is
+// true, recommended dependencies are pulled in the same way when already
+// installed with a satisfied version; unlike required dependencies, a
+// missing or version-mismatched recommended dependency is silently skipped
+// rather than rejected, since it's off by default only by the user's own
+// choice not to install it (fetching it from the Portal is out of scope
+// here, see #91). When includeRecommended is false, recommended edges are
+// ignored entirely (the --ignore-recommended opt-out). The base MOD is
+// always available and is never pulled in as a dependency. Targets already
 // installed are assumed to exist in the graph; the caller validates that
 // before calling PlanEnable.
-func PlanEnable(g *Graph, targets []mod.MOD) ([]mod.MOD, error) {
+func PlanEnable(g *Graph, targets []mod.MOD, includeRecommended bool) ([]mod.MOD, error) {
 	planned := map[mod.MOD]bool{}
 	var order []mod.MOD
 	queue := append([]mod.MOD(nil), targets...)
@@ -41,6 +43,9 @@ func PlanEnable(g *Graph, targets []mod.MOD) ([]mod.MOD, error) {
 
 		for _, edge := range g.EdgesFrom(m) {
 			if edge.To.IsBase() {
+				continue
+			}
+			if edge.Type == TypeRecommended && !includeRecommended {
 				continue
 			}
 			switch edge.Type {
@@ -110,13 +115,14 @@ func checkConflict(g *Graph, m, other mod.MOD, plannedSet map[mod.MOD]bool) erro
 	return nil
 }
 
-// MarkDisabledDependenciesForEnable walks the required and recommended
-// dependencies of every node planned for install or enable and marks
-// installed-but-disabled dependencies for enabling (recursively), so
-// installing a MOD also turns its already-present dependency chain back
-// on. Recommended dependencies are on by default, so they're treated the
-// same as required ones here.
-func MarkDisabledDependenciesForEnable(g *Graph) {
+// MarkDisabledDependenciesForEnable walks the required (and, when
+// includeRecommended is true, recommended) dependencies of every node
+// planned for install or enable and marks installed-but-disabled
+// dependencies for enabling (recursively), so installing a MOD also turns
+// its already-present dependency chain back on. Recommended dependencies
+// are on by default, so they're treated the same as required ones unless
+// the caller opts out via includeRecommended=false.
+func MarkDisabledDependenciesForEnable(g *Graph, includeRecommended bool) {
 	var queue []mod.MOD
 	for _, node := range g.Nodes() {
 		if node.Operation == OpInstall || node.Operation == OpEnable {
@@ -134,7 +140,8 @@ func MarkDisabledDependenciesForEnable(g *Graph) {
 		processed[m] = true
 
 		for _, edge := range g.EdgesFrom(m) {
-			if edge.Type != TypeRequired && edge.Type != TypeRecommended {
+			relevant := edge.Type == TypeRequired || (includeRecommended && edge.Type == TypeRecommended)
+			if !relevant {
 				continue
 			}
 			depNode, ok := g.Node(edge.To)

--- a/internal/dependency/plan_test.go
+++ b/internal/dependency/plan_test.go
@@ -21,7 +21,7 @@ func TestPlanEnablePullsInRequiredDeps(t *testing.T) {
 	requireEdge(t, g, "app", "lib", TypeRequired)
 	requireEdge(t, g, "app", "base", TypeRequired) // base is skipped
 
-	planned, err := PlanEnable(g, []mod.MOD{testMOD("app")})
+	planned, err := PlanEnable(g, []mod.MOD{testMOD("app")}, true)
 	require.NoError(t, err)
 	assert.Equal(t, []mod.MOD{testMOD("app"), testMOD("lib")}, planned)
 }
@@ -32,7 +32,7 @@ func TestPlanEnableSkipsAlreadyEnabled(t *testing.T) {
 	addNodes(t, g, "lib") // enabled
 	requireEdge(t, g, "app", "lib", TypeRequired)
 
-	planned, err := PlanEnable(g, []mod.MOD{testMOD("app")})
+	planned, err := PlanEnable(g, []mod.MOD{testMOD("app")}, true)
 	require.NoError(t, err)
 	assert.Equal(t, []mod.MOD{testMOD("app")}, planned)
 }
@@ -42,7 +42,7 @@ func TestPlanEnableMissingDependency(t *testing.T) {
 	disabledNode(t, g, "app")
 	requireEdge(t, g, "app", "ghost", TypeRequired)
 
-	_, err := PlanEnable(g, []mod.MOD{testMOD("app")})
+	_, err := PlanEnable(g, []mod.MOD{testMOD("app")}, true)
 	require.ErrorIs(t, err, ErrDependencyMissing)
 }
 
@@ -55,7 +55,7 @@ func TestPlanEnableVersionMismatch(t *testing.T) {
 		Requirement: &VersionRequirement{Operator: OpGreaterEqual, Version: mod.MODVersion{Major: 2}},
 	}))
 
-	_, err := PlanEnable(g, []mod.MOD{testMOD("app")})
+	_, err := PlanEnable(g, []mod.MOD{testMOD("app")}, true)
 	require.ErrorIs(t, err, ErrDependencyVersion)
 }
 
@@ -65,7 +65,7 @@ func TestPlanEnablePullsInInstalledRecommendedDeps(t *testing.T) {
 	disabledNode(t, g, "lib")
 	requireEdge(t, g, "app", "lib", TypeRecommended)
 
-	planned, err := PlanEnable(g, []mod.MOD{testMOD("app")})
+	planned, err := PlanEnable(g, []mod.MOD{testMOD("app")}, true)
 	require.NoError(t, err)
 	assert.Equal(t, []mod.MOD{testMOD("app"), testMOD("lib")}, planned)
 }
@@ -75,7 +75,7 @@ func TestPlanEnableSkipsUninstalledRecommendedDep(t *testing.T) {
 	disabledNode(t, g, "app")
 	requireEdge(t, g, "app", "ghost", TypeRecommended)
 
-	planned, err := PlanEnable(g, []mod.MOD{testMOD("app")})
+	planned, err := PlanEnable(g, []mod.MOD{testMOD("app")}, true)
 	require.NoError(t, err)
 	assert.Equal(t, []mod.MOD{testMOD("app")}, planned)
 }
@@ -89,7 +89,18 @@ func TestPlanEnableSkipsVersionMismatchedRecommendedDep(t *testing.T) {
 		Requirement: &VersionRequirement{Operator: OpGreaterEqual, Version: mod.MODVersion{Major: 2}},
 	}))
 
-	planned, err := PlanEnable(g, []mod.MOD{testMOD("app")})
+	planned, err := PlanEnable(g, []mod.MOD{testMOD("app")}, true)
+	require.NoError(t, err)
+	assert.Equal(t, []mod.MOD{testMOD("app")}, planned)
+}
+
+func TestPlanEnableIgnoresRecommendedDepsWhenExcluded(t *testing.T) {
+	g := NewGraph()
+	disabledNode(t, g, "app")
+	disabledNode(t, g, "lib")
+	requireEdge(t, g, "app", "lib", TypeRecommended)
+
+	planned, err := PlanEnable(g, []mod.MOD{testMOD("app")}, false)
 	require.NoError(t, err)
 	assert.Equal(t, []mod.MOD{testMOD("app")}, planned)
 }
@@ -193,7 +204,7 @@ func TestMarkDisabledDependenciesForEnable(t *testing.T) {
 	disabledNode(t, g, "optional-lib")
 	requireEdge(t, g, "new-mod", "optional-lib", TypeOptional)
 
-	MarkDisabledDependenciesForEnable(g)
+	MarkDisabledDependenciesForEnable(g, true)
 
 	lib, _ := g.Node(testMOD("lib"))
 	assert.Equal(t, OpEnable, lib.Operation)
@@ -208,10 +219,21 @@ func TestMarkDisabledDependenciesForEnableRecommended(t *testing.T) {
 	require.NoError(t, g.AddUninstalledMOD(testMOD("new-mod"), mod.MODVersion{Major: 1}, []string{"+ lib"}))
 	disabledNode(t, g, "lib")
 
-	MarkDisabledDependenciesForEnable(g)
+	MarkDisabledDependenciesForEnable(g, true)
 
 	lib, _ := g.Node(testMOD("lib"))
 	assert.Equal(t, OpEnable, lib.Operation)
+}
+
+func TestMarkDisabledDependenciesForEnableIgnoresRecommendedWhenExcluded(t *testing.T) {
+	g := NewGraph()
+	require.NoError(t, g.AddUninstalledMOD(testMOD("new-mod"), mod.MODVersion{Major: 1}, []string{"+ lib"}))
+	disabledNode(t, g, "lib")
+
+	MarkDisabledDependenciesForEnable(g, false)
+
+	lib, _ := g.Node(testMOD("lib"))
+	assert.Equal(t, OpNone, lib.Operation)
 }
 
 func TestValidateInstallGraphCycle(t *testing.T) {


### PR DESCRIPTION
## Summary
Recommended (`+`) dependencies are on by default (#90-#94), but there was no way to opt out. Add a consistent `--ignore-recommended` flag across `mod check`, `mod install`, `mod enable`, and `mod sync`.

## Changes
- `mod check`: filters `WarningRecommendedDependencyDisabled` out of the displayed/counted warnings (display-only change; `loadMODState`/`Validator` are untouched, so other commands sharing that validation are unaffected)
- `mod enable`: `PlanEnable` gains an `includeRecommended` parameter, skipping recommended edges entirely when false
- `mod install`: `resolveInstallDependencies` and `MarkDisabledDependenciesForEnable` gain the same parameter
- `mod sync`: `planSyncInstallation` threads the same parameter through to `resolveInstallDependencies`
- All existing call sites pass `includeRecommended=true`, preserving current behavior; only the new CLI flags set it to false
- Updated the CHANGELOG's Unreleased entry to describe the full recommended-dependency behavior instead of just the earlier parsing-support wording

## Test Plan
- [x] Added unit tests for the excluded case in `internal/dependency`
- [x] Added CLI-level tests for each of the four commands (new `mod_check_test.go`, since no test file existed for `mod check` before)
- [x] `mise run default` passes
