### PR TITLE
:recycle: Unify release selection into internal/resolver

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,9 @@
 ## [Unreleased]
 
+### Changed
+
+- `mod install`, `mod download`, and `mod update` now resolve `@latest` as the Portal's `latest_release` (falling back to the highest version) instead of the newest release by date; release selection is unified across commands in the new `internal/resolver` package (#180)
+
 ## [0.22.0] - 2026-07-22
 
 ### Changed

--- a/docs/superpowers/plans/2026-07-28-release-selection-unification.md
+++ b/docs/superpowers/plans/2026-07-28-release-selection-unification.md
@@ -1,0 +1,325 @@
+# Release Selection Unification Implementation Plan (PR1)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Create `internal/resolver` with unified release-selection functions and migrate every command to them, closing #180.
+
+**Architecture:** A new `internal/resolver` package (depending on `internal/api`, `internal/dependency`, `internal/mod`) owns the three selection rules. `internal/cli` keeps a thin `selectRelease(info, spec)` adapter for `modSpec` and loses its four ad-hoc helpers (`findRelease`, `findSyncRelease`, `findCompatibleRelease`, `latestByReleaseDate`).
+
+**Tech Stack:** Go, testify (assert/require), `mise run default` for verification.
+
+This is PR1 of the four-PR plan in
+`docs/superpowers/specs/2026-07-27-dependency-resolution-unification-design.md`.
+PR2-PR4 get their own plan documents later.
+
+## Global Constraints
+
+- Commit messages: English, `:emoji:` prefix (e.g. `:recycle:` refactor, `:sparkles:` feature, `:white_check_mark:` tests). No AI attribution, no `Claude-Session` trailers.
+- Code comments and doc comments: English. "MOD" is uppercase in exported identifiers and user-facing text.
+- Every task ends with `mise run test` green; the branch ends with `mise run default` green.
+- Unified "latest" rule (decided in #180): `info.LatestRelease` when present, otherwise the highest version by `mod.MODVersion.Compare`. The live `/full` endpoint always returns `latest_release: null`, so in practice the highest version wins; the field is honored for future-proofing and short-endpoint consumers.
+
+---
+
+### Task 1: `internal/resolver` package with selection functions
+
+**Files:**
+- Create: `internal/resolver/select.go`
+- Create: `internal/resolver/select_test.go`
+
+**Interfaces:**
+- Consumes: `api.MODInfo`, `api.Release`, `mod.MODVersion`, `dependency.VersionRequirement` (all existing).
+- Produces: `resolver.SelectLatest(info *api.MODInfo) *api.Release`, `resolver.SelectExact(info *api.MODInfo, version mod.MODVersion) *api.Release`, `resolver.SelectCompatible(info *api.MODInfo, requirement *dependency.VersionRequirement) *api.Release`. Task 2 calls all three.
+
+- [ ] **Step 1: Create the feature branch**
+
+```bash
+git checkout -b refactor/release-selection
+```
+
+- [ ] **Step 2: Write the failing tests**
+
+Create `internal/resolver/select_test.go` (internal test package, matching `internal/dependency`):
+
+```go
+package resolver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sakuro/factorix/internal/api"
+	"github.com/sakuro/factorix/internal/dependency"
+	"github.com/sakuro/factorix/internal/mod"
+)
+
+func release(t *testing.T, version string) api.Release {
+	t.Helper()
+	v, err := mod.ParseMODVersion(version)
+	require.NoError(t, err)
+	return api.Release{Version: v, FileName: "test-mod_" + version + ".zip"}
+}
+
+func mustVersion(t *testing.T, s string) mod.MODVersion {
+	t.Helper()
+	v, err := mod.ParseMODVersion(s)
+	require.NoError(t, err)
+	return v
+}
+
+func TestSelectLatest(t *testing.T) {
+	older := release(t, "1.0.0")
+	newer := release(t, "1.1.0")
+
+	t.Run("prefers latest_release when present", func(t *testing.T) {
+		pinned := release(t, "1.0.0")
+		info := &api.MODInfo{LatestRelease: &pinned, Releases: []api.Release{older, newer}}
+		got := SelectLatest(info)
+		require.NotNil(t, got)
+		assert.Equal(t, "1.0.0", got.Version.String())
+	})
+
+	t.Run("falls back to highest version", func(t *testing.T) {
+		// Descending order proves selection is by version, not list position.
+		info := &api.MODInfo{Releases: []api.Release{newer, older}}
+		got := SelectLatest(info)
+		require.NotNil(t, got)
+		assert.Equal(t, "1.1.0", got.Version.String())
+	})
+
+	t.Run("nil when no releases", func(t *testing.T) {
+		assert.Nil(t, SelectLatest(&api.MODInfo{}))
+	})
+}
+
+func TestSelectExact(t *testing.T) {
+	info := &api.MODInfo{Releases: []api.Release{release(t, "1.0.0"), release(t, "1.1.0")}}
+
+	got := SelectExact(info, mustVersion(t, "1.0.0"))
+	require.NotNil(t, got)
+	assert.Equal(t, "1.0.0", got.Version.String())
+
+	assert.Nil(t, SelectExact(info, mustVersion(t, "9.9.9")))
+}
+
+func TestSelectCompatible(t *testing.T) {
+	v1 := release(t, "1.0.0")
+	v2 := release(t, "2.0.0")
+	info := &api.MODInfo{Releases: []api.Release{v1, v2}}
+
+	t.Run("nil requirement selects latest", func(t *testing.T) {
+		got := SelectCompatible(info, nil)
+		require.NotNil(t, got)
+		assert.Equal(t, "2.0.0", got.Version.String())
+	})
+
+	t.Run("highest version satisfying the requirement", func(t *testing.T) {
+		requirement := &dependency.VersionRequirement{Operator: dependency.OpLessEqual, Version: mustVersion(t, "1.5.0")}
+		got := SelectCompatible(info, requirement)
+		require.NotNil(t, got)
+		assert.Equal(t, "1.0.0", got.Version.String())
+	})
+
+	t.Run("latest_release wins when it satisfies", func(t *testing.T) {
+		pinned := release(t, "1.0.0")
+		withLatest := &api.MODInfo{LatestRelease: &pinned, Releases: []api.Release{v1, v2}}
+		requirement := &dependency.VersionRequirement{Operator: dependency.OpLessEqual, Version: mustVersion(t, "2.0.0")}
+		got := SelectCompatible(withLatest, requirement)
+		require.NotNil(t, got)
+		assert.Equal(t, "1.0.0", got.Version.String())
+	})
+
+	t.Run("unsatisfying latest_release is ignored", func(t *testing.T) {
+		pinned := release(t, "2.0.0")
+		withLatest := &api.MODInfo{LatestRelease: &pinned, Releases: []api.Release{v1, v2}}
+		requirement := &dependency.VersionRequirement{Operator: dependency.OpLessEqual, Version: mustVersion(t, "1.5.0")}
+		got := SelectCompatible(withLatest, requirement)
+		require.NotNil(t, got)
+		assert.Equal(t, "1.0.0", got.Version.String())
+	})
+
+	t.Run("nil when nothing satisfies", func(t *testing.T) {
+		requirement := &dependency.VersionRequirement{Operator: dependency.OpGreaterEqual, Version: mustVersion(t, "9.0.0")}
+		assert.Nil(t, SelectCompatible(info, requirement))
+	})
+}
+```
+
+- [ ] **Step 3: Run tests to verify they fail**
+
+Run: `go test ./internal/resolver/`
+Expected: FAIL to build (package `resolver` does not exist yet).
+
+- [ ] **Step 4: Implement `select.go`**
+
+Create `internal/resolver/select.go`:
+
+```go
+// Package resolver selects MOD Portal releases and (in later stages)
+// resolves MOD dependencies against the Portal. It is the single place
+// where "latest" is defined for every command.
+package resolver
+
+import (
+	"slices"
+
+	"github.com/sakuro/factorix/internal/api"
+	"github.com/sakuro/factorix/internal/dependency"
+	"github.com/sakuro/factorix/internal/mod"
+)
+
+// SelectLatest returns the MOD's latest release: the Portal's
+// latest_release field when present, otherwise the highest version among
+// Releases. The full endpoint is known to always omit latest_release, so
+// the fallback is the common path (#180). Returns nil when the MOD has no
+// releases.
+func SelectLatest(info *api.MODInfo) *api.Release {
+	if info.LatestRelease != nil {
+		return info.LatestRelease
+	}
+	return highestVersion(info.Releases)
+}
+
+// SelectExact returns the release with exactly the given version, or nil.
+func SelectExact(info *api.MODInfo, version mod.MODVersion) *api.Release {
+	for i := range info.Releases {
+		if info.Releases[i].Version == version {
+			return &info.Releases[i]
+		}
+	}
+	return nil
+}
+
+// SelectCompatible returns the latest release satisfying the requirement:
+// with a nil requirement it is SelectLatest; otherwise latest_release when
+// that satisfies the requirement, else the highest satisfying version.
+// Returns nil when no release satisfies.
+func SelectCompatible(info *api.MODInfo, requirement *dependency.VersionRequirement) *api.Release {
+	if requirement == nil {
+		return SelectLatest(info)
+	}
+	if info.LatestRelease != nil && requirement.SatisfiedBy(info.LatestRelease.Version) {
+		return info.LatestRelease
+	}
+	var compatible []api.Release
+	for _, r := range info.Releases {
+		if requirement.SatisfiedBy(r.Version) {
+			compatible = append(compatible, r)
+		}
+	}
+	return highestVersion(compatible)
+}
+
+func highestVersion(releases []api.Release) *api.Release {
+	if len(releases) == 0 {
+		return nil
+	}
+	highest := slices.MaxFunc(releases, func(a, b api.Release) int {
+		return a.Version.Compare(b.Version)
+	})
+	return &highest
+}
+```
+
+- [ ] **Step 5: Run tests to verify they pass**
+
+Run: `go test ./internal/resolver/`
+Expected: PASS.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add internal/resolver
+git commit -m ":sparkles: Add internal/resolver with unified release selection"
+```
+
+---
+
+### Task 2: Migrate cli to the resolver selection functions
+
+**Files:**
+- Modify: `internal/cli/download_support.go` (replace `findRelease`, `findCompatibleRelease`, `latestByReleaseDate` with a `selectRelease` adapter)
+- Modify: `internal/cli/mod_install.go` (two call sites)
+- Modify: `internal/cli/mod_download.go` (two call sites)
+- Modify: `internal/cli/mod_sync.go` (delete `findSyncRelease`, one call site)
+- Modify: `internal/cli/mod_update.go` (one call site)
+- Modify: `internal/cli/download_support_test.go` (delete `TestFindRelease`, `TestFindCompatibleRelease`)
+- Modify: `internal/cli/mod_sync_test.go` (delete the `findSyncRelease` test block around lines 220-233)
+
+**Interfaces:**
+- Consumes: `resolver.SelectLatest`, `resolver.SelectExact`, `resolver.SelectCompatible` from Task 1.
+- Produces: `selectRelease(info *api.MODInfo, spec modSpec) *api.Release` in `download_support.go`, used by install, download, and sync.
+
+- [ ] **Step 1: Replace the helpers in `download_support.go`**
+
+Delete `findRelease`, `findCompatibleRelease`, and `latestByReleaseDate` (lines 43-88) and add in their place (import `github.com/sakuro/factorix/internal/resolver`):
+
+```go
+// selectRelease resolves a modSpec to a release: the unified latest rule
+// (resolver.SelectLatest) for "latest" specs, the exact version otherwise.
+func selectRelease(info *api.MODInfo, spec modSpec) *api.Release {
+	if spec.Latest {
+		return resolver.SelectLatest(info)
+	}
+	return resolver.SelectExact(info, spec.Version)
+}
+```
+
+- [ ] **Step 2: Update the call sites**
+
+- `mod_install.go` `planInstall`: `findRelease(info, spec)` → `selectRelease(info, spec)`.
+- `mod_install.go` `resolveInstallDependencies`: `findCompatibleRelease(info, requirement)` → `resolver.SelectCompatible(info, requirement)`.
+- `mod_download.go` `planDownload`: `findRelease(info, spec)` → `selectRelease(info, spec)`.
+- `mod_download.go` `resolveDownloadDependencies`: `findCompatibleRelease(info, newDeps[i].requirement)` → `resolver.SelectCompatible(info, newDeps[i].requirement)`.
+- `mod_sync.go` `planSyncInstallation`: `findSyncRelease(info, spec)` → `selectRelease(info, spec)`; delete the `findSyncRelease` function and its Ruby-inconsistency comment (the inconsistency no longer exists).
+- `mod_update.go` `findUpdateTargets`: `latest := latestByReleaseDate(info.Releases)` → `latest := resolver.SelectLatest(info)`.
+
+Add the `resolver` import to each file that now references it.
+
+- [ ] **Step 3: Delete the superseded tests**
+
+- `download_support_test.go`: delete `TestFindRelease` and `TestFindCompatibleRelease` (their behavior is covered by `internal/resolver/select_test.go`). Keep the `release` helper if other tests use it; delete it too if unused.
+- `mod_sync_test.go`: delete the `findSyncRelease` assertions (the block testing exact version, missing version, latest fallback, and `LatestRelease` preference).
+
+- [ ] **Step 4: Build and run the package tests**
+
+Run: `go build ./... && go test ./internal/cli/ ./internal/resolver/`
+Expected: build PASS. Test failures are acceptable only in integration tests whose fixtures distinguish date-based from version-based "latest" — collect the list for Step 5. Anything else must be fixed before proceeding.
+
+- [ ] **Step 5: Reconcile integration-test expectations**
+
+The mock Portal (`portal_mock_test.go`) mirrors the live API: `/full` never carries `latest_release`, and releases default to the same `ReleasedAt`. Two semantic shifts can surface:
+
+1. Fixtures where the newest-by-date release is not the highest version: "latest" now selects the highest version.
+2. Fixtures with equal dates and unordered releases: the old code picked the first listed release; the new code deterministically picks the highest version.
+
+For each failing test in `portal_integration_test.go`, `portal_integration_download_test.go`, `portal_integration_update_test.go`, `portal_integration_sync_test.go`, `mod_install_update_test.go`, or `download_test.go`: confirm the failure is one of these two shifts, then update the expected version/filename. A failure that does not match either shift is a regression — stop and fix the code instead. Also update `portal_integration_sync_test.go`'s comment referencing `findSyncRelease` (line 19) to reference the unified rule.
+
+- [ ] **Step 6: Run the full check suite**
+
+Run: `mise run default`
+Expected: PASS (test + e2e + vet + lint + fmt-check).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add internal/cli
+git commit -m ":recycle: Unify release selection on internal/resolver"
+```
+
+---
+
+### Task 3: Pull request
+
+- [ ] **Step 1: Push and open the PR**
+
+Push the branch and create the PR with the `create-pr` skill. Title: `Unify release selection into internal/resolver`. Body must include:
+
+- Summary: single definition of "latest" (`latest_release` when present, else highest version); replaces the four cli helpers.
+- Behavior change note: install/download/update "latest" moves from newest-by-release-date to the unified rule; sync is unchanged.
+- `Closes #180`, and a reference to epic #184.
+- No AI attribution.
+
+- [ ] **Step 2: Verify CI is green and report the PR URL**

--- a/docs/superpowers/specs/2026-07-27-dependency-resolution-unification-design.md
+++ b/docs/superpowers/specs/2026-07-27-dependency-resolution-unification-design.md
@@ -35,11 +35,13 @@ divergence is a historical accident rather than a design decision:
   The hardcoded `builtinMODs` list in `mod_download.go` is removed. The
   install/sync path stops querying the Portal for expansion dependencies
   (previously it relied on the fetch failing with a warning).
+- **Recommended dependencies**: `download --recursive` follows required +
+  recommended by default, like install/sync, and gains the same
+  `--ignore-recommended` opt-out flag (previously it followed required
+  only).
 
 Intentional differences stay as parameters:
 
-- `download --recursive` follows required dependencies only; install/sync
-  follow required + recommended (with `--ignore-recommended` opt-out).
 - Explicitly requested MODs fail hard when unresolvable; transitively
   discovered dependencies are skipped with a warning.
 
@@ -112,8 +114,10 @@ Behavior details:
 - **sync**: same graph flow; keeps its save-file-specific planning
   (conflicts, unlisted, strict-version deletions) on top.
 - **download**: passes a fresh empty graph (installation state is
-  irrelevant); non-recursive mode is a resolve without following any edges
-  (implemented as a separate initial-fetch-only helper or an option).
+  irrelevant); recursive mode follows required + recommended like
+  install/sync, with a new `--ignore-recommended` flag; non-recursive mode
+  is a resolve without following any edges (implemented as a separate
+  initial-fetch-only helper or an option).
 - `resolveInstallDependencies`, `resolveDownloadDependencies`, and
   `collectNewDependencies` are deleted.
 

