### PR TITLE
:bug: Recognize non-canonical version strings in installed MOD names

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Fixed
+
+- Recognize installed MOD packages whose filename uses a non-canonical version string (e.g. zero-padded like `0.1.01`), which previously caused `mod update` to repeatedly re-offer the same update (#173)
+
 ## [0.21.0] - 2026-07-13
 
 ### Added

--- a/internal/mod/installed_mod.go
+++ b/internal/mod/installed_mod.go
@@ -5,6 +5,7 @@ import (
 	"fmt"
 	"os"
 	"path/filepath"
+	"strings"
 )
 
 // Form is the on-disk shape of an installed MOD package.
@@ -37,6 +38,15 @@ type InstalledMOD struct {
 	Info    InfoJSON
 }
 
+// versionSegmentMatches reports whether s names the same version as v. It
+// parses s rather than comparing rendered strings, so on-disk names that use
+// a non-canonical version format (e.g. a MOD Portal release zero-padded as
+// "0.1.01") still match the canonical "0.1.1" declared in info.json.
+func versionSegmentMatches(s string, v MODVersion) bool {
+	parsed, err := ParseMODVersion(s)
+	return err == nil && parsed.Compare(v) == 0
+}
+
 // InstalledMODFromZIP loads an installed MOD from a ZIP file.
 // The filename must be "<name>_<version>.zip".
 func InstalledMODFromZIP(path string) (InstalledMOD, error) {
@@ -45,12 +55,13 @@ func InstalledMODFromZIP(path string) (InstalledMOD, error) {
 		return InstalledMOD{}, err
 	}
 
-	expected := fmt.Sprintf("%s_%s.zip", info.Name, info.Version)
 	actual := filepath.Base(path)
-	if actual != expected {
+	rest, hasPrefix := strings.CutPrefix(actual, info.Name+"_")
+	versionSegment, hasSuffix := strings.CutSuffix(rest, ".zip")
+	if !hasPrefix || !hasSuffix || !versionSegmentMatches(versionSegment, info.Version) {
 		return InstalledMOD{}, &FileFormatError{
 			Path: path,
-			Msg:  fmt.Sprintf("filename mismatch: expected %s, got %s", expected, actual),
+			Msg:  fmt.Sprintf("filename mismatch: expected %s_%s.zip, got %s", info.Name, info.Version, actual),
 		}
 	}
 
@@ -71,11 +82,11 @@ func InstalledMODFromDirectory(path string) (InstalledMOD, error) {
 	}
 
 	dirname := filepath.Base(path)
-	versioned := fmt.Sprintf("%s_%s", info.Name, info.Version)
-	if dirname != info.Name && dirname != versioned {
+	versionSegment, hasPrefix := strings.CutPrefix(dirname, info.Name+"_")
+	if dirname != info.Name && (!hasPrefix || !versionSegmentMatches(versionSegment, info.Version)) {
 		return InstalledMOD{}, &FileFormatError{
 			Path: path,
-			Msg:  fmt.Sprintf("directory name mismatch: expected %s or %s, got %s", info.Name, versioned, dirname),
+			Msg:  fmt.Sprintf("directory name mismatch: expected %s or %s_%s, got %s", info.Name, info.Name, info.Version, dirname),
 		}
 	}
 

--- a/internal/mod/installed_mod_test.go
+++ b/internal/mod/installed_mod_test.go
@@ -57,6 +57,18 @@ func TestInstalledMODFromZIPFilenameMismatch(t *testing.T) {
 	assert.Contains(t, ffe.Msg, "filename mismatch")
 }
 
+func TestInstalledMODFromZIPNonCanonicalVersion(t *testing.T) {
+	// A MOD Portal release may publish a non-canonical version string (e.g.
+	// zero-padded), yielding a filename like "test-mod_1.02.3.zip" for the
+	// info.json version "1.2.3". The two must still be recognized as the
+	// same version.
+	path := writeMODZip(t, t.TempDir(), "test-mod_1.02.3.zip")
+
+	im, err := InstalledMODFromZIP(path)
+	require.NoError(t, err)
+	assert.Equal(t, MODVersion{Major: 1, Minor: 2, Patch: 3}, im.Version)
+}
+
 func TestInstalledMODFromZIPInvalidZip(t *testing.T) {
 	path := filepath.Join(t.TempDir(), "test-mod_1.2.3.zip")
 	require.NoError(t, os.WriteFile(path, []byte("not a zip"), 0o644))
@@ -77,6 +89,14 @@ func TestInstalledMODFromDirectory(t *testing.T) {
 			assert.Equal(t, FormDirectory, im.Form)
 		})
 	}
+}
+
+func TestInstalledMODFromDirectoryNonCanonicalVersion(t *testing.T) {
+	path := writeMODDirectory(t, t.TempDir(), "test-mod_1.02.3")
+
+	im, err := InstalledMODFromDirectory(path)
+	require.NoError(t, err)
+	assert.Equal(t, MODVersion{Major: 1, Minor: 2, Patch: 3}, im.Version)
 }
 
 func TestInstalledMODFromDirectoryNameMismatch(t *testing.T) {

--- a/internal/mod/scanner.go
+++ b/internal/mod/scanner.go
@@ -18,7 +18,7 @@ const scanParallelism = 4
 
 // ScanInstalled finds the installed MODs: ZIP files and directories in the
 // MOD directory, plus the base/expansion MOD directories bundled in the
-// data directory. Invalid packages are skipped with a debug log. When the
+// data directory. Invalid packages are skipped with a warning log. When the
 // same name and version exists in both forms, the directory wins (a
 // development checkout shadows the packaged ZIP).
 func ScanInstalled(modDir, dataDir string, logger *slog.Logger, listener progress.Listener) ([]InstalledMOD, error) {
@@ -118,7 +118,7 @@ func scanPath(path string, logger *slog.Logger) *InstalledMOD {
 		im, err = InstalledMODFromZIP(path)
 	}
 	if err != nil {
-		logger.Debug("Skipping invalid MOD package", "path", path, "reason", err)
+		logger.Warn("Skipping invalid MOD package", "path", path, "reason", err)
 		return nil
 	}
 	return &im


### PR DESCRIPTION
## Summary
Fix `mod update` repeatedly re-offering the same update when a MOD Portal release publishes a non-canonical version string (e.g. zero-padded `0.1.01`).

## Changes
- Compare parsed `MODVersion` values instead of rendered strings when validating installed ZIP/directory names in `InstalledMODFromZIP`/`InstalledMODFromDirectory`, so formatting differences like zero-padding no longer cause a freshly downloaded package to be rejected during scanning
- Raise the scan-skip log from `Debug` to `Warn` so a genuinely invalid package is visible instead of silently causing "the update didn't take" confusion
- Add changelog entry

## Test Plan
- `mise run test` and `mise run lint` pass
- Added unit tests covering non-canonical (zero-padded) version strings in both ZIP filenames and directory names

Fixes #173
