### PR TITLE
:recycle: Split MOD Portal author commands into a new dev command

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,10 @@
 
 - Accept Factorio 2.1 as a `mod search --version` filter value
 
+### Changed
+
+- **BREAKING**: Move `mod upload`, `mod edit`, `mod changelog`, and `mod image` to a new `dev` command (`dev upload`, `dev edit`, `dev changelog`, `dev image`), separating MOD-authoring/Portal-publishing commands from gameplay-time MOD management (#167)
+
 ## [0.20.0] - 2026-07-12
 
 Factorix is being rewritten from Ruby to Go, reaching full command parity:

--- a/doc/factorix.1
+++ b/doc/factorix.1
@@ -312,7 +312,10 @@ Do not resolve recommended dependencies.
 .TP
 .BR \-\-backup\-extension =\fIVALUE\fR
 Backup file extension for mod\-list.json (default: .bak).
-.SS factorix mod changelog add ENTRY...
+.SH DEV COMMANDS
+These commands support MOD development: changelog maintenance and MOD Portal
+publishing. The MOD Portal commands require authentication.
+.SS factorix dev changelog add ENTRY...
 Add an entry to MOD changelog. Multiple arguments are joined with spaces.
 .TP
 .BR \-\-version =\fIVALUE\fR
@@ -323,7 +326,7 @@ Category (e.g., Features, Bugfixes). Required.
 .TP
 .BR \-\-changelog =\fIVALUE\fR
 Path to changelog file (default: changelog.txt).
-.SS factorix mod changelog extract
+.SS factorix dev changelog extract
 Extract a changelog section for a specific version.
 .TP
 .BR \-\-version =\fIVALUE\fR
@@ -334,7 +337,7 @@ Output in JSON format.
 .TP
 .BR \-\-changelog =\fIVALUE\fR
 Path to changelog file (default: changelog.txt).
-.SS factorix mod changelog check
+.SS factorix dev changelog check
 Validate MOD changelog structure.
 .TP
 .B \-\-release
@@ -345,7 +348,7 @@ Path to changelog file (default: changelog.txt).
 .TP
 .BR \-\-info\-json =\fIVALUE\fR
 Path to info.json file (default: info.json).
-.SS factorix mod changelog release
+.SS factorix dev changelog release
 Convert Unreleased changelog section to a versioned section.
 .TP
 .BR \-\-version =\fIVALUE\fR
@@ -359,9 +362,7 @@ Path to changelog file (default: changelog.txt).
 .TP
 .BR \-\-info\-json =\fIVALUE\fR
 Path to info.json file (default: info.json).
-.SH MOD PORTAL COMMANDS
-These commands interact with the Factorio MOD Portal and require authentication.
-.SS factorix mod upload FILE
+.SS factorix dev upload FILE
 Upload MOD to Factorio MOD Portal. Handles both new MODs and updates.
 .TP
 .BR \-\-description =\fIVALUE\fR
@@ -375,7 +376,7 @@ License identifier.
 .TP
 .BR \-\-source\-url =\fIVALUE\fR
 Repository URL.
-.SS factorix mod edit MOD_NAME
+.SS factorix dev edit MOD_NAME
 Edit MOD metadata on Factorio MOD Portal.
 .TP
 .BR \-\-title =\fIVALUE\fR
@@ -407,14 +408,14 @@ FAQ text.
 .TP
 .BR \-\-deprecated
 Deprecation flag. Use \-\-deprecated=false to clear it.
-.SS factorix mod image list MOD_NAME
+.SS factorix dev image list MOD_NAME
 List images for a MOD.
 .TP
 .B \-\-json
 Output in JSON format.
-.SS factorix mod image add MOD_NAME IMAGE_FILE
+.SS factorix dev image add MOD_NAME IMAGE_FILE
 Add an image to a MOD.
-.SS factorix mod image edit MOD_NAME IMAGE_IDS
+.SS factorix dev image edit MOD_NAME IMAGE_IDS
 Edit MOD's image list. Reorder or remove images by specifying IDs in desired order.
 .SH SETTINGS COMMANDS
 .SS factorix mod settings dump [SETTINGS_FILE]

--- a/e2e/cases/changelog/check-invalid/case.yaml
+++ b/e2e/cases/changelog/check-invalid/case.yaml
@@ -1,4 +1,4 @@
-command: [mod, changelog, check]
+command: [dev, changelog, check]
 files:
   - {from: //testdata/changelog/wrong_order.txt, to: cwd/changelog.txt}
 expect:

--- a/e2e/cases/changelog/check-valid/case.yaml
+++ b/e2e/cases/changelog/check-valid/case.yaml
@@ -1,4 +1,4 @@
-command: [mod, changelog, check]
+command: [dev, changelog, check]
 files:
   - {from: //testdata/changelog/basic.txt, to: cwd/changelog.txt}
 expect:

--- a/e2e/cases/changelog/extract/case.yaml
+++ b/e2e/cases/changelog/extract/case.yaml
@@ -1,4 +1,4 @@
-command: [mod, changelog, extract, --version, 1.1.0]
+command: [dev, changelog, extract, --version, 1.1.0]
 files:
   - {from: //testdata/changelog/basic.txt, to: cwd/changelog.txt}
 expect:

--- a/internal/cli/cli.go
+++ b/internal/cli/cli.go
@@ -99,6 +99,7 @@ func NewRootCommand() (root *cobra.Command, reportError func(error)) {
 		newLaunchCommand(c),
 		newManCommand(),
 		newMODCommand(c),
+		newDevCommand(c),
 		newCacheCommand(c),
 		newBlueprintCommand(c),
 		newRConCommand(c),

--- a/internal/cli/dev.go
+++ b/internal/cli/dev.go
@@ -1,0 +1,20 @@
+package cli
+
+import (
+	"github.com/spf13/cobra"
+)
+
+func newDevCommand(c *cli) *cobra.Command {
+	dev := &cobra.Command{
+		Use:   "dev",
+		Short: "MOD development and MOD Portal publishing commands",
+	}
+	dev.AddCommand(
+		newDevUploadCommand(c),
+		newDevEditCommand(c),
+		newDevChangelogCommand(c),
+		newDevImageCommand(c),
+	)
+
+	return dev
+}

--- a/internal/cli/dev_changelog.go
+++ b/internal/cli/dev_changelog.go
@@ -15,21 +15,21 @@ import (
 	"github.com/sakuro/factorix/internal/mod"
 )
 
-func newMODChangelogCommand(c *cli) *cobra.Command {
+func newDevChangelogCommand(c *cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "changelog",
 		Short: "Manage MOD changelogs",
 	}
 	cmd.AddCommand(
-		newMODChangelogAddCommand(c),
-		newMODChangelogCheckCommand(c),
-		newMODChangelogExtractCommand(c),
-		newMODChangelogReleaseCommand(c),
+		newDevChangelogAddCommand(c),
+		newDevChangelogCheckCommand(c),
+		newDevChangelogExtractCommand(c),
+		newDevChangelogReleaseCommand(c),
 	)
 	return cmd
 }
 
-func newMODChangelogAddCommand(c *cli) *cobra.Command {
+func newDevChangelogAddCommand(c *cli) *cobra.Command {
 	var version, category, changelogPath string
 
 	cmd := &cobra.Command{
@@ -62,7 +62,7 @@ func newMODChangelogAddCommand(c *cli) *cobra.Command {
 	return cmd
 }
 
-func newMODChangelogCheckCommand(c *cli) *cobra.Command {
+func newDevChangelogCheckCommand(c *cli) *cobra.Command {
 	var release bool
 	var changelogPath, infoJSONPath string
 
@@ -166,7 +166,7 @@ func validateReleaseMode(log *changelog.Changelog, infoJSONPath string) ([]strin
 	return errs, nil
 }
 
-func newMODChangelogExtractCommand(c *cli) *cobra.Command {
+func newDevChangelogExtractCommand(c *cli) *cobra.Command {
 	var version, changelogPath string
 	var jsonOutput bool
 
@@ -254,7 +254,7 @@ func appendJSON(b *bytes.Buffer, v any) error {
 	return nil
 }
 
-func newMODChangelogReleaseCommand(c *cli) *cobra.Command {
+func newDevChangelogReleaseCommand(c *cli) *cobra.Command {
 	var version, date, changelogPath, infoJSONPath string
 
 	cmd := &cobra.Command{

--- a/internal/cli/dev_changelog_test.go
+++ b/internal/cli/dev_changelog_test.go
@@ -13,66 +13,66 @@ func changelogFixture(name string) string {
 	return filepath.Join("..", "..", "testdata", "changelog", name)
 }
 
-func TestMODChangelogCheckValid(t *testing.T) {
+func TestDevChangelogCheckValid(t *testing.T) {
 	newSandbox(t)
-	out, err := runCLI(t, "mod", "changelog", "check", "--changelog", changelogFixture("basic.txt"))
+	out, err := runCLI(t, "dev", "changelog", "check", "--changelog", changelogFixture("basic.txt"))
 	require.NoError(t, err)
 	assert.Equal(t, expectedStdout(t, "changelog", "check-valid", "expected_stdout.txt"), out)
 }
 
-func TestMODChangelogCheckWrongOrder(t *testing.T) {
+func TestDevChangelogCheckWrongOrder(t *testing.T) {
 	newSandbox(t)
-	out, err := runCLI(t, "mod", "changelog", "check", "--changelog", changelogFixture("wrong_order.txt"))
+	out, err := runCLI(t, "dev", "changelog", "check", "--changelog", changelogFixture("wrong_order.txt"))
 	require.Error(t, err)
 	assert.Equal(t, "Changelog validation failed", err.Error())
 	assert.Equal(t, expectedStdout(t, "changelog", "check-invalid", "expected_stdout.txt"), out)
 }
 
-func TestMODChangelogCheckParseFailure(t *testing.T) {
+func TestDevChangelogCheckParseFailure(t *testing.T) {
 	s := newSandbox(t)
 	path := filepath.Join(s.root, "broken.txt")
 	require.NoError(t, os.WriteFile(path, []byte("not a changelog\n"), 0o644))
 
-	out, err := runCLI(t, "mod", "changelog", "check", "--changelog", path)
+	out, err := runCLI(t, "dev", "changelog", "check", "--changelog", path)
 	require.Error(t, err)
 	assert.Contains(t, out, "  - Failed to parse changelog:")
 }
 
-func TestMODChangelogCheckReleaseMode(t *testing.T) {
+func TestDevChangelogCheckReleaseMode(t *testing.T) {
 	s := newSandbox(t)
 	path := filepath.Join(s.root, "changelog.txt")
-	_, err := runCLI(t, "mod", "changelog", "add", "--changelog", path, "--category", "Features", "New", "thing")
+	_, err := runCLI(t, "dev", "changelog", "add", "--changelog", path, "--category", "Features", "New", "thing")
 	require.NoError(t, err)
 
 	// Unreleased section present and info.json missing.
-	out, err := runCLI(t, "mod", "changelog", "check", "--release",
+	out, err := runCLI(t, "dev", "changelog", "check", "--release",
 		"--changelog", path, "--info-json", filepath.Join(s.root, "info.json"))
 	require.Error(t, err)
 	assert.Contains(t, out, "  - Unreleased section is not allowed in release mode\n")
 	assert.Contains(t, out, "  - info.json not found: ")
 
 	// Released changelog whose version does not match info.json.
-	_, err = runCLI(t, "mod", "changelog", "release", "--changelog", path, "--version", "1.0.0", "--date", "2026-07-10")
+	_, err = runCLI(t, "dev", "changelog", "release", "--changelog", path, "--version", "1.0.0", "--date", "2026-07-10")
 	require.NoError(t, err)
 	infoPath := filepath.Join(s.root, "info.json")
 	info := `{"name": "m", "version": "2.0.0", "title": "m", "author": "a", "factorio_version": "2.0"}`
 	require.NoError(t, os.WriteFile(infoPath, []byte(info), 0o644))
 
-	out, err = runCLI(t, "mod", "changelog", "check", "--release", "--changelog", path, "--info-json", infoPath)
+	out, err = runCLI(t, "dev", "changelog", "check", "--release", "--changelog", path, "--info-json", infoPath)
 	require.Error(t, err)
 	assert.Contains(t, out, "  - info.json version (2.0.0) does not match first changelog version (1.0.0)\n")
 }
 
-func TestMODChangelogExtractText(t *testing.T) {
+func TestDevChangelogExtractText(t *testing.T) {
 	newSandbox(t)
-	out, err := runCLI(t, "mod", "changelog", "extract", "--version", "1.1.0", "--changelog", changelogFixture("basic.txt"))
+	out, err := runCLI(t, "dev", "changelog", "extract", "--version", "1.1.0", "--changelog", changelogFixture("basic.txt"))
 	require.NoError(t, err)
 	assert.Equal(t, expectedStdout(t, "changelog", "extract", "expected_stdout.txt"), out)
 }
 
-func TestMODChangelogExtractJSON(t *testing.T) {
+func TestDevChangelogExtractJSON(t *testing.T) {
 	newSandbox(t)
-	out, err := runCLI(t, "mod", "changelog", "extract", "--version", "1.1.0", "--json", "--changelog", changelogFixture("basic.txt"))
+	out, err := runCLI(t, "dev", "changelog", "extract", "--version", "1.1.0", "--json", "--changelog", changelogFixture("basic.txt"))
 	require.NoError(t, err)
 	// Category order follows the file, date is null when absent (as in
 	// Ruby's JSON.pretty_generate).
@@ -92,18 +92,18 @@ func TestMODChangelogExtractJSON(t *testing.T) {
 `, out)
 }
 
-func TestMODChangelogExtractVersionNotFound(t *testing.T) {
+func TestDevChangelogExtractVersionNotFound(t *testing.T) {
 	newSandbox(t)
-	_, err := runCLI(t, "mod", "changelog", "extract", "--version", "9.9.9", "--changelog", changelogFixture("basic.txt"))
+	_, err := runCLI(t, "dev", "changelog", "extract", "--version", "9.9.9", "--changelog", changelogFixture("basic.txt"))
 	require.Error(t, err)
 	assert.Equal(t, "version not found: 9.9.9", err.Error())
 }
 
-func TestMODChangelogAddCreatesUnreleased(t *testing.T) {
+func TestDevChangelogAddCreatesUnreleased(t *testing.T) {
 	s := newSandbox(t)
 	path := filepath.Join(s.root, "changelog.txt")
 
-	out, err := runCLI(t, "mod", "changelog", "add", "--changelog", path, "--category", "Features", "Added", "something", "new")
+	out, err := runCLI(t, "dev", "changelog", "add", "--changelog", path, "--category", "Features", "Added", "something", "new")
 	require.NoError(t, err)
 	assert.Equal(t, "✓ Added entry to Unreleased [Features]\n", out)
 
@@ -112,14 +112,14 @@ func TestMODChangelogAddCreatesUnreleased(t *testing.T) {
 	assert.Contains(t, string(data), "Version: Unreleased\n  Features:\n    - Added something new\n")
 }
 
-func TestMODChangelogAddToExistingVersion(t *testing.T) {
+func TestDevChangelogAddToExistingVersion(t *testing.T) {
 	s := newSandbox(t)
 	path := filepath.Join(s.root, "changelog.txt")
 	fixture, err := os.ReadFile(changelogFixture("basic.txt"))
 	require.NoError(t, err)
 	require.NoError(t, os.WriteFile(path, fixture, 0o644))
 
-	out, err := runCLI(t, "mod", "changelog", "add", "--changelog", path, "--version", "1.0.0", "--category", "Features", "Another", "one")
+	out, err := runCLI(t, "dev", "changelog", "add", "--changelog", path, "--version", "1.0.0", "--category", "Features", "Another", "one")
 	require.NoError(t, err)
 	assert.Equal(t, "✓ Added entry to 1.0.0 [Features]\n", out)
 
@@ -128,31 +128,31 @@ func TestMODChangelogAddToExistingVersion(t *testing.T) {
 	assert.Contains(t, string(data), "    - Initial release\n    - Another one\n")
 }
 
-func TestMODChangelogAddDuplicateEntry(t *testing.T) {
+func TestDevChangelogAddDuplicateEntry(t *testing.T) {
 	s := newSandbox(t)
 	path := filepath.Join(s.root, "changelog.txt")
 
-	_, err := runCLI(t, "mod", "changelog", "add", "--changelog", path, "--category", "Features", "Same")
+	_, err := runCLI(t, "dev", "changelog", "add", "--changelog", path, "--category", "Features", "Same")
 	require.NoError(t, err)
-	_, err = runCLI(t, "mod", "changelog", "add", "--changelog", path, "--category", "Features", "Same")
+	_, err = runCLI(t, "dev", "changelog", "add", "--changelog", path, "--category", "Features", "Same")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "duplicate entry: Same")
 }
 
-func TestMODChangelogAddRequiresCategory(t *testing.T) {
+func TestDevChangelogAddRequiresCategory(t *testing.T) {
 	newSandbox(t)
-	_, err := runCLI(t, "mod", "changelog", "add", "Entry")
+	_, err := runCLI(t, "dev", "changelog", "add", "Entry")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "category")
 }
 
-func TestMODChangelogRelease(t *testing.T) {
+func TestDevChangelogRelease(t *testing.T) {
 	s := newSandbox(t)
 	path := filepath.Join(s.root, "changelog.txt")
-	_, err := runCLI(t, "mod", "changelog", "add", "--changelog", path, "--category", "Features", "New", "thing")
+	_, err := runCLI(t, "dev", "changelog", "add", "--changelog", path, "--category", "Features", "New", "thing")
 	require.NoError(t, err)
 
-	out, err := runCLI(t, "mod", "changelog", "release", "--changelog", path, "--version", "1.2.0", "--date", "2026-07-10")
+	out, err := runCLI(t, "dev", "changelog", "release", "--changelog", path, "--version", "1.2.0", "--date", "2026-07-10")
 	require.NoError(t, err)
 	assert.Equal(t, "✓ Converted Unreleased to 1.2.0 (2026-07-10)\n", out)
 
@@ -161,23 +161,23 @@ func TestMODChangelogRelease(t *testing.T) {
 	assert.Contains(t, string(data), "Version: 1.2.0\nDate: 2026-07-10\n")
 }
 
-func TestMODChangelogReleaseVersionFromInfoJSON(t *testing.T) {
+func TestDevChangelogReleaseVersionFromInfoJSON(t *testing.T) {
 	s := newSandbox(t)
 	path := filepath.Join(s.root, "changelog.txt")
 	infoPath := filepath.Join(s.root, "info.json")
-	_, err := runCLI(t, "mod", "changelog", "add", "--changelog", path, "--category", "Features", "New", "thing")
+	_, err := runCLI(t, "dev", "changelog", "add", "--changelog", path, "--category", "Features", "New", "thing")
 	require.NoError(t, err)
 	info := `{"name": "m", "version": "3.4.5", "title": "m", "author": "a", "factorio_version": "2.0"}`
 	require.NoError(t, os.WriteFile(infoPath, []byte(info), 0o644))
 
-	out, err := runCLI(t, "mod", "changelog", "release", "--changelog", path, "--info-json", infoPath, "--date", "2026-07-10")
+	out, err := runCLI(t, "dev", "changelog", "release", "--changelog", path, "--info-json", infoPath, "--date", "2026-07-10")
 	require.NoError(t, err)
 	assert.Equal(t, "✓ Converted Unreleased to 3.4.5 (2026-07-10)\n", out)
 }
 
-func TestMODChangelogReleaseWithoutUnreleased(t *testing.T) {
+func TestDevChangelogReleaseWithoutUnreleased(t *testing.T) {
 	newSandbox(t)
-	_, err := runCLI(t, "mod", "changelog", "release", "--changelog", changelogFixture("basic.txt"), "--version", "9.9.9")
+	_, err := runCLI(t, "dev", "changelog", "release", "--changelog", changelogFixture("basic.txt"), "--version", "9.9.9")
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "first section is not Unreleased")
 }

--- a/internal/cli/dev_edit.go
+++ b/internal/cli/dev_edit.go
@@ -9,7 +9,7 @@ import (
 	"github.com/sakuro/factorix/internal/api"
 )
 
-func newMODEditCommand(c *cli) *cobra.Command {
+func newDevEditCommand(c *cli) *cobra.Command {
 	var metadata api.EditMetadata
 	var deprecated bool
 

--- a/internal/cli/dev_image.go
+++ b/internal/cli/dev_image.go
@@ -11,20 +11,20 @@ import (
 	"github.com/sakuro/factorix/internal/api"
 )
 
-func newMODImageCommand(c *cli) *cobra.Command {
+func newDevImageCommand(c *cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "image",
 		Short: "Manage MOD images",
 	}
 	cmd.AddCommand(
-		newMODImageListCommand(c),
-		newMODImageAddCommand(c),
-		newMODImageEditCommand(c),
+		newDevImageListCommand(c),
+		newDevImageAddCommand(c),
+		newDevImageEditCommand(c),
 	)
 	return cmd
 }
 
-func newMODImageListCommand(c *cli) *cobra.Command {
+func newDevImageListCommand(c *cli) *cobra.Command {
 	var jsonOutput bool
 
 	cmd := &cobra.Command{
@@ -92,7 +92,7 @@ func outputImageJSON(p *printer, images []api.Image) error {
 	return nil
 }
 
-func newMODImageAddCommand(c *cli) *cobra.Command {
+func newDevImageAddCommand(c *cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "add <mod-name> <image-file>",
 		Short: "Add an image to a MOD",
@@ -133,7 +133,7 @@ func newMODImageAddCommand(c *cli) *cobra.Command {
 	return cmd
 }
 
-func newMODImageEditCommand(c *cli) *cobra.Command {
+func newDevImageEditCommand(c *cli) *cobra.Command {
 	cmd := &cobra.Command{
 		Use:   "edit <mod-name> <image-id>...",
 		Short: "Edit MOD's image list (reorder/remove images)",

--- a/internal/cli/dev_upload.go
+++ b/internal/cli/dev_upload.go
@@ -15,7 +15,7 @@ import (
 	"github.com/sakuro/factorix/internal/mod"
 )
 
-func newMODUploadCommand(c *cli) *cobra.Command {
+func newDevUploadCommand(c *cli) *cobra.Command {
 	var description, category, license, sourceURL string
 
 	cmd := &cobra.Command{

--- a/internal/cli/dev_upload_edit_image_test.go
+++ b/internal/cli/dev_upload_edit_image_test.go
@@ -12,29 +12,29 @@ import (
 	"github.com/sakuro/factorix/internal/api"
 )
 
-func TestMODUploadFileValidation(t *testing.T) {
+func TestDevUploadFileValidation(t *testing.T) {
 	s := newSandbox(t)
 
-	_, err := runCLI(t, "mod", "upload", filepath.Join(s.root, "missing.zip"))
+	_, err := runCLI(t, "dev", "upload", filepath.Join(s.root, "missing.zip"))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "File not found: ")
 
 	dir := filepath.Join(s.root, "a-directory.zip")
 	require.NoError(t, os.Mkdir(dir, 0o755))
-	_, err = runCLI(t, "mod", "upload", dir)
+	_, err = runCLI(t, "dev", "upload", dir)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "Not a file: ")
 
 	notZip := filepath.Join(s.root, "mod.tar")
 	require.NoError(t, os.WriteFile(notZip, []byte("x"), 0o644))
-	_, err = runCLI(t, "mod", "upload", notZip)
+	_, err = runCLI(t, "dev", "upload", notZip)
 	require.Error(t, err)
 	assert.Equal(t, "File must be a .zip file", err.Error())
 }
 
-func TestMODEditRejectsInvalidLicense(t *testing.T) {
+func TestDevEditRejectsInvalidLicense(t *testing.T) {
 	newSandbox(t)
-	out, err := runCLI(t, "mod", "edit", "some-mod", "--license", "MIT")
+	out, err := runCLI(t, "dev", "edit", "some-mod", "--license", "MIT")
 	require.Error(t, err)
 	assert.Equal(t, "Invalid license identifier", err.Error())
 	assert.Contains(t, out, "✗ Invalid license identifier: MIT\n")
@@ -42,18 +42,18 @@ func TestMODEditRejectsInvalidLicense(t *testing.T) {
 	assert.Contains(t, out, "Custom licenses: custom_<24 hex chars>")
 }
 
-func TestMODEditRequiresMetadata(t *testing.T) {
+func TestDevEditRequiresMetadata(t *testing.T) {
 	newSandbox(t)
-	out, err := runCLI(t, "mod", "edit", "some-mod")
+	out, err := runCLI(t, "dev", "edit", "some-mod")
 	require.Error(t, err)
 	assert.Equal(t, "No metadata options provided", err.Error())
 	assert.Contains(t, out, "✗ At least one metadata option must be provided\n")
 	assert.Contains(t, out, "Available options: --description, --summary, --title, --category, --tags, --license, --homepage, --source-url, --faq, --deprecated\n")
 }
 
-func TestMODImageAddMissingFile(t *testing.T) {
+func TestDevImageAddMissingFile(t *testing.T) {
 	s := newSandbox(t)
-	_, err := runCLI(t, "mod", "image", "add", "some-mod", filepath.Join(s.root, "missing.png"))
+	_, err := runCLI(t, "dev", "image", "add", "some-mod", filepath.Join(s.root, "missing.png"))
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "Image file not found: ")
 }

--- a/internal/cli/mod.go
+++ b/internal/cli/mod.go
@@ -22,10 +22,6 @@ func newMODCommand(c *cli) *cobra.Command {
 		newMODUninstallCommand(c),
 		newMODUpdateCommand(c),
 		newMODSyncCommand(c),
-		newMODUploadCommand(c),
-		newMODEditCommand(c),
-		newMODChangelogCommand(c),
-		newMODImageCommand(c),
 	)
 
 	return mod

--- a/internal/cli/portal_integration_upload_test.go
+++ b/internal/cli/portal_integration_upload_test.go
@@ -9,7 +9,7 @@ import (
 	"github.com/stretchr/testify/require"
 )
 
-func TestMODUploadNewMODAgainstMockPortal(t *testing.T) {
+func TestDevUploadNewMODAgainstMockPortal(t *testing.T) {
 	newSandbox(t)
 	portal := newMockPortal(t) // new-mod does not exist on the portal
 	portal.withPortal(t)
@@ -17,7 +17,7 @@ func TestMODUploadNewMODAgainstMockPortal(t *testing.T) {
 	zipPath := filepath.Join(t.TempDir(), "new-mod_1.0.0.zip")
 	writeMODZip(t, zipPath, "new-mod", "1.0.0")
 
-	out, err := runCLI(t, "mod", "upload", zipPath, "--category", "content")
+	out, err := runCLI(t, "dev", "upload", zipPath, "--category", "content")
 	require.NoError(t, err)
 	assert.Contains(t, out, "Upload completed successfully!")
 
@@ -29,7 +29,7 @@ func TestMODUploadNewMODAgainstMockPortal(t *testing.T) {
 	assert.Equal(t, "Bearer test-api-key", portal.managementCalls[0].Auth)
 }
 
-func TestMODUploadExistingMODAgainstMockPortal(t *testing.T) {
+func TestDevUploadExistingMODAgainstMockPortal(t *testing.T) {
 	newSandbox(t)
 	portal := newMockPortal(t, portalMOD{Name: "existing-mod", Title: "Existing MOD", Owner: "alice"})
 	portal.withPortal(t)
@@ -37,7 +37,7 @@ func TestMODUploadExistingMODAgainstMockPortal(t *testing.T) {
 	zipPath := filepath.Join(t.TempDir(), "existing-mod_2.0.0.zip")
 	writeMODZip(t, zipPath, "existing-mod", "2.0.0")
 
-	out, err := runCLI(t, "mod", "upload", zipPath, "--category", "content")
+	out, err := runCLI(t, "dev", "upload", zipPath, "--category", "content")
 	require.NoError(t, err)
 	assert.Contains(t, out, "Upload completed successfully!")
 
@@ -49,7 +49,7 @@ func TestMODUploadExistingMODAgainstMockPortal(t *testing.T) {
 	assert.Equal(t, []string{"content"}, portal.managementCalls[1].Form["category"])
 }
 
-func TestMODUploadRequiresAPIKey(t *testing.T) {
+func TestDevUploadRequiresAPIKey(t *testing.T) {
 	newSandbox(t)
 	portal := newMockPortal(t)
 	portal.withPortal(t)
@@ -58,17 +58,17 @@ func TestMODUploadRequiresAPIKey(t *testing.T) {
 	zipPath := filepath.Join(t.TempDir(), "new-mod_1.0.0.zip")
 	writeMODZip(t, zipPath, "new-mod", "1.0.0")
 
-	_, err := runCLI(t, "mod", "upload", zipPath)
+	_, err := runCLI(t, "dev", "upload", zipPath)
 	require.Error(t, err)
 	assert.Contains(t, err.Error(), "FACTORIO_API_KEY")
 }
 
-func TestMODEditAgainstMockPortal(t *testing.T) {
+func TestDevEditAgainstMockPortal(t *testing.T) {
 	newSandbox(t)
 	portal := newMockPortal(t, portalMOD{Name: "some-mod", Title: "Some MOD", Owner: "alice"})
 	portal.withPortal(t)
 
-	out, err := runCLI(t, "mod", "edit", "some-mod", "--title", "New Title", "--summary", "New summary")
+	out, err := runCLI(t, "dev", "edit", "some-mod", "--title", "New Title", "--summary", "New summary")
 	require.NoError(t, err)
 	assert.Contains(t, out, "Metadata updated successfully!")
 
@@ -80,7 +80,7 @@ func TestMODEditAgainstMockPortal(t *testing.T) {
 	assert.Equal(t, []string{"New summary"}, call.Form["summary"])
 }
 
-func TestMODImageListAgainstMockPortal(t *testing.T) {
+func TestDevImageListAgainstMockPortal(t *testing.T) {
 	newSandbox(t)
 	portal := newMockPortal(t, portalMOD{
 		Name: "some-mod", Title: "Some MOD", Owner: "alice",
@@ -88,13 +88,13 @@ func TestMODImageListAgainstMockPortal(t *testing.T) {
 	})
 	portal.withPortal(t)
 
-	out, err := runCLI(t, "mod", "image", "list", "some-mod")
+	out, err := runCLI(t, "dev", "image", "list", "some-mod")
 	require.NoError(t, err)
 	assert.Contains(t, out, "abc123")
 	assert.Contains(t, out, "https://example.com/thumb.png")
 }
 
-func TestMODImageAddAgainstMockPortal(t *testing.T) {
+func TestDevImageAddAgainstMockPortal(t *testing.T) {
 	s := newSandbox(t)
 	portal := newMockPortal(t)
 	portal.imageUploadResponse = portalImage{ID: "new-img-id", Thumbnail: "https://example.com/t.png", URL: "https://example.com/f.png"}
@@ -103,7 +103,7 @@ func TestMODImageAddAgainstMockPortal(t *testing.T) {
 	imagePath := filepath.Join(s.root, "screenshot.png")
 	require.NoError(t, os.WriteFile(imagePath, []byte("fake-png-content"), 0o644))
 
-	out, err := runCLI(t, "mod", "image", "add", "some-mod", imagePath)
+	out, err := runCLI(t, "dev", "image", "add", "some-mod", imagePath)
 	require.NoError(t, err)
 	assert.Contains(t, out, "Image added successfully!")
 	assert.Contains(t, out, "new-img-id")
@@ -112,12 +112,12 @@ func TestMODImageAddAgainstMockPortal(t *testing.T) {
 	assert.Equal(t, "/api/v2/mods/images/add", portal.managementCalls[0].Path)
 }
 
-func TestMODImageEditAgainstMockPortal(t *testing.T) {
+func TestDevImageEditAgainstMockPortal(t *testing.T) {
 	newSandbox(t)
 	portal := newMockPortal(t)
 	portal.withPortal(t)
 
-	out, err := runCLI(t, "mod", "image", "edit", "some-mod", "img1", "img2")
+	out, err := runCLI(t, "dev", "image", "edit", "some-mod", "img1", "img2")
 	require.NoError(t, err)
 	assert.Contains(t, out, "Image list updated successfully!")
 


### PR DESCRIPTION
## Summary
Splits `factorix mod`'s 16 subcommands, which mixed gameplay-time MOD operations with MOD-authoring/Portal-publishing operations, by moving the four authoring commands into a new top-level `dev` command.

## Changes
- `mod` keeps 12 gameplay-facing subcommands: list, check, settings, enable, disable, search, show, download, install, uninstall, update, sync
- New `dev` command holds `upload`, `edit`, `changelog` (add/check/extract/release), and `image` (list/add/edit)
- Renames the moved constructors and tests from `MOD*` to `Dev*`
- Updates the man page and e2e changelog cases to use `dev changelog ...`

## Test Plan
- `mise run default` (test + e2e + vet + lint + fmt-check) passes
- Manually verified `factorix mod --help` and `factorix dev --help` show the expected split command trees

Fixes #167
