### PR TITLE
:bug: Size progress bars to the terminal width

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 - Accept Factorio 2.1 as a `mod search --version` filter value
 - Recognize `recycler` as an official expansion MOD alongside `space-age`, `quality`, and `elevated-rails` (#169)
 
+### Fixed
+
+- Size download progress bars to the actual terminal width instead of a fixed 40 columns
+
 ## [0.20.0] - 2026-07-12
 
 Factorix is being rewritten from Ruby to Go, reaching full command parity:

--- a/internal/progress/renderer.go
+++ b/internal/progress/renderer.go
@@ -31,8 +31,10 @@ func NewRenderer() *Renderer {
 // loop when it detects the output is itself a terminal, which a
 // bytes.Buffer never is; production callers already gate on a real TTY via
 // NewRenderer, so this is a no-op there.
+// Width is left unset so mpb sizes bars to the terminal's actual width
+// instead of a fixed column count.
 func newRenderer(w io.Writer) *Renderer {
-	return &Renderer{container: mpb.New(mpb.WithOutput(w), mpb.WithWidth(40), mpb.WithAutoRefresh())}
+	return &Renderer{container: mpb.New(mpb.WithOutput(w), mpb.WithAutoRefresh())}
 }
 
 // Listener adds a bar labeled with title and returns a listener driving


### PR DESCRIPTION
## Summary
Progress bars for downloads were clamped to a fixed 40-column width regardless of the terminal's actual size.

## Changes
- `internal/progress/renderer.go`: drop `mpb.WithWidth(40)` so mpb falls back to its default of measuring the real terminal width on each render
- Bars now stretch to fill the line (minus decorators) and track terminal resizes

## Test Plan
- `mise run default` passes (test + e2e + vet + lint + fmt-check)
- Visual confirmation requires a real TTY (e.g. `factorix mod download <mod>` in an actual terminal)
