### PR TITLE
:sparkles: Recognize recycler as an official expansion MOD

### DIFF
--- a/internal/cli/mod_download.go
+++ b/internal/cli/mod_download.go
@@ -16,7 +16,7 @@ import (
 	"github.com/sakuro/factorix/internal/mod"
 )
 
-var builtinMODs = []string{"base", "elevated-rails", "quality", "space-age"}
+var builtinMODs = []string{"base", "elevated-rails", "quality", "recycler", "space-age"}
 
 func newMODDownloadCommand(c *cli) *cobra.Command {
 	var directory string

--- a/internal/mod/mod.go
+++ b/internal/mod/mod.go
@@ -13,6 +13,7 @@ var expansionMODs = map[string]bool{
 	"space-age":      true,
 	"quality":        true,
 	"elevated-rails": true,
+	"recycler":       true,
 }
 
 // IsBase reports whether this is the base MOD.
@@ -22,7 +23,7 @@ func (m MOD) IsBase() bool {
 }
 
 // IsExpansion reports whether this is an official expansion MOD
-// (space-age, quality, or elevated-rails). The check is case-sensitive.
+// (space-age, quality, elevated-rails, or recycler). The check is case-sensitive.
 func (m MOD) IsExpansion() bool {
 	return expansionMODs[m.Name]
 }

--- a/internal/mod/mod_test.go
+++ b/internal/mod/mod_test.go
@@ -14,7 +14,7 @@ func TestMODIsBase(t *testing.T) {
 }
 
 func TestMODIsExpansion(t *testing.T) {
-	for _, name := range []string{"space-age", "quality", "elevated-rails"} {
+	for _, name := range []string{"space-age", "quality", "elevated-rails", "recycler"} {
 		assert.True(t, MOD{Name: name}.IsExpansion(), name)
 	}
 	assert.False(t, MOD{Name: "base"}.IsExpansion())


### PR DESCRIPTION
## Summary
Recognizes `recycler` as an official Factorio expansion MOD, alongside `space-age`, `quality`, and `elevated-rails`.

## Changes
- `internal/mod/mod.go`: add `recycler` to `expansionMODs`, used by `MOD.IsExpansion()`
- `internal/cli/mod_download.go`: add `recycler` to `builtinMODs`
- `internal/mod/mod_test.go`: cover `recycler` in `TestMODIsExpansion`

## Test Plan
- `mise run default` passes (test + e2e + vet + lint + fmt-check)
