### PR TITLE
:sparkles: Add mod license list/show to look up standard license identifiers

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -4,6 +4,7 @@
 
 - Accept Factorio 2.1 as a `mod search --version` filter value
 - Recognize `recycler` as an official expansion MOD alongside `space-age`, `quality`, and `elevated-rails` (#169)
+- Add `mod license list` and `mod license show <id>` to look up standard MOD Portal license identifiers and their license text URLs (#166)
 
 ### Fixed
 

--- a/doc/factorix.1
+++ b/doc/factorix.1
@@ -416,6 +416,18 @@ Output in JSON format.
 Add an image to a MOD.
 .SS factorix mod image edit MOD_NAME IMAGE_IDS
 Edit MOD's image list. Reorder or remove images by specifying IDs in desired order.
+.SS factorix mod license list
+List standard MOD Portal license identifiers, with name and license text URL.
+.TP
+.B \-\-json
+Output in JSON format.
+.SS factorix mod license show ID
+Show a standard MOD Portal license identifier's name, title, description, and
+URL. Fails for custom license identifiers (\fBcustom_\fR + 24 hex chars), which
+have no fixed URL.
+.TP
+.B \-\-json
+Output in JSON format.
 .SH SETTINGS COMMANDS
 .SS factorix mod settings dump [SETTINGS_FILE]
 Dump MOD settings to JSON format.

--- a/internal/api/license.go
+++ b/internal/api/license.go
@@ -31,3 +31,56 @@ func LicenseIdentifiers() []string {
 func ValidLicenseIdentifier(value string) bool {
 	return slices.Contains(licenseIdentifiers, value) || customLicensePattern.MatchString(value)
 }
+
+// standardLicenses is the catalog of standard license identifiers, mirroring
+// Ruby's Factorix::API::License flyweight instances (lib/factorix/api/license.rb
+// on the ruby branch) field for field.
+var standardLicenses = map[string]License{
+	"default_mit": {
+		ID: "default_mit", Name: "MIT", Title: "MIT License",
+		Description: "A permissive license that is short and to the point. It lets people do anything with your code with proper attribution and without warranty.",
+		URL:         "https://raw.githubusercontent.com/spdx/license-list-data/main/text/MIT.txt",
+	},
+	"default_gnugplv3": {
+		ID: "default_gnugplv3", Name: "GNU GPLv3", Title: "GNU General Public License v3.0",
+		Description: "The GNU GPL is the most widely used free software license and has a strong copyleft requirement.",
+		URL:         "https://raw.githubusercontent.com/spdx/license-list-data/main/text/GPL-3.0-or-later.txt",
+	},
+	"default_gnulgplv3": {
+		ID: "default_gnulgplv3", Name: "GNU LGPLv3", Title: "GNU Lesser General Public License v3.0",
+		Description: "Version 3 of the GNU LGPL is an additional set of permissions to the GNU GPLv3 license that requires derived works use the same license.",
+		URL:         "https://raw.githubusercontent.com/spdx/license-list-data/main/text/LGPL-3.0-or-later.txt",
+	},
+	"default_mozilla2": {
+		ID: "default_mozilla2", Name: "Mozilla Public License 2.0", Title: "Mozilla Public License Version 2.0",
+		Description: "The Mozilla Public License (MPL 2.0) attempts to be a compromise between the permissive BSD license and the reciprocal GPL license.",
+		URL:         "https://raw.githubusercontent.com/spdx/license-list-data/main/text/MPL-2.0.txt",
+	},
+	"default_apache2": {
+		ID: "default_apache2", Name: "Apache License 2.0", Title: "Apache License, Version 2.0",
+		Description: "A permissive license that also provides an express grant of patent rights from contributors to users.",
+		URL:         "https://raw.githubusercontent.com/spdx/license-list-data/main/text/Apache-2.0.txt",
+	},
+	"default_unlicense": {
+		ID: "default_unlicense", Name: "The Unlicense", Title: "The Unlicense",
+		Description: "The Unlicense is a template to waive copyright interest in software and dedicate it to the public domain.",
+		URL:         "https://raw.githubusercontent.com/spdx/license-list-data/main/text/Unlicense.txt",
+	},
+}
+
+// StandardLicenses returns the catalog of standard licenses, ordered as in
+// LicenseIdentifiers.
+func StandardLicenses() []License {
+	result := make([]License, len(licenseIdentifiers))
+	for i, id := range licenseIdentifiers {
+		result[i] = standardLicenses[id]
+	}
+	return result
+}
+
+// StandardLicenseFor returns the catalog entry for a standard license
+// identifier. ok is false for custom or unrecognized identifiers.
+func StandardLicenseFor(id string) (license License, ok bool) {
+	license, ok = standardLicenses[id]
+	return license, ok
+}

--- a/internal/api/license_test.go
+++ b/internal/api/license_test.go
@@ -4,6 +4,7 @@ import (
 	"testing"
 
 	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
 )
 
 func TestValidLicenseIdentifier(t *testing.T) {
@@ -17,4 +18,27 @@ func TestValidLicenseIdentifier(t *testing.T) {
 	assert.False(t, ValidLicenseIdentifier("custom_0123456789ABCDEF01234567")) // uppercase hex
 	assert.False(t, ValidLicenseIdentifier("custom_0123"))                     // too short
 	assert.False(t, ValidLicenseIdentifier("custom_0123456789abcdef012345678"))
+}
+
+func TestStandardLicenses(t *testing.T) {
+	licenses := StandardLicenses()
+	require.Len(t, licenses, len(LicenseIdentifiers()))
+	for i, license := range licenses {
+		assert.Equal(t, LicenseIdentifiers()[i], license.ID)
+		assert.NotEmpty(t, license.Name)
+		assert.NotEmpty(t, license.URL)
+	}
+}
+
+func TestStandardLicenseFor(t *testing.T) {
+	license, ok := StandardLicenseFor("default_mit")
+	require.True(t, ok)
+	assert.Equal(t, "MIT", license.Name)
+	assert.Equal(t, "https://raw.githubusercontent.com/spdx/license-list-data/main/text/MIT.txt", license.URL)
+
+	_, ok = StandardLicenseFor("custom_0123456789abcdef01234567")
+	assert.False(t, ok)
+
+	_, ok = StandardLicenseFor("MIT")
+	assert.False(t, ok)
 }

--- a/internal/cli/mod.go
+++ b/internal/cli/mod.go
@@ -26,6 +26,7 @@ func newMODCommand(c *cli) *cobra.Command {
 		newMODEditCommand(c),
 		newMODChangelogCommand(c),
 		newMODImageCommand(c),
+		newMODLicenseCommand(c),
 	)
 
 	return mod

--- a/internal/cli/mod_edit.go
+++ b/internal/cli/mod_edit.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"errors"
-	"strings"
 
 	"github.com/spf13/cobra"
 
@@ -20,10 +19,7 @@ func newMODEditCommand(c *cli) *cobra.Command {
 		RunE: func(cmd *cobra.Command, args []string) error {
 			p := c.printer(cmd)
 			if metadata.License != "" && !api.ValidLicenseIdentifier(metadata.License) {
-				p.Error("Invalid license identifier: " + metadata.License)
-				p.Say("Valid identifiers: " + strings.Join(api.LicenseIdentifiers(), ", "))
-				p.Say("Custom licenses: custom_<24 hex chars> (e.g., custom_0123456789abcdef01234567)")
-				return errors.New("Invalid license identifier")
+				return invalidLicenseIdentifierError(p, metadata.License)
 			}
 
 			if cmd.Flags().Changed("deprecated") {

--- a/internal/cli/mod_license.go
+++ b/internal/cli/mod_license.go
@@ -1,0 +1,129 @@
+package cli
+
+import (
+	"encoding/json"
+	"errors"
+	"strings"
+
+	"github.com/spf13/cobra"
+
+	"github.com/sakuro/factorix/internal/api"
+)
+
+func newMODLicenseCommand(c *cli) *cobra.Command {
+	cmd := &cobra.Command{
+		Use:   "license",
+		Short: "Look up standard MOD Portal license identifiers",
+	}
+	cmd.AddCommand(
+		newMODLicenseListCommand(c),
+		newMODLicenseShowCommand(c),
+	)
+	return cmd
+}
+
+func newMODLicenseListCommand(c *cli) *cobra.Command {
+	var jsonOutput bool
+
+	cmd := &cobra.Command{
+		Use:   "list",
+		Short: "List standard MOD Portal license identifiers",
+		Args:  cobra.NoArgs,
+		RunE: func(cmd *cobra.Command, _ []string) error {
+			p := c.printer(cmd)
+			licenses := api.StandardLicenses()
+			if jsonOutput {
+				return outputLicenseListJSON(p, licenses)
+			}
+			outputLicenseListTable(p, licenses)
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSON format")
+	return cmd
+}
+
+func outputLicenseListTable(p *printer, licenses []api.License) {
+	idWidth, nameWidth := len("ID"), len("NAME")
+	for _, license := range licenses {
+		idWidth = max(idWidth, len(license.ID))
+		nameWidth = max(nameWidth, len(license.Name))
+	}
+	p.Printf("%-*s  %-*s  %s\n", idWidth, "ID", nameWidth, "NAME", "URL")
+	for _, license := range licenses {
+		p.Printf("%-*s  %-*s  %s\n", idWidth, license.ID, nameWidth, license.Name, license.URL)
+	}
+}
+
+func outputLicenseListJSON(p *printer, licenses []api.License) error {
+	data, err := json.MarshalIndent(licenses, "", "  ")
+	if err != nil {
+		return err
+	}
+	p.Println(string(data))
+	return nil
+}
+
+func newMODLicenseShowCommand(c *cli) *cobra.Command {
+	var jsonOutput bool
+
+	cmd := &cobra.Command{
+		Use:   "show <id>",
+		Short: "Show a standard MOD Portal license identifier's details",
+		Args:  cobra.ExactArgs(1),
+		RunE: func(cmd *cobra.Command, args []string) error {
+			id := args[0]
+			p := c.printer(cmd)
+			if !api.ValidLicenseIdentifier(id) {
+				return invalidLicenseIdentifierError(p, id)
+			}
+			license, ok := api.StandardLicenseFor(id)
+			if !ok {
+				p.Error("Custom license identifiers have no fixed URL: " + id)
+				p.Say("Look up the license text via the MOD Portal page for the MOD that uses it")
+				return errors.New("Custom license identifiers have no fixed URL")
+			}
+
+			if jsonOutput {
+				data, err := json.MarshalIndent(license, "", "  ")
+				if err != nil {
+					return err
+				}
+				p.Println(string(data))
+				return nil
+			}
+			displayLicense(p, license)
+			return nil
+		},
+	}
+	cmd.Flags().BoolVar(&jsonOutput, "json", false, "Output in JSON format")
+	return cmd
+}
+
+func displayLicense(p *printer, license api.License) {
+	type row struct{ label, value string }
+	rows := []row{
+		{"ID", license.ID},
+		{"Name", license.Name},
+		{"Title", license.Title},
+		{"Description", license.Description},
+		{"URL", license.URL},
+	}
+	width := 0
+	for _, r := range rows {
+		width = max(width, len(r.label))
+	}
+	for _, r := range rows {
+		p.Printf("%-*s  %s\n", width, r.label, r.value)
+	}
+}
+
+// invalidLicenseIdentifierError reports and returns the standard error for
+// an unrecognized --license/license-identifier value; shared by mod edit
+// and mod license show.
+func invalidLicenseIdentifierError(p *printer, id string) error {
+	p.Error("Invalid license identifier: " + id)
+	p.Say("Valid identifiers: " + strings.Join(api.LicenseIdentifiers(), ", "))
+	p.Say("Custom licenses: custom_<24 hex chars> (e.g., custom_0123456789abcdef01234567)")
+	return errors.New("Invalid license identifier")
+}

--- a/internal/cli/mod_license_test.go
+++ b/internal/cli/mod_license_test.go
@@ -1,0 +1,56 @@
+package cli
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+)
+
+func TestMODLicenseListTable(t *testing.T) {
+	out, err := runCLI(t, "mod", "license", "list")
+	require.NoError(t, err)
+	assert.Contains(t, out, "ID")
+	assert.Contains(t, out, "NAME")
+	assert.Contains(t, out, "default_mit")
+	assert.Contains(t, out, "MIT")
+	assert.Contains(t, out, "https://raw.githubusercontent.com/spdx/license-list-data/main/text/MIT.txt")
+}
+
+func TestMODLicenseListJSON(t *testing.T) {
+	out, err := runCLI(t, "mod", "license", "list", "--json")
+	require.NoError(t, err)
+	assert.Contains(t, out, `"id": "default_mit"`)
+	assert.Contains(t, out, `"name": "MIT"`)
+}
+
+func TestMODLicenseShow(t *testing.T) {
+	out, err := runCLI(t, "mod", "license", "show", "default_mit")
+	require.NoError(t, err)
+	assert.Contains(t, out, "ID           default_mit")
+	assert.Contains(t, out, "Name         MIT")
+	assert.Contains(t, out, "https://raw.githubusercontent.com/spdx/license-list-data/main/text/MIT.txt")
+}
+
+func TestMODLicenseShowJSON(t *testing.T) {
+	out, err := runCLI(t, "mod", "license", "show", "default_mit", "--json")
+	require.NoError(t, err)
+	assert.Contains(t, out, `"id": "default_mit"`)
+}
+
+func TestMODLicenseShowInvalidIdentifier(t *testing.T) {
+	newSandbox(t)
+	out, err := runCLI(t, "mod", "license", "show", "MIT")
+	require.Error(t, err)
+	assert.Equal(t, "Invalid license identifier", err.Error())
+	assert.Contains(t, out, "✗ Invalid license identifier: MIT\n")
+	assert.Contains(t, out, "Valid identifiers: default_mit, ")
+}
+
+func TestMODLicenseShowCustomIdentifier(t *testing.T) {
+	newSandbox(t)
+	out, err := runCLI(t, "mod", "license", "show", "custom_0123456789abcdef01234567")
+	require.Error(t, err)
+	assert.Equal(t, "Custom license identifiers have no fixed URL", err.Error())
+	assert.Contains(t, out, "✗ Custom license identifiers have no fixed URL: custom_0123456789abcdef01234567\n")
+}


### PR DESCRIPTION
## Summary
Adds `mod license list` and `mod license show <id>` to look up standard Factorio MOD Portal license identifiers and their license text URLs, restoring functionality the Ruby version exposed as `Factorix::API::License.for(id).url`.

## Changes
- `internal/api/license.go`: add `StandardLicenses()`/`StandardLicenseFor(id)`, a catalog mirroring Ruby's `Factorix::API::License` flyweight instances (id, name, title, description, url) field for field
- `internal/cli/mod_license.go`: add `mod license list` and `mod license show <id>` (table/`--json`), split into separate subcommands (rather than one command with an optional argument) so `--json` output stays a predictable shape — array for list, object for show
- Extract the shared "invalid license identifier" error into `invalidLicenseIdentifierError`, reused by `mod edit` and `mod license show`

## Test Plan
- `mise run default` passes (test + e2e + vet + lint + fmt-check)
- Manually verified `mod license list`, `mod license list --json`, `mod license show default_mit`, `mod license show default_mit --json`, and error paths for invalid/custom identifiers

Fixes #166