--- a/docs/superpowers/specs/2026-07-27-dependency-resolution-unification-design.md
+++ b/docs/superpowers/specs/2026-07-27-dependency-resolution-unification-design.md
@@ -1,0 +1,202 @@
+# Dependency Resolution and MOD Command Unification
+
+## Goal
+
+The MOD management commands (`install`, `uninstall`, `enable`, `disable`,
+`update`, `sync`, `download`) each implement their own copies of closely
+related logic. The duplication makes maintenance hard: a fix in one command
+does not reach its siblings, and the copies have already drifted (see #180).
+
+Unify four areas, parameterizing intentional behavioral differences:
+
+- **A. Portal fetch + recursive dependency resolution** — two parallel BFS
+  implementations (`resolveInstallDependencies` in `mod_install.go`,
+  `resolveDownloadDependencies` in `mod_download.go`) plus three copies of
+  the initial fetch-and-select loop (install, sync, download).
+- **B. Planning BFS** — `PlanEnable`, `PlanDisable`, and
+  `MarkDisabledDependenciesForEnable` in `internal/dependency/plan.go` are
+  three similar traversals differing in direction and edge filter.
+- **C. mod-list.json mutation and package deletion** — the
+  Contains/Enabled/Enable-or-Add pattern appears in `executeInstall`,
+  `executeUpdates`, and `applySyncChange`; form-aware file deletion appears
+  in `executeUninstall` and `executeSyncDeletions`.
+- **D. Command skeleton** — the RequireGameStopped → loadMODState → plan →
+  confirm → execute → backup+save sequence is repeated across commands.
+
+## Behavioral policy
+
+Unification is allowed to change observable behavior where the current
+divergence is a historical accident rather than a design decision:
+
+- **"latest" resolution (closes #180)**: unified on the Portal's
+  `latest_release` field. This changes install/download/update (previously
+  newest-by-release-date) and leaves sync effectively unchanged.
+- **Builtin MOD skipping**: unified on `mod.MOD.IsBase() || IsExpansion()`.
+  The hardcoded `builtinMODs` list in `mod_download.go` is removed. The
+  install/sync path stops querying the Portal for expansion dependencies
+  (previously it relied on the fetch failing with a warning).
+
+Intentional differences stay as parameters:
+
+- `download --recursive` follows required dependencies only; install/sync
+  follow required + recommended (with `--ignore-recommended` opt-out).
+- Explicitly requested MODs fail hard when unresolvable; transitively
+  discovered dependencies are skipped with a warning.
+
+## Component: `internal/resolver` (new package)
+
+Depends on `internal/api`, `internal/dependency`, `internal/mod`.
+`internal/dependency` stays free of `api` imports (pure graph algorithms).
+
+### Release selection
+
+```go
+// SelectLatest returns info.LatestRelease when present, otherwise the
+// release with the highest version (mod.MODVersion.Compare).
+func SelectLatest(info *api.MODInfo) *api.Release
+
+// SelectExact returns the release with exactly the given version, or nil.
+func SelectExact(info *api.MODInfo, version mod.MODVersion) *api.Release
+
+// SelectCompatible returns SelectLatest when requirement is nil. Otherwise
+// it returns info.LatestRelease when that satisfies the requirement, else
+// the highest-version release satisfying it, else nil.
+func SelectCompatible(info *api.MODInfo, requirement *dependency.VersionRequirement) *api.Release
+```
+
+These replace `findRelease`, `findSyncRelease`, `findCompatibleRelease`,
+and `latestByReleaseDate` in `internal/cli`. `mod update` uses
+`SelectLatest` for its newer-version check.
+
+### Spec
+
+`cli.modSpec` moves here as `resolver.Spec` (same fields: `MOD`, `Latest`,
+`Version`). The string parsing (`parseMODSpec`) stays in `internal/cli`;
+`mod uninstall` keeps its own spec type (exact-version-only semantics).
+
+### Resolution engine
+
+```go
+type Resolver struct {
+    Portal api.PortalAPI // needs GetMODFull
+    Logger *slog.Logger
+}
+
+type Options struct {
+    Jobs              int  // parallel Portal requests
+    FollowRecommended bool // also follow recommended edges
+}
+
+// Resolve fetches each spec from the Portal, adds it to graph (via
+// AddUninstalledMOD), then walks required (and, per Options, recommended)
+// edges breadth-first, fetching MODs not yet in the graph and extending it
+// until the frontier is empty. It returns the selected release for every
+// newly added MOD.
+func (r *Resolver) Resolve(ctx context.Context, graph *dependency.Graph, specs []Spec, opts Options) (map[mod.MOD]api.Release, error)
+```
+
+Behavior details:
+
+- Explicit specs: fetch with `GetMODFull`, select with `SelectLatest` /
+  `SelectExact`; any failure aborts with an error.
+- Transitive dependencies: select with `SelectCompatible`; fetch failure or
+  no compatible release logs a warning and skips the MOD.
+- Base and expansion MODs are never fetched or added.
+- Fetches run concurrently through the existing
+  `fetchMODInfoConcurrently`-style errgroup pattern (moves into resolver).
+
+### Callers
+
+- **install**: passes the installed-MOD graph; keeps
+  `MarkDisabledDependenciesForEnable` + `ValidateInstallGraph` afterwards.
+- **sync**: same graph flow; keeps its save-file-specific planning
+  (conflicts, unlisted, strict-version deletions) on top.
+- **download**: passes a fresh empty graph (installation state is
+  irrelevant); non-recursive mode is a resolve without following any edges
+  (implemented as a separate initial-fetch-only helper or an option).
+- `resolveInstallDependencies`, `resolveDownloadDependencies`, and
+  `collectNewDependencies` are deleted.
+
+## Component: planning traversal (`internal/dependency/plan.go`)
+
+An unexported traversal helper unifies the three BFS loops:
+
+```go
+type walkOptions struct {
+    direction  walkDirection       // forward (EdgesFrom) or dependents
+    followEdge func(Edge) bool     // whether to traverse this edge
+    visit      func(mod.MOD) error // per-node action; an error aborts the walk
+}
+```
+
+`PlanEnable`, `PlanDisable`, and `MarkDisabledDependenciesForEnable` are
+reimplemented on top of it. Public API and behavior are unchanged; existing
+tests in `plan_test.go` must pass unmodified. The exact helper signature may
+be adjusted during implementation as long as the three functions share one
+queue/visited loop.
+
+## Component: mutation helpers
+
+- `mod.InstalledMOD.Remove() error` — deletes the package from disk,
+  handling `FormDirectory` vs zip. Used by uninstall and sync.
+- `mod.MODList.EnsureEnabled(m MOD) (added bool, err error)` — enables an
+  existing entry or adds a new enabled one. Used by install and update.
+- `mod.MODList.Replace(m MOD, state MODState) error` — Remove + Add, for
+  changing the recorded version/state atomically. Used by update and sync.
+
+## Component: command skeleton (`internal/cli`)
+
+One generic function, not a framework:
+
+```go
+type mutationOpts struct {
+    yes             bool
+    quiet           bool
+    backupExtension string
+    confirmPrompt   string
+    emptyMessage    string
+}
+
+// runMODMutation: RequireGameStopped → loadMODState → plan → (empty? print
+// emptyMessage, done) → show plan → confirm → execute → backup + save
+// mod-list.json.
+func runMODMutation[P any](cmd *cobra.Command, c *cli, opts mutationOpts,
+    plan func(ctx context.Context, application *app.App, state *modState) (P, error),
+    isEmpty func(P) bool,
+    show func(p *printer, plan P),
+    execute func(ctx context.Context, application *app.App, state *modState, plan P) error,
+) error
+```
+
+Adopted by install, uninstall, enable, disable, update, and sync. sync's
+extra outputs (mod-settings.dat, package deletions) happen inside its
+`execute`. Read-only commands (list, check, search, show, download, …) are
+out of scope. If a command's flow genuinely does not fit (e.g. a
+conditional save), fitting it in by force is not required — adopt the
+helper only where it simplifies.
+
+## Testing
+
+- New unit tests for `internal/resolver` using a Portal mock (reshape
+  `portal_mock_test.go` for reuse or add a mock in the resolver package).
+- Existing cli tests and e2e cases stay; only expectations covered by the
+  intentional behavior changes (latest resolution, expansion skipping) are
+  updated, with the reason stated in the PR.
+- Every PR passes `mise run default`.
+
+## Delivery plan
+
+Four sequential PRs, each independently reviewable:
+
+1. **PR1 — release selection**: create `internal/resolver` with the Select
+   functions; migrate all commands; delete the four cli selection helpers.
+   Closes #180.
+2. **PR2 — resolution engine**: add `Resolver.Resolve`; migrate install,
+   sync, download; delete the two BFS implementations and `builtinMODs`.
+3. **PR3 — planning traversal**: unify the three BFS loops in
+   `internal/dependency/plan.go`. Pure refactor.
+4. **PR4 — mutation helpers + skeleton**: `InstalledMOD.Remove`, `MODList`
+   helpers, `runMODMutation`; migrate the six mutation commands.
+
+GitHub tracking: one epic issue with a task list; #180 covers PR1; three
+new issues cover PR2-PR4.

--- a/go.sum
+++ b/go.sum
@@ -26,8 +26,6 @@ github.com/mattn/go-colorable v0.1.14 h1:9A9LHSqF/7dyVVX6g0U9cwm9pG3kP9gSzcuIPHP
 github.com/mattn/go-colorable v0.1.14/go.mod h1:6LmQG8QLFO4G5z1gPvYEzlUgJ2wF+stgPZH1UqBm1s8=
 github.com/mattn/go-isatty v0.0.20 h1:xfD0iDuEKnDkl03q4limB+vH+GxLEtL/jb4xVJSWWEY=
 github.com/mattn/go-isatty v0.0.20/go.mod h1:W+V8PltTTMOvKvAeJH7IuucS94S2C6jfK/D7dTCTo3Y=
-github.com/mattn/go-runewidth v0.0.23 h1:7ykA0T0jkPpzSvMS5i9uoNn2Xy3R383f9HDx3RybWcw=
-github.com/mattn/go-runewidth v0.0.23/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
 github.com/mattn/go-runewidth v0.0.24 h1:cpokDiIn0MGnhdHwuWnJBITySJ20QyNGnY2kR/ay2DU=
 github.com/mattn/go-runewidth v0.0.24/go.mod h1:XBkDxAl56ILZc9knddidhrOlY5R/pDhgLpndooCuJAs=
 github.com/pmezard/go-difflib v1.0.0 h1:4DBwDE0NGyQoBHbLQYPwSUPoCMWR5BEzIk/f1lZbAQM=
@@ -41,8 +39,6 @@ github.com/spf13/pflag v1.0.9 h1:9exaQaMOCwffKiiiYk6/BndUBv+iRViNW+4lEMi0PvY=
 github.com/spf13/pflag v1.0.9/go.mod h1:McXfInJRrz4CZXVZOBLb0bTZqETkiAhM9Iw0y3An2Bg=
 github.com/stretchr/testify v1.11.1 h1:7s2iGBzp5EwR7/aIZr8ao5+dra3wiQyKjjFuvgVKu7U=
 github.com/stretchr/testify v1.11.1/go.mod h1:wZwfW3scLgRK+23gO65QZefKpKQRnfz6sD981Nm4B6U=
-github.com/vbauerster/mpb/v8 v8.12.1 h1:pyj3yQ2ZGQJgUXm4h17QpR+eERaNz5OQ1ftPSEE/sMM=
-github.com/vbauerster/mpb/v8 v8.12.1/go.mod h1:XLXRfStkw/6i5k0aQltijDHT1Z93fD1DVwmIdcFUp6k=
 github.com/vbauerster/mpb/v8 v8.13.0 h1:uv5hrYmoVNy+3w4mjePgQXwmqUzLjhKX5p2+77CFfwo=
 github.com/vbauerster/mpb/v8 v8.13.0/go.mod h1:yY6DDD9c3idT01aDMzs98st5aotXIOXXUgPG3hAbAHk=
 go.yaml.in/yaml/v3 v3.0.4/go.mod h1:DhzuOOF2ATzADvBadXxruRBLzYTpT36CKvDb3+aBEFg=

--- a/internal/cli/download_support.go
+++ b/internal/cli/download_support.go
@@ -11,9 +11,9 @@ import (
 
 	"github.com/sakuro/factorix/internal/api"
 	"github.com/sakuro/factorix/internal/app"
-	"github.com/sakuro/factorix/internal/dependency"
 	"github.com/sakuro/factorix/internal/mod"
 	"github.com/sakuro/factorix/internal/progress"
+	"github.com/sakuro/factorix/internal/resolver"
 	"github.com/sakuro/factorix/internal/transfer"
 )
 
@@ -40,51 +40,13 @@ func parseMODSpec(spec string) (modSpec, error) {
 	return modSpec{MOD: mod.MOD{Name: name}, Version: version}, nil
 }
 
-// findRelease returns the release matching spec: the most recently released
-// one for "latest", or the exact version otherwise. "Latest" is computed
-// from Releases rather than trusting MODInfo.LatestRelease — the Portal API
-// wiki never specifies how that field is chosen (highest version? most
-// recent? filtered by Factorio-version compatibility?), so relying on it
-// would make "latest" mean something undocumented and possibly unstable.
-func findRelease(info *api.MODInfo, spec modSpec) *api.Release {
+// selectRelease resolves a modSpec to a release: the unified latest rule
+// (resolver.SelectLatest) for "latest" specs, the exact version otherwise.
+func selectRelease(info *api.MODInfo, spec modSpec) *api.Release {
 	if spec.Latest {
-		return latestByReleaseDate(info.Releases)
+		return resolver.SelectLatest(info)
 	}
-	for i := range info.Releases {
-		if info.Releases[i].Version == spec.Version {
-			return &info.Releases[i]
-		}
-	}
-	return nil
-}
-
-// findCompatibleRelease returns the most recently released version
-// satisfying requirement (or the most recent release of any version when
-// requirement is nil).
-func findCompatibleRelease(info *api.MODInfo, requirement *dependency.VersionRequirement) *api.Release {
-	if requirement == nil {
-		return latestByReleaseDate(info.Releases)
-	}
-	var compatible []api.Release
-	for _, r := range info.Releases {
-		if requirement.SatisfiedBy(r.Version) {
-			compatible = append(compatible, r)
-		}
-	}
-	return latestByReleaseDate(compatible)
-}
-
-func latestByReleaseDate(releases []api.Release) *api.Release {
-	if len(releases) == 0 {
-		return nil
-	}
-	latest := &releases[0]
-	for i := 1; i < len(releases); i++ {
-		if releases[i].ReleasedAt.After(latest.ReleasedAt) {
-			latest = &releases[i]
-		}
-	}
-	return latest
+	return resolver.SelectExact(info, spec.Version)
 }
 
 // downloadTarget is a MOD release resolved to a local output path.

--- a/internal/cli/download_support_test.go
+++ b/internal/cli/download_support_test.go
@@ -2,7 +2,6 @@ package cli
 
 import (
 	"testing"
-	"time"
 
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
@@ -12,12 +11,12 @@ import (
 	"github.com/sakuro/factorix/internal/mod"
 )
 
-func release(version string, releasedAt time.Time) api.Release {
+func release(version string) api.Release {
 	v, err := mod.ParseMODVersion(version)
 	if err != nil {
 		panic(err)
 	}
-	return api.Release{Version: v, ReleasedAt: releasedAt, FileName: "test-mod_" + version + ".zip"}
+	return api.Release{Version: v, FileName: "test-mod_" + version + ".zip"}
 }
 
 func TestParseMODSpec(t *testing.T) {
@@ -52,7 +51,7 @@ func TestValidateFilename(t *testing.T) {
 
 func TestBuildDownloadTargets(t *testing.T) {
 	infos := []fetchedMODInfo{
-		{MOD: mod.MOD{Name: "some-mod"}, MODInfo: &api.MODInfo{Name: "some-mod"}, Release: release("1.0.0", time.Now())},
+		{MOD: mod.MOD{Name: "some-mod"}, MODInfo: &api.MODInfo{Name: "some-mod"}, Release: release("1.0.0")},
 	}
 	targets, err := buildDownloadTargets(infos, "/tmp/downloads")
 	require.NoError(t, err)

--- a/internal/cli/download_support_test.go
+++ b/internal/cli/download_support_test.go
@@ -42,41 +42,6 @@ func TestParseMODSpec(t *testing.T) {
 	require.Error(t, err)
 }
 
-func TestFindRelease(t *testing.T) {
-	older := release("1.0.0", time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
-	newer := release("1.1.0", time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC))
-	info := &api.MODInfo{Releases: []api.Release{older, newer}}
-
-	got := findRelease(info, modSpec{Latest: true})
-	require.NotNil(t, got)
-	assert.Equal(t, "1.1.0", got.Version.String())
-
-	got = findRelease(info, modSpec{Version: mod.MODVersion{Major: 1}})
-	require.NotNil(t, got)
-	assert.Equal(t, "1.0.0", got.Version.String())
-
-	got = findRelease(info, modSpec{Version: mod.MODVersion{Major: 9}})
-	assert.Nil(t, got)
-}
-
-func TestFindCompatibleRelease(t *testing.T) {
-	v1 := release("1.0.0", time.Date(2024, 1, 1, 0, 0, 0, 0, time.UTC))
-	v2 := release("2.0.0", time.Date(2024, 6, 1, 0, 0, 0, 0, time.UTC))
-	info := &api.MODInfo{Releases: []api.Release{v1, v2}}
-
-	got := findCompatibleRelease(info, nil)
-	require.NotNil(t, got)
-	assert.Equal(t, "2.0.0", got.Version.String())
-
-	requirement := &dependency.VersionRequirement{Operator: dependency.OpLessEqual, Version: mod.MODVersion{Major: 1}}
-	got = findCompatibleRelease(info, requirement)
-	require.NotNil(t, got)
-	assert.Equal(t, "1.0.0", got.Version.String())
-
-	requirement = &dependency.VersionRequirement{Operator: dependency.OpGreaterEqual, Version: mod.MODVersion{Major: 9}}
-	assert.Nil(t, findCompatibleRelease(info, requirement))
-}
-
 func TestValidateFilename(t *testing.T) {
 	require.NoError(t, validateFilename("test-mod_1.0.0.zip"))
 

--- a/internal/cli/mod_download.go
+++ b/internal/cli/mod_download.go
@@ -14,6 +14,7 @@ import (
 	"github.com/sakuro/factorix/internal/app"
 	"github.com/sakuro/factorix/internal/dependency"
 	"github.com/sakuro/factorix/internal/mod"
+	"github.com/sakuro/factorix/internal/resolver"
 )
 
 var builtinMODs = []string{"base", "elevated-rails", "quality", "recycler", "space-age"}
@@ -117,7 +118,7 @@ func planDownload(ctx context.Context, application *app.App, specs []modSpec, do
 		if err != nil {
 			return fetchedMODInfo{}, err
 		}
-		release := findRelease(info, spec)
+		release := selectRelease(info, spec)
 		if release == nil {
 			return fetchedMODInfo{}, fmt.Errorf("Release not found for %s@%s", spec.MOD.Name, specVersionLabel(spec))
 		}
@@ -187,7 +188,7 @@ func resolveDownloadDependencies(ctx context.Context, application *app.App, init
 				return fetchedMODInfo{}, nil
 			}
 			i := slices.IndexFunc(newDeps, func(d requiredDependency) bool { return d.name == spec.MOD.Name })
-			release := findCompatibleRelease(info, newDeps[i].requirement)
+			release := resolver.SelectCompatible(info, newDeps[i].requirement)
 			if release == nil {
 				warnAndSkip(application, spec.MOD.Name, errors.New("no compatible release found"))
 				return fetchedMODInfo{}, nil

--- a/internal/cli/mod_install.go
+++ b/internal/cli/mod_install.go
@@ -13,6 +13,7 @@ import (
 	"github.com/sakuro/factorix/internal/app"
 	"github.com/sakuro/factorix/internal/dependency"
 	"github.com/sakuro/factorix/internal/mod"
+	"github.com/sakuro/factorix/internal/resolver"
 )
 
 // installTarget is one planned action: download-and-enable a new MOD, or
@@ -155,7 +156,7 @@ func planInstall(ctx context.Context, application *app.App, graph *dependency.Gr
 		if err != nil {
 			return fetchedMODInfo{}, err
 		}
-		release := findRelease(info, spec)
+		release := selectRelease(info, spec)
 		if release == nil {
 			return fetchedMODInfo{}, fmt.Errorf("Release not found for %s@%s", spec.MOD.Name, specVersionLabel(spec))
 		}
@@ -262,7 +263,7 @@ func resolveInstallDependencies(ctx context.Context, application *app.App, graph
 				application.Logger.Warn("Skipping dependency", "mod", spec.MOD.Name, "required_by", requiredBy.Name, "reason", err)
 				return fetchedMODInfo{}, nil
 			}
-			release := findCompatibleRelease(info, requirement)
+			release := resolver.SelectCompatible(info, requirement)
 			if release == nil {
 				application.Logger.Warn("Skipping dependency", "mod", spec.MOD.Name, "required_by", requiredBy.Name, "reason", "no compatible release found")
 				return fetchedMODInfo{}, nil

--- a/internal/cli/mod_sync.go
+++ b/internal/cli/mod_sync.go
@@ -261,7 +261,7 @@ func planSyncInstallation(ctx context.Context, application *app.App, graph *depe
 		if err != nil {
 			return fetchedMODInfo{}, err
 		}
-		release := findSyncRelease(info, spec)
+		release := selectRelease(info, spec)
 		if release == nil {
 			return fetchedMODInfo{}, fmt.Errorf("Release not found for %s@%s", spec.MOD.Name, spec.Version)
 		}
@@ -315,36 +315,6 @@ func planSyncInstallation(ctx context.Context, application *app.App, graph *depe
 		result[i] = syncInstallTarget{downloadTarget: target}
 	}
 	return result, dependencyEntries, nil
-}
-
-// findSyncRelease picks the exact save version in strict mode; otherwise
-// the portal's latest_release, falling back to the highest version. This
-// mirrors Ruby's mod/sync.rb#fetch_single_mod_info exactly, including its
-// inconsistency with mod install/download (download_support.rb, via
-// findRelease): that path never trusts latest_release — its selection
-// method is undocumented by the Portal API wiki — and instead computes
-// "latest" itself from release dates. Sync keeps the Ruby behavior as-is
-// rather than "fixing" a cross-command inconsistency outside this task's
-// scope.
-func findSyncRelease(info *api.MODInfo, spec modSpec) *api.Release {
-	if !spec.Latest {
-		for i := range info.Releases {
-			if info.Releases[i].Version == spec.Version {
-				return &info.Releases[i]
-			}
-		}
-		return nil
-	}
-	if info.LatestRelease != nil {
-		return info.LatestRelease
-	}
-	if len(info.Releases) == 0 {
-		return nil
-	}
-	highest := slices.MaxFunc(info.Releases, func(a, b api.Release) int {
-		return a.Version.Compare(b.Version)
-	})
-	return &highest
 }
 
 // enrichSyncInstallTargets records the currently installed version of each

--- a/internal/cli/mod_sync_test.go
+++ b/internal/cli/mod_sync_test.go
@@ -9,7 +9,6 @@ import (
 	"github.com/stretchr/testify/assert"
 	"github.com/stretchr/testify/require"
 
-	"github.com/sakuro/factorix/internal/api"
 	"github.com/sakuro/factorix/internal/mod"
 	"github.com/sakuro/factorix/internal/save"
 	"github.com/sakuro/factorix/internal/serdes"
@@ -212,25 +211,6 @@ func writeMODZip(t *testing.T, path, name, version string) {
 	require.NoError(t, err)
 	require.NoError(t, zw.Close())
 	require.NoError(t, f.Close())
-}
-
-func TestFindSyncRelease(t *testing.T) {
-	v1 := mustVersion(t, "1.0.0")
-	v2 := mustVersion(t, "2.0.0")
-	info := &api.MODInfo{Releases: []api.Release{{Version: v1}, {Version: v2}}}
-
-	// Strict: exact version or nothing.
-	release := findSyncRelease(info, modSpec{Version: v1})
-	require.NotNil(t, release)
-	assert.Equal(t, v1, release.Version)
-	assert.Nil(t, findSyncRelease(info, modSpec{Version: mustVersion(t, "9.9.9")}))
-
-	// Latest: latest_release wins, highest version as fallback.
-	release = findSyncRelease(info, modSpec{Latest: true})
-	require.NotNil(t, release)
-	assert.Equal(t, v2, release.Version)
-	withLatest := &api.MODInfo{Releases: info.Releases, LatestRelease: &api.Release{Version: v1}}
-	assert.Equal(t, v1, findSyncRelease(withLatest, modSpec{Latest: true}).Version)
 }
 
 func TestPlanMODListChangesStrictVersion(t *testing.T) {

--- a/internal/cli/mod_update.go
+++ b/internal/cli/mod_update.go
@@ -12,6 +12,7 @@ import (
 	"github.com/sakuro/factorix/internal/api"
 	"github.com/sakuro/factorix/internal/app"
 	"github.com/sakuro/factorix/internal/mod"
+	"github.com/sakuro/factorix/internal/resolver"
 )
 
 // updateTarget is one MOD with a newer release available.
@@ -160,7 +161,7 @@ func findUpdateTargets(ctx context.Context, application *app.App, targetMODs []m
 				}
 				return err
 			}
-			latest := latestByReleaseDate(info.Releases)
+			latest := resolver.SelectLatest(info)
 			if latest == nil || !current.Less(latest.Version) {
 				return nil
 			}

--- a/internal/cli/portal_integration_sync_test.go
+++ b/internal/cli/portal_integration_sync_test.go
@@ -15,9 +15,8 @@ func TestMODSyncInstallsMissingMODAgainstMockPortal(t *testing.T) {
 	s.writeMODList(t, modListEntry{name: "base", enabled: true})
 	portal := newMockPortal(t, portalMOD{
 		Name: "some-mod", Title: "Some MOD", Owner: "alice",
-		// mod sync (unlike install/download) trusts latest_release first
-		// (see findSyncRelease) — set both so the test exercises the real
-		// full-endpoint shape either way.
+		// All commands now share the unified latest rule (resolver.SelectLatest):
+		// latest_release first, falling back to the highest version.
 		Releases: []portalRelease{{
 			Version: "1.0.0", FileName: "some-mod_1.0.0.zip", DownloadURL: "/download/some-mod_1.0.0.zip",
 		}},

--- a/internal/cli/portal_integration_test.go
+++ b/internal/cli/portal_integration_test.go
@@ -112,8 +112,7 @@ func TestMODInstallAgainstMockPortal(t *testing.T) {
 	}
 	portal := newMockPortal(t, portalMOD{
 		Name: "some-mod", Title: "Some MOD", Owner: "alice",
-		// mod install hits /full, which never carries latest_release; it
-		// resolves "@latest" from Releases by release date.
+		// mod install hits /full, which never carries latest_release; resolver.SelectLatest picks the highest version.
 		Releases: []portalRelease{release},
 	})
 	portal.withPortal(t)

--- a/internal/resolver/select.go
+++ b/internal/resolver/select.go
@@ -1,0 +1,64 @@
+// Package resolver selects MOD Portal releases and (in later stages)
+// resolves MOD dependencies against the Portal. It is the single place
+// where "latest" is defined for every command.
+package resolver
+
+import (
+	"slices"
+
+	"github.com/sakuro/factorix/internal/api"
+	"github.com/sakuro/factorix/internal/dependency"
+	"github.com/sakuro/factorix/internal/mod"
+)
+
+// SelectLatest returns the MOD's latest release: the Portal's
+// latest_release field when present, otherwise the highest version among
+// Releases. The full endpoint is known to always omit latest_release, so
+// the fallback is the common path (#180). Returns nil when the MOD has no
+// releases.
+func SelectLatest(info *api.MODInfo) *api.Release {
+	if info.LatestRelease != nil {
+		return info.LatestRelease
+	}
+	return highestVersion(info.Releases)
+}
+
+// SelectExact returns the release with exactly the given version, or nil.
+func SelectExact(info *api.MODInfo, version mod.MODVersion) *api.Release {
+	for i := range info.Releases {
+		if info.Releases[i].Version == version {
+			return &info.Releases[i]
+		}
+	}
+	return nil
+}
+
+// SelectCompatible returns the latest release satisfying the requirement:
+// with a nil requirement it is SelectLatest; otherwise latest_release when
+// that satisfies the requirement, else the highest satisfying version.
+// Returns nil when no release satisfies.
+func SelectCompatible(info *api.MODInfo, requirement *dependency.VersionRequirement) *api.Release {
+	if requirement == nil {
+		return SelectLatest(info)
+	}
+	if info.LatestRelease != nil && requirement.SatisfiedBy(info.LatestRelease.Version) {
+		return info.LatestRelease
+	}
+	var compatible []api.Release
+	for _, r := range info.Releases {
+		if requirement.SatisfiedBy(r.Version) {
+			compatible = append(compatible, r)
+		}
+	}
+	return highestVersion(compatible)
+}
+
+func highestVersion(releases []api.Release) *api.Release {
+	if len(releases) == 0 {
+		return nil
+	}
+	highest := slices.MaxFunc(releases, func(a, b api.Release) int {
+		return a.Version.Compare(b.Version)
+	})
+	return &highest
+}

--- a/internal/resolver/select_test.go
+++ b/internal/resolver/select_test.go
@@ -1,0 +1,103 @@
+package resolver
+
+import (
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sakuro/factorix/internal/api"
+	"github.com/sakuro/factorix/internal/dependency"
+	"github.com/sakuro/factorix/internal/mod"
+)
+
+func release(t *testing.T, version string) api.Release {
+	t.Helper()
+	v, err := mod.ParseMODVersion(version)
+	require.NoError(t, err)
+	return api.Release{Version: v, FileName: "test-mod_" + version + ".zip"}
+}
+
+func mustVersion(t *testing.T, s string) mod.MODVersion {
+	t.Helper()
+	v, err := mod.ParseMODVersion(s)
+	require.NoError(t, err)
+	return v
+}
+
+func TestSelectLatest(t *testing.T) {
+	older := release(t, "1.0.0")
+	newer := release(t, "1.1.0")
+
+	t.Run("prefers latest_release when present", func(t *testing.T) {
+		pinned := release(t, "1.0.0")
+		info := &api.MODInfo{LatestRelease: &pinned, Releases: []api.Release{older, newer}}
+		got := SelectLatest(info)
+		require.NotNil(t, got)
+		assert.Equal(t, "1.0.0", got.Version.String())
+	})
+
+	t.Run("falls back to highest version", func(t *testing.T) {
+		// Descending order proves selection is by version, not list position.
+		info := &api.MODInfo{Releases: []api.Release{newer, older}}
+		got := SelectLatest(info)
+		require.NotNil(t, got)
+		assert.Equal(t, "1.1.0", got.Version.String())
+	})
+
+	t.Run("nil when no releases", func(t *testing.T) {
+		assert.Nil(t, SelectLatest(&api.MODInfo{}))
+	})
+}
+
+func TestSelectExact(t *testing.T) {
+	info := &api.MODInfo{Releases: []api.Release{release(t, "1.0.0"), release(t, "1.1.0")}}
+
+	got := SelectExact(info, mustVersion(t, "1.0.0"))
+	require.NotNil(t, got)
+	assert.Equal(t, "1.0.0", got.Version.String())
+
+	assert.Nil(t, SelectExact(info, mustVersion(t, "9.9.9")))
+}
+
+func TestSelectCompatible(t *testing.T) {
+	v1 := release(t, "1.0.0")
+	v2 := release(t, "2.0.0")
+	info := &api.MODInfo{Releases: []api.Release{v1, v2}}
+
+	t.Run("nil requirement selects latest", func(t *testing.T) {
+		got := SelectCompatible(info, nil)
+		require.NotNil(t, got)
+		assert.Equal(t, "2.0.0", got.Version.String())
+	})
+
+	t.Run("highest version satisfying the requirement", func(t *testing.T) {
+		requirement := &dependency.VersionRequirement{Operator: dependency.OpLessEqual, Version: mustVersion(t, "1.5.0")}
+		got := SelectCompatible(info, requirement)
+		require.NotNil(t, got)
+		assert.Equal(t, "1.0.0", got.Version.String())
+	})
+
+	t.Run("latest_release wins when it satisfies", func(t *testing.T) {
+		pinned := release(t, "1.0.0")
+		withLatest := &api.MODInfo{LatestRelease: &pinned, Releases: []api.Release{v1, v2}}
+		requirement := &dependency.VersionRequirement{Operator: dependency.OpLessEqual, Version: mustVersion(t, "2.0.0")}
+		got := SelectCompatible(withLatest, requirement)
+		require.NotNil(t, got)
+		assert.Equal(t, "1.0.0", got.Version.String())
+	})
+
+	t.Run("unsatisfying latest_release is ignored", func(t *testing.T) {
+		pinned := release(t, "2.0.0")
+		withLatest := &api.MODInfo{LatestRelease: &pinned, Releases: []api.Release{v1, v2}}
+		requirement := &dependency.VersionRequirement{Operator: dependency.OpLessEqual, Version: mustVersion(t, "1.5.0")}
+		got := SelectCompatible(withLatest, requirement)
+		require.NotNil(t, got)
+		assert.Equal(t, "1.0.0", got.Version.String())
+	})
+
+	t.Run("nil when nothing satisfies", func(t *testing.T) {
+		requirement := &dependency.VersionRequirement{Operator: dependency.OpGreaterEqual, Version: mustVersion(t, "9.0.0")}
+		assert.Nil(t, SelectCompatible(info, requirement))
+	})
+}


### PR DESCRIPTION
## Summary
Unify MOD Portal release selection into a new `internal/resolver` package, giving every command a single definition of "latest": the Portal's `latest_release` when present, falling back to the highest version.

## Changes
- Add `internal/resolver` with `SelectLatest`, `SelectExact`, and `SelectCompatible`
- Replace the four ad-hoc cli helpers (`findRelease`, `findSyncRelease`, `findCompatibleRelease`, `latestByReleaseDate`) with resolver calls via a thin `selectRelease` adapter
- Remove stale `go-runewidth` entries from `go.sum` (left behind by #177)
- Include the design spec and implementation plan for the wider unification (epic #184)

## Before
`mod install`/`mod download`/`mod update` computed `@latest` as the newest release by date; `mod sync` used `latest_release` with a highest-version fallback.

## After
All commands use the unified rule. `mod sync` behavior is unchanged; since the `/full` endpoint never carries `latest_release`, the highest version is what applies in practice.

## Test Plan
- `mise run default` (test + e2e + vet + lint + fmt-check) passes
- New unit tests cover `latest_release` priority, highest-version fallback, exact match, and requirement-constrained selection

Closes #180
Related to #184
