### PR TITLE
:sparkles: Accept Factorio 2.1 in the mod search version filter

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Added
+
+- Accept Factorio 2.1 as a `mod search --version` filter value
+
 ## [0.20.0] - 2026-07-12
 
 Factorix is being rewritten from Ruby to Go, reaching full command parity:

--- a/internal/api/portal.go
+++ b/internal/api/portal.go
@@ -50,7 +50,7 @@ type GetMODsOptions struct {
 var (
 	validSorts    = []string{"name", "created_at", "updated_at"}
 	validOrders   = []string{"asc", "desc"}
-	validVersions = []string{"0.13", "0.14", "0.15", "0.16", "0.17", "0.18", "1.0", "1.1", "2.0"}
+	validVersions = []string{"0.13", "0.14", "0.15", "0.16", "0.17", "0.18", "1.0", "1.1", "2.0", "2.1"}
 )
 
 func (o GetMODsOptions) validate() error {

--- a/internal/api/portal_test.go
+++ b/internal/api/portal_test.go
@@ -138,4 +138,5 @@ func TestGetMODsValidation(t *testing.T) {
 
 	// "max" is a valid page size but requires a server; validation alone passes.
 	require.NoError(t, GetMODsOptions{PageSize: "max"}.validate())
+	require.NoError(t, GetMODsOptions{Version: "2.1"}.validate())
 }


### PR DESCRIPTION
## Summary
Add Factorio 2.1 to the MOD Portal search API's version filter whitelist.

## Changes
- Add `"2.1"` to `validVersions` in `internal/api/portal.go`, so `mod search --version 2.1` is accepted
- The default version is unaffected — it's derived dynamically from the installed `base` MOD's version, not hardcoded to "2.0"

## Test Plan
- [x] Added a positive-validation test case for `Version: "2.1"`
- [x] `mise run default` passes
