### PR TITLE
:arrow_up: Migrate retry-go from v4 to v5

### DIFF
--- a/go.mod
+++ b/go.mod
@@ -4,7 +4,7 @@ go 1.25.0
 
 require (
 	github.com/BurntSushi/toml v1.6.0
-	github.com/avast/retry-go/v4 v4.7.0
+	github.com/avast/retry-go/v5 v5.0.0
 	github.com/fatih/color v1.19.0
 	github.com/gofrs/flock v0.13.0
 	github.com/spf13/cobra v1.10.2

--- a/go.sum
+++ b/go.sum
@@ -4,8 +4,8 @@ github.com/VividCortex/ewma v1.2.0 h1:f58SaIzcDXrSy3kWaHNvuJgJ3Nmz59Zji6XoJR/q1o
 github.com/VividCortex/ewma v1.2.0/go.mod h1:nz4BbCtbLyFDeC9SUHbtcT5644juEuWfUAUnGx7j5l4=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d h1:licZJFw2RwpHMqeKTCYkitsPqHNxTmd4SNR5r94FGM8=
 github.com/acarl005/stripansi v0.0.0-20180116102854-5a71ef0e047d/go.mod h1:asat636LX7Bqt5lYEZ27JNDcqxfjdBQuJ/MM4CN/Lzo=
-github.com/avast/retry-go/v4 v4.7.0 h1:yjDs35SlGvKwRNSykujfjdMxMhMQQM0TnIjJaHB+Zio=
-github.com/avast/retry-go/v4 v4.7.0/go.mod h1:ZMPDa3sY2bKgpLtap9JRUgk2yTAba7cgiFhqxY2Sg6Q=
+github.com/avast/retry-go/v5 v5.0.0 h1:kf1Qc2UsTZ4qq8elDymqfbISvkyMuhgRxuJqX2NHP7k=
+github.com/avast/retry-go/v5 v5.0.0/go.mod h1://d+usmKWio1agtZfS1H/ltTqwtIfBnRq9zEwjc3eH8=
 github.com/clipperhouse/uax29/v2 v2.7.0 h1:+gs4oBZ2gPfVrKPthwbMzWZDaAFPGYK72F0NJv2v7Vk=
 github.com/clipperhouse/uax29/v2 v2.7.0/go.mod h1:EFJ2TJMRUaplDxHKj1qAEhCtQPW2tJSwu5BF98AuoVM=
 github.com/cpuguy83/go-md2man/v2 v2.0.6/go.mod h1:oOW0eioCTA6cOiMLiUPZOpcVxMig6NIQQ7OS05n1F4g=

--- a/internal/httpx/retry.go
+++ b/internal/httpx/retry.go
@@ -8,7 +8,7 @@ import (
 	"net/http"
 	"time"
 
-	"github.com/avast/retry-go/v4"
+	"github.com/avast/retry-go/v5"
 )
 
 // RetryTransport retries requests that fail at the transport level
@@ -53,20 +53,7 @@ func (t *RetryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 	}
 
 	attempt := 0
-	return retry.DoWithData(
-		func() (*http.Response, error) {
-			r := req
-			if attempt > 0 && req.GetBody != nil {
-				body, err := req.GetBody()
-				if err != nil {
-					return nil, retry.Unrecoverable(err)
-				}
-				r = req.Clone(req.Context())
-				r.Body = body
-			}
-			attempt++
-			return t.next.RoundTrip(r)
-		},
+	retrier := retry.NewWithData[*http.Response](
 		retry.Context(req.Context()),
 		retry.Attempts(t.attempts),
 		retry.Delay(t.delay),
@@ -80,4 +67,17 @@ func (t *RetryTransport) RoundTrip(req *http.Request) (*http.Response, error) {
 		}),
 		retry.LastErrorOnly(true),
 	)
+	return retrier.Do(func() (*http.Response, error) {
+		r := req
+		if attempt > 0 && req.GetBody != nil {
+			body, err := req.GetBody()
+			if err != nil {
+				return nil, retry.Unrecoverable(err)
+			}
+			r = req.Clone(req.Context())
+			r.Body = body
+		}
+		attempt++
+		return t.next.RoundTrip(r)
+	})
 }


### PR DESCRIPTION
## Summary
Renovate's v4->v5 update PR (#155) only bumped go.mod/go.sum, leaving an unused v5 requirement alongside the still-imported v4 — Go module major version bumps change the import path, so Renovate can't rewrite the source itself.

## Changes
- Replace v4's functional-options call style (`retry.DoWithData(fn, opts...)`) with v5's builder (`retry.NewWithData[T](opts...).Do(fn)`) in `internal/httpx/retry.go`
- The option functions used (`Context`, `Attempts`, `Delay`, `MaxJitter`, `DelayType`, `CombineDelay`, `BackOffDelay`, `RandomDelay`, `RetryIf`, `OnRetry`, `LastErrorOnly`, `Unrecoverable`) are unchanged in v5, so this is a mechanical rewrite with no intended behavioral difference
- `go.mod`/`go.sum` cleanly swap v4 for v5

## Test Plan
- [x] Existing `retry_test.go` suite (5 tests covering recovery, give-up, body replay, unreplayable body, context cancellation) passes unchanged
- [x] `mise run default` passes

Closes #155
