### PR TITLE
:recycle: Unify dependency resolution into Resolver.Resolve

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -5,6 +5,10 @@
 - `mod install`, `mod download`, and `mod update` now resolve `@latest` as the Portal's `latest_release` (falling back to the highest version) instead of the newest release by date; release selection is unified across commands in the new `internal/resolver` package (#180)
 - `mod download --recursive` now resolves recommended dependencies as well (use `--ignore-recommended` to opt out), and dependency resolution across install/sync/download shares one engine that never queries the Portal for base/expansion MODs (#181)
 
+### Fixed
+
+- Dependency resolution (install/sync/download) now merges version requirements from every dependent before selecting a release for a shared transitive dependency, instead of only the last-processed requirement, which could silently select an incompatible version; an unsatisfiable combination is now skipped with a warning (#181)
+
 ## [0.22.0] - 2026-07-22
 
 ### Changed

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -3,6 +3,7 @@
 ### Changed
 
 - `mod install`, `mod download`, and `mod update` now resolve `@latest` as the Portal's `latest_release` (falling back to the highest version) instead of the newest release by date; release selection is unified across commands in the new `internal/resolver` package (#180)
+- `mod download --recursive` now resolves recommended dependencies as well (use `--ignore-recommended` to opt out), and dependency resolution across install/sync/download shares one engine that never queries the Portal for base/expansion MODs (#181)
 
 ## [0.22.0] - 2026-07-22
 

--- a/doc/factorix.1
+++ b/doc/factorix.1
@@ -262,7 +262,10 @@ Download directory (default: current directory).
 Number of parallel downloads (default: 4).
 .TP
 .BR \-r ", " \-\-recursive
-Include required dependencies recursively.
+Include dependencies recursively (required and recommended).
+.TP
+.B \-\-ignore\-recommended
+Do not resolve recommended dependencies.
 .SS factorix mod enable MOD_NAMES
 Enable MOD(s) in mod-list.json. Recursively enables dependencies.
 .TP

--- a/docs/superpowers/plans/2026-07-28-resolution-engine-unification.md
+++ b/docs/superpowers/plans/2026-07-28-resolution-engine-unification.md
@@ -1,0 +1,748 @@
+# Resolution Engine Unification Implementation Plan (PR2)
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Replace the two parallel dependency-resolution BFS implementations (`resolveInstallDependencies`, `resolveDownloadDependencies`) with a single graph-based engine, `Resolver.Resolve`, in `internal/resolver`. Closes #181.
+
+**Architecture:** `internal/resolver` gains a `Resolver` (Portal client + logger) with two entry points: `Fetch` (resolve explicit specs to releases, hard failure) and `Resolve` (Fetch + extend a `dependency.Graph` with transitive required/recommended dependencies, warn-and-skip). install and sync pass the installed-MOD graph; download passes a fresh empty graph (recursive) or calls `Fetch` (non-recursive). `cli.modSpec` moves to `resolver.Spec`.
+
+**Tech Stack:** Go, testify, `golang.org/x/sync/errgroup`, `mise run default` for verification.
+
+This is PR2 of the plan in
+`docs/superpowers/specs/2026-07-27-dependency-resolution-unification-design.md`.
+
+## Global Constraints
+
+- Commit messages: English, `:emoji:` prefix. No AI attribution, no trailers.
+- Code comments and doc comments: English. "MOD" is uppercase in exported identifiers and user-facing text.
+- Every task ends with `mise run test` green; the branch ends with `mise run default` green.
+- `internal/resolver` may depend on `internal/api`, `internal/dependency`, `internal/mod` (plus stdlib, errgroup, testify). `internal/dependency` must stay free of `api` imports.
+- Decided behavior changes (spec "Behavioral policy"): (1) `mod download --recursive` follows required + recommended dependencies by default and gains `--ignore-recommended`; (2) base/expansion MODs are never fetched from the Portal during dependency resolution (previously install/sync queried expansions and warned on 404, and download used a hardcoded `builtinMODs` list).
+- Explicitly requested MODs fail hard when unresolvable; transitively discovered dependencies are skipped with a warning.
+
+---
+
+### Task 1: `resolver.Spec` and `Resolver.Fetch`
+
+**Files:**
+- Create: `internal/resolver/spec.go`
+- Create: `internal/resolver/resolver.go`
+- Create: `internal/resolver/resolver_test.go`
+
+**Interfaces:**
+- Consumes: `SelectLatest`, `SelectExact` from `internal/resolver/select.go` (already on main); `api.MODInfo`, `api.Release`, `mod.MOD`, `mod.MODVersion`.
+- Produces (Tasks 2-3 rely on these exact shapes):
+  - `type Spec struct { MOD mod.MOD; Latest bool; Version mod.MODVersion }` with methods `Select(info *api.MODInfo) *api.Release` and `VersionLabel() string`
+  - `type Portal interface { GetMODFull(ctx context.Context, name string) (*api.MODInfo, error) }` (satisfied by `*api.MODPortalAPI`)
+  - `type Resolver struct { Portal Portal; Logger *slog.Logger }`
+  - `type Fetched struct { MOD mod.MOD; Info *api.MODInfo; Release api.Release }`
+  - `func (r *Resolver) Fetch(ctx context.Context, specs []Spec, jobs int) ([]Fetched, error)`
+  - unexported `concurrentFetch(ctx, jobs, specs, resolve)` used again in Task 2
+
+- [ ] **Step 1: Write the failing tests**
+
+Create `internal/resolver/resolver_test.go`:
+
+```go
+package resolver
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sakuro/factorix/internal/api"
+	"github.com/sakuro/factorix/internal/mod"
+)
+
+// fakePortal serves canned MODInfo responses and records which MOD names
+// were requested (concurrently, hence the mutex).
+type fakePortal struct {
+	mu        sync.Mutex
+	mods      map[string]*api.MODInfo
+	requested []string
+}
+
+func (f *fakePortal) GetMODFull(_ context.Context, name string) (*api.MODInfo, error) {
+	f.mu.Lock()
+	f.requested = append(f.requested, name)
+	f.mu.Unlock()
+	info, ok := f.mods[name]
+	if !ok {
+		return nil, fmt.Errorf("%w: %s", api.ErrMODNotOnPortal, name)
+	}
+	return info, nil
+}
+
+func (f *fakePortal) requestedNames() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.requested...)
+}
+
+// modInfo builds a MODInfo with one release per version string; the last
+// version listed carries the given dependency strings.
+func modInfo(t *testing.T, name string, deps []string, versions ...string) *api.MODInfo {
+	t.Helper()
+	info := &api.MODInfo{Name: name}
+	for i, vs := range versions {
+		v, err := mod.ParseMODVersion(vs)
+		require.NoError(t, err)
+		release := api.Release{Version: v, FileName: name + "_" + vs + ".zip"}
+		if i == len(versions)-1 {
+			release.InfoJSON.Dependencies = deps
+		}
+		info.Releases = append(info.Releases, release)
+	}
+	return info
+}
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func TestFetch(t *testing.T) {
+	portal := &fakePortal{mods: map[string]*api.MODInfo{
+		"alpha": modInfo(t, "alpha", nil, "1.0.0", "1.1.0"),
+		"beta":  modInfo(t, "beta", nil, "2.0.0"),
+	}}
+	r := &Resolver{Portal: portal, Logger: discardLogger()}
+
+	t.Run("resolves latest and exact specs", func(t *testing.T) {
+		fetched, err := r.Fetch(context.Background(), []Spec{
+			{MOD: mod.MOD{Name: "alpha"}, Latest: true},
+			{MOD: mod.MOD{Name: "beta"}, Version: mustVersion(t, "2.0.0")},
+		}, 2)
+		require.NoError(t, err)
+		require.Len(t, fetched, 2)
+		assert.Equal(t, "1.1.0", fetched[0].Release.Version.String())
+		assert.Equal(t, "2.0.0", fetched[1].Release.Version.String())
+		assert.NotNil(t, fetched[0].Info)
+	})
+
+	t.Run("unknown MOD fails the call", func(t *testing.T) {
+		_, err := r.Fetch(context.Background(), []Spec{{MOD: mod.MOD{Name: "ghost"}, Latest: true}}, 1)
+		require.Error(t, err)
+	})
+
+	t.Run("missing release fails with spec label", func(t *testing.T) {
+		_, err := r.Fetch(context.Background(), []Spec{{MOD: mod.MOD{Name: "beta"}, Version: mustVersion(t, "9.9.9")}}, 1)
+		require.ErrorContains(t, err, "beta@9.9.9")
+	})
+}
+
+func TestSpecVersionLabel(t *testing.T) {
+	assert.Equal(t, "latest", Spec{MOD: mod.MOD{Name: "a"}, Latest: true}.VersionLabel())
+	assert.Equal(t, "1.2.0", Spec{MOD: mod.MOD{Name: "a"}, Version: mustVersion(t, "1.2.0")}.VersionLabel())
+}
+```
+
+`mustVersion` already exists in `internal/resolver/select_test.go` (same package) — do not redefine it. `api.ErrMODNotOnPortal` exists in `internal/api`.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/resolver/`
+Expected: FAIL to build (`Spec`, `Resolver` undefined).
+
+- [ ] **Step 3: Implement `spec.go` and `resolver.go`**
+
+Create `internal/resolver/spec.go`:
+
+```go
+package resolver
+
+import (
+	"github.com/sakuro/factorix/internal/api"
+	"github.com/sakuro/factorix/internal/mod"
+)
+
+// Spec is a parsed MOD specification: a name plus either "latest" or an
+// exact version.
+type Spec struct {
+	MOD     mod.MOD
+	Latest  bool
+	Version mod.MODVersion // meaningless when Latest
+}
+
+// Select returns the release the spec designates, or nil when absent.
+func (s Spec) Select(info *api.MODInfo) *api.Release {
+	if s.Latest {
+		return SelectLatest(info)
+	}
+	return SelectExact(info, s.Version)
+}
+
+// VersionLabel renders the requested version for error messages.
+func (s Spec) VersionLabel() string {
+	if s.Latest {
+		return "latest"
+	}
+	return s.Version.String()
+}
+```
+
+Create `internal/resolver/resolver.go`:
+
+```go
+package resolver
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"golang.org/x/sync/errgroup"
+
+	"github.com/sakuro/factorix/internal/api"
+	"github.com/sakuro/factorix/internal/mod"
+)
+
+// Portal is the subset of the MOD Portal API the resolver needs. Only the
+// full endpoint is usable here: /full is the only response that carries
+// each release's dependencies.
+type Portal interface {
+	GetMODFull(ctx context.Context, name string) (*api.MODInfo, error)
+}
+
+// Resolver fetches MODs from the Portal and resolves their dependencies.
+type Resolver struct {
+	Portal Portal
+	Logger *slog.Logger
+}
+
+// Fetched pairs a requested MOD with its full info and selected release.
+type Fetched struct {
+	MOD     mod.MOD
+	Info    *api.MODInfo
+	Release api.Release
+}
+
+// Fetch resolves each spec to a release with up to jobs concurrent Portal
+// requests. Any spec that cannot be fetched or has no matching release
+// fails the whole call: these are MODs the user explicitly asked for.
+func (r *Resolver) Fetch(ctx context.Context, specs []Spec, jobs int) ([]Fetched, error) {
+	return concurrentFetch(ctx, jobs, specs, func(ctx context.Context, spec Spec) (Fetched, error) {
+		info, err := r.Portal.GetMODFull(ctx, spec.MOD.Name)
+		if err != nil {
+			return Fetched{}, err
+		}
+		release := spec.Select(info)
+		if release == nil {
+			return Fetched{}, fmt.Errorf("Release not found for %s@%s", spec.MOD.Name, spec.VersionLabel())
+		}
+		return Fetched{MOD: spec.MOD, Info: info, Release: *release}, nil
+	})
+}
+
+// concurrentFetch runs resolve for each spec, jobs at a time, preserving
+// input order in the results.
+func concurrentFetch(ctx context.Context, jobs int, specs []Spec, resolve func(context.Context, Spec) (Fetched, error)) ([]Fetched, error) {
+	results := make([]Fetched, len(specs))
+	group, ctx := errgroup.WithContext(ctx)
+	group.SetLimit(jobs)
+	for i, spec := range specs {
+		group.Go(func() error {
+			result, err := resolve(ctx, spec)
+			if err != nil {
+				return err
+			}
+			results[i] = result
+			return nil
+		})
+	}
+	if err := group.Wait(); err != nil {
+		return nil, err
+	}
+	return results, nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/resolver/`
+Expected: PASS. Also run `go vet ./internal/resolver/` and `mise run lint`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/resolver
+git commit -m ":sparkles: Add resolver.Spec and Resolver.Fetch"
+```
+
+---
+
+### Task 2: `Resolver.Resolve` — the unified dependency engine
+
+**Files:**
+- Modify: `internal/resolver/resolver.go` (append `Options`, `Resolve`, `resolveDependencies`, `missingDependency`)
+- Modify: `internal/resolver/resolver_test.go` (append `TestResolve`)
+
+**Interfaces:**
+- Consumes: `Spec`, `Fetched`, `Resolver`, `concurrentFetch` from Task 1; `SelectCompatible` from select.go; `dependency.Graph` methods `AddUninstalledMOD`, `EdgesFrom`, `Contains`, `Node`; `dependency.TypeRequired`, `TypeRecommended`; `mod.MOD.IsBase/IsExpansion`.
+- Produces (Task 3 relies on):
+  - `type Options struct { Jobs int; FollowRecommended bool }`
+  - `func (r *Resolver) Resolve(ctx context.Context, graph *dependency.Graph, specs []Spec, opts Options) (map[mod.MOD]api.Release, error)`
+  - Contract: the returned map holds the selected release for **every spec** (even ones whose node already existed in the graph) and for every transitive dependency the call added; skipped dependencies and pre-existing graph nodes reached as dependencies are absent.
+
+- [ ] **Step 1: Write the failing tests**
+
+Append to `internal/resolver/resolver_test.go`:
+
+```go
+func TestResolve(t *testing.T) {
+	newResolver := func(mods map[string]*api.MODInfo) (*Resolver, *fakePortal) {
+		portal := &fakePortal{mods: mods}
+		return &Resolver{Portal: portal, Logger: discardLogger()}, portal
+	}
+	latestSpec := func(name string) Spec {
+		return Spec{MOD: mod.MOD{Name: name}, Latest: true}
+	}
+
+	t.Run("resolves required chain recursively", func(t *testing.T) {
+		r, _ := newResolver(map[string]*api.MODInfo{
+			"app": modInfo(t, "app", []string{"lib"}, "1.0.0"),
+			"lib": modInfo(t, "lib", []string{"core"}, "1.0.0"),
+			"core": modInfo(t, "core", nil, "1.0.0"),
+		})
+		graph := dependency.NewGraph()
+		releases, err := r.Resolve(context.Background(), graph, []Spec{latestSpec("app")}, Options{Jobs: 2})
+		require.NoError(t, err)
+		assert.Len(t, releases, 3)
+		assert.True(t, graph.Contains(mod.MOD{Name: "core"}))
+	})
+
+	t.Run("follows recommended only when enabled", func(t *testing.T) {
+		mods := map[string]*api.MODInfo{
+			"app":   modInfo(t, "app", []string{"+ extra"}, "1.0.0"),
+			"extra": modInfo(t, "extra", nil, "1.0.0"),
+		}
+		r, _ := newResolver(mods)
+		releases, err := r.Resolve(context.Background(), dependency.NewGraph(), []Spec{latestSpec("app")}, Options{Jobs: 2, FollowRecommended: true})
+		require.NoError(t, err)
+		assert.Contains(t, releases, mod.MOD{Name: "extra"})
+
+		r2, portal2 := newResolver(mods)
+		releases, err = r2.Resolve(context.Background(), dependency.NewGraph(), []Spec{latestSpec("app")}, Options{Jobs: 2})
+		require.NoError(t, err)
+		assert.NotContains(t, releases, mod.MOD{Name: "extra"})
+		assert.NotContains(t, portal2.requestedNames(), "extra")
+	})
+
+	t.Run("honors dependency version requirements", func(t *testing.T) {
+		r, _ := newResolver(map[string]*api.MODInfo{
+			"app": modInfo(t, "app", []string{"lib <= 1.5.0"}, "1.0.0"),
+			"lib": modInfo(t, "lib", nil, "1.0.0", "2.0.0"),
+		})
+		releases, err := r.Resolve(context.Background(), dependency.NewGraph(), []Spec{latestSpec("app")}, Options{Jobs: 2})
+		require.NoError(t, err)
+		assert.Equal(t, "1.0.0", releases[mod.MOD{Name: "lib"}].Version.String())
+	})
+
+	t.Run("never fetches base or expansion dependencies", func(t *testing.T) {
+		r, portal := newResolver(map[string]*api.MODInfo{
+			"app": modInfo(t, "app", []string{"base >= 2.0.0", "quality", "space-age"}, "1.0.0"),
+		})
+		releases, err := r.Resolve(context.Background(), dependency.NewGraph(), []Spec{latestSpec("app")}, Options{Jobs: 2})
+		require.NoError(t, err)
+		assert.Len(t, releases, 1)
+		assert.Equal(t, []string{"app"}, portal.requestedNames())
+	})
+
+	t.Run("skips dependencies already in the graph", func(t *testing.T) {
+		r, portal := newResolver(map[string]*api.MODInfo{
+			"app": modInfo(t, "app", []string{"lib"}, "1.0.0"),
+		})
+		graph := dependency.NewGraph()
+		require.NoError(t, graph.AddNode(dependency.Node{MOD: mod.MOD{Name: "lib"}, Version: mustVersion(t, "1.0.0"), Enabled: true, Installed: true}))
+		releases, err := r.Resolve(context.Background(), graph, []Spec{latestSpec("app")}, Options{Jobs: 2})
+		require.NoError(t, err)
+		assert.NotContains(t, releases, mod.MOD{Name: "lib"})
+		assert.NotContains(t, portal.requestedNames(), "lib")
+	})
+
+	t.Run("marks installed-but-disabled spec for enable and still returns its release", func(t *testing.T) {
+		r, _ := newResolver(map[string]*api.MODInfo{
+			"app": modInfo(t, "app", nil, "1.0.0"),
+		})
+		graph := dependency.NewGraph()
+		require.NoError(t, graph.AddNode(dependency.Node{MOD: mod.MOD{Name: "app"}, Version: mustVersion(t, "1.0.0"), Installed: true}))
+		releases, err := r.Resolve(context.Background(), graph, []Spec{latestSpec("app")}, Options{Jobs: 2})
+		require.NoError(t, err)
+		assert.Contains(t, releases, mod.MOD{Name: "app"})
+		node, ok := graph.Node(mod.MOD{Name: "app"})
+		require.True(t, ok)
+		assert.Equal(t, dependency.OpEnable, node.Operation)
+	})
+
+	t.Run("skips unfetchable transitive dependency with warning", func(t *testing.T) {
+		r, _ := newResolver(map[string]*api.MODInfo{
+			"app": modInfo(t, "app", []string{"gone"}, "1.0.0"),
+		})
+		graph := dependency.NewGraph()
+		releases, err := r.Resolve(context.Background(), graph, []Spec{latestSpec("app")}, Options{Jobs: 2})
+		require.NoError(t, err)
+		assert.NotContains(t, releases, mod.MOD{Name: "gone"})
+		assert.False(t, graph.Contains(mod.MOD{Name: "gone"}))
+	})
+
+	t.Run("skips transitive dependency with no compatible release", func(t *testing.T) {
+		r, _ := newResolver(map[string]*api.MODInfo{
+			"app": modInfo(t, "app", []string{"lib >= 9.0.0"}, "1.0.0"),
+			"lib": modInfo(t, "lib", nil, "1.0.0"),
+		})
+		releases, err := r.Resolve(context.Background(), dependency.NewGraph(), []Spec{latestSpec("app")}, Options{Jobs: 2})
+		require.NoError(t, err)
+		assert.NotContains(t, releases, mod.MOD{Name: "lib"})
+	})
+}
+```
+
+Add `"github.com/sakuro/factorix/internal/dependency"` to the test file imports.
+
+- [ ] **Step 2: Run tests to verify they fail**
+
+Run: `go test ./internal/resolver/`
+Expected: FAIL to build (`Options`, `Resolve` undefined).
+
+- [ ] **Step 3: Implement `Resolve`**
+
+Append to `internal/resolver/resolver.go` (add `"github.com/sakuro/factorix/internal/dependency"` to imports):
+
+```go
+// Options tunes Resolve.
+type Options struct {
+	Jobs              int  // concurrent Portal requests
+	FollowRecommended bool // also follow recommended dependency edges
+}
+
+// Resolve fetches each spec from the Portal, adds it to graph (via
+// AddUninstalledMOD), then walks required (and, per opts, recommended)
+// edges breadth-first, fetching MODs not yet in the graph and extending it
+// until the frontier is empty. It returns the selected release for every
+// spec and every dependency it added. Explicitly requested specs fail
+// hard; a transitive dependency that cannot be fetched or has no release
+// satisfying its version requirement is skipped with a warning. Base and
+// expansion MODs are never fetched.
+func (r *Resolver) Resolve(ctx context.Context, graph *dependency.Graph, specs []Spec, opts Options) (map[mod.MOD]api.Release, error) {
+	initial, err := r.Fetch(ctx, specs, opts.Jobs)
+	if err != nil {
+		return nil, err
+	}
+
+	releases := make(map[mod.MOD]api.Release, len(initial))
+	frontier := make([]mod.MOD, 0, len(initial))
+	for _, f := range initial {
+		if err := graph.AddUninstalledMOD(f.MOD, f.Release.Version, f.Release.InfoJSON.Dependencies); err != nil {
+			return nil, err
+		}
+		releases[f.MOD] = f.Release
+		frontier = append(frontier, f.MOD)
+	}
+
+	if err := r.resolveDependencies(ctx, graph, releases, frontier, opts); err != nil {
+		return nil, err
+	}
+	return releases, nil
+}
+
+// missingDependency is a dependency edge pointing at a MOD not yet in the
+// graph, remembered with its requirement and dependent for fetching.
+type missingDependency struct {
+	mod         mod.MOD
+	requirement *dependency.VersionRequirement
+	requiredBy  mod.MOD
+}
+
+func (r *Resolver) resolveDependencies(ctx context.Context, graph *dependency.Graph, releases map[mod.MOD]api.Release, frontier []mod.MOD, opts Options) error {
+	processed := map[mod.MOD]bool{}
+	for len(frontier) > 0 {
+		var missing []missingDependency
+		for _, m := range frontier {
+			if processed[m] {
+				continue
+			}
+			processed[m] = true
+			for _, edge := range graph.EdgesFrom(m) {
+				relevant := edge.Type == dependency.TypeRequired || (opts.FollowRecommended && edge.Type == dependency.TypeRecommended)
+				if !relevant {
+					continue
+				}
+				// The base MOD and the official expansions are not on the
+				// Portal; they are installed with the game, never fetched.
+				if edge.To.IsBase() || edge.To.IsExpansion() {
+					continue
+				}
+				if graph.Contains(edge.To) {
+					continue
+				}
+				missing = append(missing, missingDependency{mod: edge.To, requirement: edge.Requirement, requiredBy: m})
+			}
+		}
+		frontier = nil
+		if len(missing) == 0 {
+			continue
+		}
+
+		specs := make([]Spec, len(missing))
+		for i, dep := range missing {
+			specs[i] = Spec{MOD: dep.mod, Latest: true}
+		}
+		results, err := concurrentFetch(ctx, opts.Jobs, specs, func(ctx context.Context, spec Spec) (Fetched, error) {
+			var requirement *dependency.VersionRequirement
+			var requiredBy mod.MOD
+			for _, dep := range missing {
+				if dep.mod == spec.MOD {
+					requirement = dep.requirement
+					requiredBy = dep.requiredBy
+					break
+				}
+			}
+			info, err := r.Portal.GetMODFull(ctx, spec.MOD.Name)
+			if err != nil {
+				r.Logger.Warn("Skipping dependency", "mod", spec.MOD.Name, "required_by", requiredBy.Name, "reason", err)
+				return Fetched{}, nil
+			}
+			release := SelectCompatible(info, requirement)
+			if release == nil {
+				r.Logger.Warn("Skipping dependency", "mod", spec.MOD.Name, "required_by", requiredBy.Name, "reason", "no compatible release found")
+				return Fetched{}, nil
+			}
+			return Fetched{MOD: spec.MOD, Info: info, Release: *release}, nil
+		})
+		if err != nil {
+			return err
+		}
+
+		for _, f := range results {
+			if f.Info == nil {
+				continue // skipped above with a warning
+			}
+			if err := graph.AddUninstalledMOD(f.MOD, f.Release.Version, f.Release.InfoJSON.Dependencies); err != nil {
+				return err
+			}
+			releases[f.MOD] = f.Release
+			frontier = append(frontier, f.MOD)
+		}
+	}
+	return nil
+}
+```
+
+- [ ] **Step 4: Run tests to verify they pass**
+
+Run: `go test ./internal/resolver/`
+Expected: PASS. Also `go vet ./internal/resolver/` and `mise run lint`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add internal/resolver
+git commit -m ":sparkles: Add Resolver.Resolve dependency engine"
+```
+
+---
+
+### Task 3: Migrate install, sync, and download; delete the legacy resolvers
+
+**Files:**
+- Modify: `internal/cli/download_support.go` (delete `modSpec`, `fetchedMODInfo`, `fetchMODInfoConcurrently`, `selectRelease`; rework `parseMODSpec`, `buildDownloadTargets`; add `releaseDownloadTargets`; drop `downloadTarget.MODInfo`)
+- Modify: `internal/cli/mod_install.go` (Resolve call; delete `resolveInstallDependencies`)
+- Modify: `internal/cli/mod_sync.go` (Resolve call; fold target building)
+- Modify: `internal/cli/mod_download.go` (Fetch/Resolve; delete `resolveDownloadDependencies`, `collectNewDependencies`, `requiredDependency`, `warnAndSkip`, `specVersionLabel`, `builtinMODs`; add `--ignore-recommended`)
+- Modify: `internal/cli/download_support_test.go`, other cli tests as reconciliation requires
+- Modify: `CHANGELOG.md`
+
+**Interfaces:**
+- Consumes: `resolver.Spec` (fields `MOD`, `Latest`, `Version`), `resolver.Resolver{Portal, Logger}`, `resolver.Options{Jobs, FollowRecommended}`, `Resolver.Fetch(ctx, specs, jobs) ([]resolver.Fetched, error)`, `Resolver.Resolve(ctx, graph, specs, opts) (map[mod.MOD]api.Release, error)`, `resolver.Fetched{MOD, Info, Release}`.
+- Produces: `parseMODSpec(spec string) (resolver.Spec, error)`; `buildDownloadTargets(fetched []resolver.Fetched, outputDir string) ([]downloadTarget, error)`; `releaseDownloadTargets(releases map[mod.MOD]api.Release, outputDir string) ([]downloadTarget, error)`.
+
+- [ ] **Step 1: Rework `download_support.go`**
+
+Delete `modSpec`, `selectRelease`, `fetchedMODInfo`, and `fetchMODInfoConcurrently`. Change `parseMODSpec` to return `resolver.Spec` (same parsing logic, construct `resolver.Spec{...}`). Remove the `MODInfo` field from `downloadTarget` (it is written but never read). Replace `buildDownloadTargets` and add `releaseDownloadTargets`:
+
+```go
+func buildDownloadTargets(fetched []resolver.Fetched, outputDir string) ([]downloadTarget, error) {
+	targets := make([]downloadTarget, 0, len(fetched))
+	for _, f := range fetched {
+		if err := validateFilename(f.Release.FileName); err != nil {
+			return nil, err
+		}
+		targets = append(targets, downloadTarget{
+			MOD:        f.MOD,
+			Release:    f.Release,
+			OutputPath: filepath.Join(outputDir, f.Release.FileName),
+		})
+	}
+	return targets, nil
+}
+
+// releaseDownloadTargets converts a Resolve result into download targets
+// (order follows map iteration; downloads run concurrently anyway).
+func releaseDownloadTargets(releases map[mod.MOD]api.Release, outputDir string) ([]downloadTarget, error) {
+	targets := make([]downloadTarget, 0, len(releases))
+	for m, release := range releases {
+		if err := validateFilename(release.FileName); err != nil {
+			return nil, err
+		}
+		targets = append(targets, downloadTarget{
+			MOD:        m,
+			Release:    release,
+			OutputPath: filepath.Join(outputDir, release.FileName),
+		})
+	}
+	return targets, nil
+}
+```
+
+- [ ] **Step 2: Migrate `mod_install.go`**
+
+Replace the body of `planInstall` between the `PortalAPI()` call and the `MarkDisabledDependenciesForEnable` line with a single Resolve call, and delete `resolveInstallDependencies`:
+
+```go
+func planInstall(ctx context.Context, application *app.App, graph *dependency.Graph, specs []resolver.Spec, jobs int, includeRecommended bool) ([]installTarget, error) {
+	portalAPI, err := application.PortalAPI()
+	if err != nil {
+		return nil, err
+	}
+	res := &resolver.Resolver{Portal: portalAPI, Logger: application.Logger}
+	releases, err := res.Resolve(ctx, graph, specs, resolver.Options{Jobs: jobs, FollowRecommended: includeRecommended})
+	if err != nil {
+		return nil, err
+	}
+
+	dependency.MarkDisabledDependenciesForEnable(graph, includeRecommended)
+	if err := dependency.ValidateInstallGraph(graph); err != nil {
+		return nil, err
+	}
+	// ... the existing targets loop over graph.Nodes() stays unchanged ...
+}
+```
+
+The RunE closure's `specs` slice becomes `[]resolver.Spec` (the `parseMODSpec` result type change propagates).
+
+- [ ] **Step 3: Migrate `mod_sync.go`**
+
+In `planSyncInstallation`, replace the fetch + AddUninstalledMOD loop + `resolveInstallDependencies` call + two-stage target building with:
+
+```go
+	specs := make([]resolver.Spec, len(entries))
+	for i, entry := range entries {
+		specs[i] = resolver.Spec{MOD: mod.MOD{Name: entry.Name}, Latest: !strict, Version: entry.Version}
+	}
+	res := &resolver.Resolver{Portal: portal, Logger: application.Logger}
+	releases, err := res.Resolve(ctx, graph, specs, resolver.Options{Jobs: jobs, FollowRecommended: includeRecommended})
+	if err != nil {
+		return nil, nil, err
+	}
+
+	requested := make(map[mod.MOD]bool, len(specs))
+	for _, spec := range specs {
+		requested[spec.MOD] = true
+	}
+	// Dependency-resolved MODs aren't in entries/saveMODs, so the caller
+	// needs their names and versions to fold them into the save-driven
+	// mod-list.json planning (see the RunE closure above).
+	var dependencyEntries []save.MODEntry
+	targets, err := releaseDownloadTargets(releases, modDir)
+	if err != nil {
+		return nil, nil, err
+	}
+	for m, release := range releases {
+		if !requested[m] {
+			dependencyEntries = append(dependencyEntries, save.MODEntry{Name: m.Name, Version: release.Version})
+		}
+	}
+
+	result := make([]syncInstallTarget, len(targets))
+	for i, target := range targets {
+		result[i] = syncInstallTarget{downloadTarget: target}
+	}
+	return result, dependencyEntries, nil
+```
+
+Delete the now-stale comment about `Version` staying set "so error messages can name the save-file version" — the unified Fetch error labels latest-mode specs as `@latest`. This message change is accepted (unification of an incidental difference).
+
+- [ ] **Step 4: Migrate `mod_download.go`**
+
+Add the flag variable `ignoreRecommended` alongside `recursive`, register it, and update the `-r` help text:
+
+```go
+	cmd.Flags().BoolVarP(&recursive, "recursive", "r", false, "Include dependencies recursively (required and recommended)")
+	cmd.Flags().BoolVar(&ignoreRecommended, "ignore-recommended", false, "Do not resolve recommended dependencies")
+```
+
+Replace `planDownload` and delete `resolveDownloadDependencies`, `collectNewDependencies`, `requiredDependency`, `warnAndSkip`, `specVersionLabel`, and the `builtinMODs` variable:
+
+```go
+func planDownload(ctx context.Context, application *app.App, specs []resolver.Spec, downloadDir string, jobs int, recursive, includeRecommended bool) ([]downloadTarget, error) {
+	portalAPI, err := application.PortalAPI()
+	if err != nil {
+		return nil, err
+	}
+	res := &resolver.Resolver{Portal: portalAPI, Logger: application.Logger}
+
+	if !recursive {
+		fetched, err := res.Fetch(ctx, specs, jobs)
+		if err != nil {
+			return nil, err
+		}
+		return buildDownloadTargets(fetched, downloadDir)
+	}
+
+	// Installation state is irrelevant to a plain download, so resolution
+	// runs against an empty graph: every dependency counts as missing.
+	releases, err := res.Resolve(ctx, dependency.NewGraph(), specs, resolver.Options{Jobs: jobs, FollowRecommended: includeRecommended})
+	if err != nil {
+		return nil, err
+	}
+	return releaseDownloadTargets(releases, downloadDir)
+}
+```
+
+The RunE closure passes `!ignoreRecommended` as the new argument. Remove imports that become unused (`errors`, `maps`, `slices`, `dependency` stays for `NewGraph`).
+
+- [ ] **Step 5: Reconcile tests**
+
+Run: `go build ./... && go test ./internal/cli/ ./internal/resolver/`
+
+Expected mechanical updates:
+- `download_support_test.go`: `TestParseMODSpec` expectations become `resolver.Spec{...}`; `TestCollectNewDependencies` is deleted (behavior now covered by `TestResolve`); `TestBuildDownloadTargets` switches to `[]resolver.Fetched`.
+- Other failures are legitimate only if they map to one of the three decided changes: (a) download `--recursive` now also resolves recommended dependencies, (b) expansion/base dependencies are no longer requested from the mock Portal (fixtures asserting those requests or warnings change), (c) "Release not found" errors for latest-mode sync specs now say `@latest` instead of the save version. Anything else is a regression — fix the code, not the test. Document each expectation change and its category in the report.
+
+- [ ] **Step 6: CHANGELOG entry**
+
+Add under `[Unreleased]` → `### Changed` (create the subsection if the previous release consumed it; keep the existing entry style, one bullet, trailing issue reference):
+
+```markdown
+- `mod download --recursive` now resolves recommended dependencies as well (use `--ignore-recommended` to opt out), and dependency resolution across install/sync/download shares one engine that never queries the Portal for base/expansion MODs (#181)
+```
+
+Also check `grep -rn "recursive" README.md doc/` — update any prose describing `mod download -r` as "required dependencies only".
+
+- [ ] **Step 7: Run the full check suite**
+
+Run: `mise run default`
+Expected: PASS.
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add -A
+git commit -m ":recycle: Unify dependency resolution on Resolver.Resolve"
+```
+
+---
+
+### Task 4: Pull request
+
+- [ ] **Step 1: Push and open the PR**
+
+Push the branch and create the PR with the `create-pr` skill. Title: `:recycle: Unify dependency resolution into Resolver.Resolve`. Body includes: summary (one engine, graph-based, replaces two BFS implementations), the three behavior changes from Task 3 Step 5, `Closes #181`, `Related to #184`. No AI attribution.
+
+- [ ] **Step 2: Verify CI is green and report the PR URL**

--- a/internal/cli/download_support.go
+++ b/internal/cli/download_support.go
@@ -19,40 +19,23 @@ import (
 
 var errInvalidFilename = errors.New("invalid filename")
 
-// modSpec is a parsed "name", "name@version", or "name@latest" argument.
-type modSpec struct {
-	MOD     mod.MOD
-	Latest  bool
-	Version mod.MODVersion // meaningless when Latest
-}
-
 // parseMODSpec parses a MOD specification. "latest" and the bare name both
 // mean the latest release.
-func parseMODSpec(spec string) (modSpec, error) {
+func parseMODSpec(spec string) (resolver.Spec, error) {
 	name, versionStr, hasVersion := strings.Cut(spec, "@")
 	if !hasVersion || versionStr == "" || versionStr == "latest" {
-		return modSpec{MOD: mod.MOD{Name: name}, Latest: true}, nil
+		return resolver.Spec{MOD: mod.MOD{Name: name}, Latest: true}, nil
 	}
 	version, err := mod.ParseMODVersion(versionStr)
 	if err != nil {
-		return modSpec{}, err
+		return resolver.Spec{}, err
 	}
-	return modSpec{MOD: mod.MOD{Name: name}, Version: version}, nil
-}
-
-// selectRelease resolves a modSpec to a release: the unified latest rule
-// (resolver.SelectLatest) for "latest" specs, the exact version otherwise.
-func selectRelease(info *api.MODInfo, spec modSpec) *api.Release {
-	if spec.Latest {
-		return resolver.SelectLatest(info)
-	}
-	return resolver.SelectExact(info, spec.Version)
+	return resolver.Spec{MOD: mod.MOD{Name: name}, Version: version}, nil
 }
 
 // downloadTarget is a MOD release resolved to a local output path.
 type downloadTarget struct {
 	MOD        mod.MOD
-	MODInfo    *api.MODInfo
 	Release    api.Release
 	OutputPath string
 }
@@ -73,50 +56,36 @@ func validateFilename(filename string) error {
 	return nil
 }
 
-func buildDownloadTargets(infos []fetchedMODInfo, outputDir string) ([]downloadTarget, error) {
-	targets := make([]downloadTarget, 0, len(infos))
-	for _, info := range infos {
-		if err := validateFilename(info.Release.FileName); err != nil {
+func buildDownloadTargets(fetched []resolver.Fetched, outputDir string) ([]downloadTarget, error) {
+	targets := make([]downloadTarget, 0, len(fetched))
+	for _, f := range fetched {
+		if err := validateFilename(f.Release.FileName); err != nil {
 			return nil, err
 		}
 		targets = append(targets, downloadTarget{
-			MOD:        info.MOD,
-			MODInfo:    info.MODInfo,
-			Release:    info.Release,
-			OutputPath: filepath.Join(outputDir, info.Release.FileName),
+			MOD:        f.MOD,
+			Release:    f.Release,
+			OutputPath: filepath.Join(outputDir, f.Release.FileName),
 		})
 	}
 	return targets, nil
 }
 
-// fetchedMODInfo pairs a resolved release with its MOD and full info,
-// carried through target-building and (for downloads) dependency resolution.
-type fetchedMODInfo struct {
-	MOD     mod.MOD
-	MODInfo *api.MODInfo
-	Release api.Release
-}
-
-// fetchMODInfoConcurrently resolves each spec to a release via resolve, run
-// with up to jobs concurrent Portal requests.
-func fetchMODInfoConcurrently(ctx context.Context, jobs int, specs []modSpec, resolve func(context.Context, modSpec) (fetchedMODInfo, error)) ([]fetchedMODInfo, error) {
-	results := make([]fetchedMODInfo, len(specs))
-	group, ctx := errgroup.WithContext(ctx)
-	group.SetLimit(jobs)
-	for i, spec := range specs {
-		group.Go(func() error {
-			result, err := resolve(ctx, spec)
-			if err != nil {
-				return err
-			}
-			results[i] = result
-			return nil
+// releaseDownloadTargets converts a Resolve result into download targets
+// (order follows map iteration; downloads run concurrently anyway).
+func releaseDownloadTargets(releases map[mod.MOD]api.Release, outputDir string) ([]downloadTarget, error) {
+	targets := make([]downloadTarget, 0, len(releases))
+	for m, release := range releases {
+		if err := validateFilename(release.FileName); err != nil {
+			return nil, err
+		}
+		targets = append(targets, downloadTarget{
+			MOD:        m,
+			Release:    release,
+			OutputPath: filepath.Join(outputDir, release.FileName),
 		})
 	}
-	if err := group.Wait(); err != nil {
-		return nil, err
-	}
-	return results, nil
+	return targets, nil
 }
 
 // downloadTargets downloads each target to its OutputPath, up to jobs

--- a/internal/cli/download_support_test.go
+++ b/internal/cli/download_support_test.go
@@ -7,8 +7,8 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/sakuro/factorix/internal/api"
-	"github.com/sakuro/factorix/internal/dependency"
 	"github.com/sakuro/factorix/internal/mod"
+	"github.com/sakuro/factorix/internal/resolver"
 )
 
 func release(version string) api.Release {
@@ -22,12 +22,12 @@ func release(version string) api.Release {
 func TestParseMODSpec(t *testing.T) {
 	tests := []struct {
 		input string
-		want  modSpec
+		want  resolver.Spec
 	}{
-		{"some-mod", modSpec{MOD: mod.MOD{Name: "some-mod"}, Latest: true}},
-		{"some-mod@latest", modSpec{MOD: mod.MOD{Name: "some-mod"}, Latest: true}},
-		{"some-mod@", modSpec{MOD: mod.MOD{Name: "some-mod"}, Latest: true}},
-		{"some-mod@1.2.0", modSpec{MOD: mod.MOD{Name: "some-mod"}, Version: mod.MODVersion{Major: 1, Minor: 2}}},
+		{"some-mod", resolver.Spec{MOD: mod.MOD{Name: "some-mod"}, Latest: true}},
+		{"some-mod@latest", resolver.Spec{MOD: mod.MOD{Name: "some-mod"}, Latest: true}},
+		{"some-mod@", resolver.Spec{MOD: mod.MOD{Name: "some-mod"}, Latest: true}},
+		{"some-mod@1.2.0", resolver.Spec{MOD: mod.MOD{Name: "some-mod"}, Version: mod.MODVersion{Major: 1, Minor: 2}}},
 	}
 	for _, tt := range tests {
 		t.Run(tt.input, func(t *testing.T) {
@@ -50,34 +50,15 @@ func TestValidateFilename(t *testing.T) {
 }
 
 func TestBuildDownloadTargets(t *testing.T) {
-	infos := []fetchedMODInfo{
-		{MOD: mod.MOD{Name: "some-mod"}, MODInfo: &api.MODInfo{Name: "some-mod"}, Release: release("1.0.0")},
+	fetched := []resolver.Fetched{
+		{MOD: mod.MOD{Name: "some-mod"}, Info: &api.MODInfo{Name: "some-mod"}, Release: release("1.0.0")},
 	}
-	targets, err := buildDownloadTargets(infos, "/tmp/downloads")
+	targets, err := buildDownloadTargets(fetched, "/tmp/downloads")
 	require.NoError(t, err)
 	require.Len(t, targets, 1)
 	assert.Equal(t, "/tmp/downloads/test-mod_1.0.0.zip", targets[0].OutputPath)
 
-	infos[0].Release.FileName = "../escape.zip"
-	_, err = buildDownloadTargets(infos, "/tmp/downloads")
+	fetched[0].Release.FileName = "../escape.zip"
+	_, err = buildDownloadTargets(fetched, "/tmp/downloads")
 	require.ErrorIs(t, err, errInvalidFilename)
-}
-
-func TestCollectNewDependencies(t *testing.T) {
-	known := map[string]fetchedMODInfo{
-		"app": {
-			MOD: mod.MOD{Name: "app"},
-			Release: api.Release{InfoJSON: api.ReleaseInfoJSON{
-				Dependencies: []string{"base", "lib >= 1.0", "? optional-lib", "elevated-rails"},
-			}},
-		},
-	}
-	deps := collectNewDependencies([]string{"app"}, known, map[string]bool{})
-	require.Len(t, deps, 1)
-	assert.Equal(t, "lib", deps[0].name)
-	require.NotNil(t, deps[0].requirement)
-	assert.Equal(t, dependency.OpGreaterEqual, deps[0].requirement.Operator)
-
-	// Already-processed names yield nothing on a second pass.
-	assert.Empty(t, collectNewDependencies([]string{"app"}, known, map[string]bool{"app": true}))
 }

--- a/internal/cli/mod_download.go
+++ b/internal/cli/mod_download.go
@@ -2,27 +2,21 @@ package cli
 
 import (
 	"context"
-	"errors"
 	"fmt"
-	"maps"
 	"os"
 	"path/filepath"
-	"slices"
 
 	"github.com/spf13/cobra"
 
 	"github.com/sakuro/factorix/internal/app"
 	"github.com/sakuro/factorix/internal/dependency"
-	"github.com/sakuro/factorix/internal/mod"
 	"github.com/sakuro/factorix/internal/resolver"
 )
-
-var builtinMODs = []string{"base", "elevated-rails", "quality", "recycler", "space-age"}
 
 func newMODDownloadCommand(c *cli) *cobra.Command {
 	var directory string
 	var jobs int
-	var recursive bool
+	var recursive, ignoreRecommended bool
 
 	cmd := &cobra.Command{
 		Use:   "download <mod-spec>...",
@@ -49,7 +43,7 @@ func newMODDownloadCommand(c *cli) *cobra.Command {
 				return fmt.Errorf("Cannot download to MOD directory. Use 'mod install' instead.")
 			}
 
-			specs := make([]modSpec, len(args))
+			specs := make([]resolver.Spec, len(args))
 			for i, arg := range args {
 				spec, err := parseMODSpec(arg)
 				if err != nil {
@@ -58,7 +52,7 @@ func newMODDownloadCommand(c *cli) *cobra.Command {
 				specs[i] = spec
 			}
 
-			targets, err := planDownload(cmd.Context(), application, specs, downloadDir, jobs, recursive)
+			targets, err := planDownload(cmd.Context(), application, specs, downloadDir, jobs, recursive, !ignoreRecommended)
 			if err != nil {
 				return err
 			}
@@ -78,7 +72,8 @@ func newMODDownloadCommand(c *cli) *cobra.Command {
 	}
 	cmd.Flags().StringVarP(&directory, "directory", "d", ".", "Download directory")
 	cmd.Flags().IntVarP(&jobs, "jobs", "j", 4, "Number of parallel downloads")
-	cmd.Flags().BoolVarP(&recursive, "recursive", "r", false, "Include required dependencies recursively")
+	cmd.Flags().BoolVarP(&recursive, "recursive", "r", false, "Include dependencies recursively (required and recommended)")
+	cmd.Flags().BoolVar(&ignoreRecommended, "ignore-recommended", false, "Do not resolve recommended dependencies")
 	return cmd
 }
 
@@ -104,144 +99,26 @@ func sameDirAsMODDir(application *app.App, dir string) (bool, error) {
 	return realDownloadDir == realMODDir, nil
 }
 
-func planDownload(ctx context.Context, application *app.App, specs []modSpec, downloadDir string, jobs int, recursive bool) ([]downloadTarget, error) {
+func planDownload(ctx context.Context, application *app.App, specs []resolver.Spec, downloadDir string, jobs int, recursive, includeRecommended bool) ([]downloadTarget, error) {
 	portalAPI, err := application.PortalAPI()
 	if err != nil {
 		return nil, err
 	}
+	res := &resolver.Resolver{Portal: portalAPI, Logger: application.Logger}
 
-	// The full endpoint is required here: only /full includes each
-	// release's dependencies in info_json, and recursive resolution reads
-	// them (with the short endpoint they silently come back empty).
-	initial, err := fetchMODInfoConcurrently(ctx, jobs, specs, func(ctx context.Context, spec modSpec) (fetchedMODInfo, error) {
-		info, err := portalAPI.GetMODFull(ctx, spec.MOD.Name)
-		if err != nil {
-			return fetchedMODInfo{}, err
-		}
-		release := selectRelease(info, spec)
-		if release == nil {
-			return fetchedMODInfo{}, fmt.Errorf("Release not found for %s@%s", spec.MOD.Name, specVersionLabel(spec))
-		}
-		return fetchedMODInfo{MOD: spec.MOD, MODInfo: info, Release: *release}, nil
-	})
-	if err != nil {
-		return nil, err
-	}
-
-	all := initial
-	if recursive {
-		all, err = resolveDownloadDependencies(ctx, application, initial, jobs)
+	if !recursive {
+		fetched, err := res.Fetch(ctx, specs, jobs)
 		if err != nil {
 			return nil, err
 		}
+		return buildDownloadTargets(fetched, downloadDir)
 	}
-	return buildDownloadTargets(all, downloadDir)
-}
 
-func specVersionLabel(spec modSpec) string {
-	if spec.Latest {
-		return "latest"
-	}
-	return spec.Version.String()
-}
-
-type requiredDependency struct {
-	name        string
-	requirement *dependency.VersionRequirement
-}
-
-// resolveDownloadDependencies expands the initial fetch set with required
-// dependencies (recursively), skipping builtin MODs. A dependency with no
-// compatible release, or that errors while fetching, is skipped with a
-// warning rather than failing the whole download — a single incompatible
-// dependency should not block installing the MODs the user actually asked
-// for.
-func resolveDownloadDependencies(ctx context.Context, application *app.App, initial []fetchedMODInfo, jobs int) ([]fetchedMODInfo, error) {
-	portalAPI, err := application.PortalAPI()
+	// Installation state is irrelevant to a plain download, so resolution
+	// runs against an empty graph: every dependency counts as missing.
+	releases, err := res.Resolve(ctx, dependency.NewGraph(), specs, resolver.Options{Jobs: jobs, FollowRecommended: includeRecommended})
 	if err != nil {
 		return nil, err
 	}
-
-	known := map[string]fetchedMODInfo{}
-	frontier := make([]string, 0, len(initial))
-	for _, info := range initial {
-		known[info.MOD.Name] = info
-		frontier = append(frontier, info.MOD.Name)
-	}
-	processed := map[string]bool{}
-
-	for len(frontier) > 0 {
-		newDeps := collectNewDependencies(frontier, known, processed)
-		frontier = nil
-		if len(newDeps) == 0 {
-			continue
-		}
-
-		specs := make([]modSpec, len(newDeps))
-		for i, dep := range newDeps {
-			specs[i] = modSpec{MOD: mod.MOD{Name: dep.name}}
-		}
-		results, err := fetchMODInfoConcurrently(ctx, jobs, specs, func(ctx context.Context, spec modSpec) (fetchedMODInfo, error) {
-			info, err := portalAPI.GetMODFull(ctx, spec.MOD.Name)
-			if err != nil {
-				warnAndSkip(application, spec.MOD.Name, err)
-				return fetchedMODInfo{}, nil
-			}
-			i := slices.IndexFunc(newDeps, func(d requiredDependency) bool { return d.name == spec.MOD.Name })
-			release := resolver.SelectCompatible(info, newDeps[i].requirement)
-			if release == nil {
-				warnAndSkip(application, spec.MOD.Name, errors.New("no compatible release found"))
-				return fetchedMODInfo{}, nil
-			}
-			return fetchedMODInfo{MOD: spec.MOD, MODInfo: info, Release: *release}, nil
-		})
-		if err != nil {
-			return nil, err
-		}
-
-		for _, r := range results {
-			if r.MODInfo == nil {
-				continue // skipped: warnAndSkip already logged the reason
-			}
-			known[r.MOD.Name] = r
-			frontier = append(frontier, r.MOD.Name)
-		}
-	}
-
-	return slices.Collect(maps.Values(known)), nil
-}
-
-// warnAndSkip logs a dependency the caller treats as skippable rather than
-// fatal.
-func warnAndSkip(application *app.App, modName string, cause error) {
-	application.Logger.Warn("Skipping dependency", "mod", modName, "reason", cause)
-}
-
-func collectNewDependencies(batch []string, known map[string]fetchedMODInfo, processed map[string]bool) []requiredDependency {
-	var newDeps []requiredDependency
-	for _, name := range batch {
-		if processed[name] {
-			continue
-		}
-		processed[name] = true
-
-		info, ok := known[name]
-		if !ok {
-			continue
-		}
-		for _, depString := range info.Release.InfoJSON.Dependencies {
-			entry, err := dependency.Parse(depString)
-			if err != nil || entry.Type != dependency.TypeRequired {
-				continue
-			}
-			if slices.Contains(builtinMODs, entry.MOD.Name) {
-				continue
-			}
-			if _, ok := known[entry.MOD.Name]; ok {
-				continue
-			}
-			newDeps = append(newDeps, requiredDependency{name: entry.MOD.Name, requirement: entry.Requirement})
-		}
-	}
-	return newDeps
+	return releaseDownloadTargets(releases, downloadDir)
 }

--- a/internal/cli/mod_install.go
+++ b/internal/cli/mod_install.go
@@ -54,7 +54,7 @@ func newMODInstallCommand(c *cli) *cobra.Command {
 				return fmt.Errorf("MOD directory does not exist: %s", modDir)
 			}
 
-			specs := make([]modSpec, len(args))
+			specs := make([]resolver.Spec, len(args))
 			for i, arg := range args {
 				spec, err := parseMODSpec(arg)
 				if err != nil {
@@ -143,40 +143,14 @@ func splitInstallTargets(targets []installTarget) (installs, enables []installTa
 // with them and their required dependencies (recursively), marks disabled
 // installed dependencies for enabling, validates the result, and extracts
 // the actions to perform.
-func planInstall(ctx context.Context, application *app.App, graph *dependency.Graph, specs []modSpec, jobs int, includeRecommended bool) ([]installTarget, error) {
+func planInstall(ctx context.Context, application *app.App, graph *dependency.Graph, specs []resolver.Spec, jobs int, includeRecommended bool) ([]installTarget, error) {
 	portalAPI, err := application.PortalAPI()
 	if err != nil {
 		return nil, err
 	}
-
-	// The full endpoint is required: only /full includes each release's
-	// dependencies, which drive the recursive resolution below.
-	initial, err := fetchMODInfoConcurrently(ctx, jobs, specs, func(ctx context.Context, spec modSpec) (fetchedMODInfo, error) {
-		info, err := portalAPI.GetMODFull(ctx, spec.MOD.Name)
-		if err != nil {
-			return fetchedMODInfo{}, err
-		}
-		release := selectRelease(info, spec)
-		if release == nil {
-			return fetchedMODInfo{}, fmt.Errorf("Release not found for %s@%s", spec.MOD.Name, specVersionLabel(spec))
-		}
-		return fetchedMODInfo{MOD: spec.MOD, MODInfo: info, Release: *release}, nil
-	})
+	res := &resolver.Resolver{Portal: portalAPI, Logger: application.Logger}
+	releases, err := res.Resolve(ctx, graph, specs, resolver.Options{Jobs: jobs, FollowRecommended: includeRecommended})
 	if err != nil {
-		return nil, err
-	}
-
-	releases := map[mod.MOD]api.Release{}
-	frontier := make([]mod.MOD, 0, len(initial))
-	for _, info := range initial {
-		if err := graph.AddUninstalledMOD(info.MOD, info.Release.Version, info.Release.InfoJSON.Dependencies); err != nil {
-			return nil, err
-		}
-		releases[info.MOD] = info.Release
-		frontier = append(frontier, info.MOD)
-	}
-
-	if err := resolveInstallDependencies(ctx, application, graph, releases, frontier, jobs, includeRecommended); err != nil {
 		return nil, err
 	}
 
@@ -200,92 +174,6 @@ func planInstall(ctx context.Context, application *app.App, graph *dependency.Gr
 		}
 	}
 	return targets, nil
-}
-
-// resolveInstallDependencies walks the required (and, when includeRecommended
-// is true, recommended) edges of newly-added graph nodes and fetches MODs
-// not yet in the graph, extending it recursively. Recommended dependencies
-// are on by default, so they're fetched the same as required ones unless
-// the caller opts out. A dependency that cannot be fetched or has no
-// compatible release is skipped with a warning rather than failing the
-// install.
-func resolveInstallDependencies(ctx context.Context, application *app.App, graph *dependency.Graph, releases map[mod.MOD]api.Release, frontier []mod.MOD, jobs int, includeRecommended bool) error {
-	portalAPI, err := application.PortalAPI()
-	if err != nil {
-		return err
-	}
-
-	processed := map[mod.MOD]bool{}
-	for len(frontier) > 0 {
-		type missingDep struct {
-			mod         mod.MOD
-			requirement *dependency.VersionRequirement
-			requiredBy  mod.MOD
-		}
-		var missing []missingDep
-		for _, m := range frontier {
-			if processed[m] {
-				continue
-			}
-			processed[m] = true
-			for _, edge := range graph.EdgesFrom(m) {
-				relevant := edge.Type == dependency.TypeRequired || (includeRecommended && edge.Type == dependency.TypeRecommended)
-				if !relevant {
-					continue
-				}
-				if graph.Contains(edge.To) {
-					continue
-				}
-				missing = append(missing, missingDep{mod: edge.To, requirement: edge.Requirement, requiredBy: m})
-			}
-		}
-		frontier = nil
-		if len(missing) == 0 {
-			continue
-		}
-
-		specs := make([]modSpec, len(missing))
-		for i, dep := range missing {
-			specs[i] = modSpec{MOD: dep.mod}
-		}
-		results, err := fetchMODInfoConcurrently(ctx, jobs, specs, func(ctx context.Context, spec modSpec) (fetchedMODInfo, error) {
-			var requirement *dependency.VersionRequirement
-			var requiredBy mod.MOD
-			for _, dep := range missing {
-				if dep.mod == spec.MOD {
-					requirement = dep.requirement
-					requiredBy = dep.requiredBy
-					break
-				}
-			}
-			info, err := portalAPI.GetMODFull(ctx, spec.MOD.Name)
-			if err != nil {
-				application.Logger.Warn("Skipping dependency", "mod", spec.MOD.Name, "required_by", requiredBy.Name, "reason", err)
-				return fetchedMODInfo{}, nil
-			}
-			release := resolver.SelectCompatible(info, requirement)
-			if release == nil {
-				application.Logger.Warn("Skipping dependency", "mod", spec.MOD.Name, "required_by", requiredBy.Name, "reason", "no compatible release found")
-				return fetchedMODInfo{}, nil
-			}
-			return fetchedMODInfo{MOD: spec.MOD, MODInfo: info, Release: *release}, nil
-		})
-		if err != nil {
-			return err
-		}
-
-		for _, r := range results {
-			if r.MODInfo == nil {
-				continue // skipped above
-			}
-			if err := graph.AddUninstalledMOD(r.MOD, r.Release.Version, r.Release.InfoJSON.Dependencies); err != nil {
-				return err
-			}
-			releases[r.MOD] = r.Release
-			frontier = append(frontier, r.MOD)
-		}
-	}
-	return nil
 }
 
 func executeInstall(ctx context.Context, c *cli, cmd *cobra.Command, application *app.App, modList *mod.MODList, modDir string, installs, enables []installTarget, jobs int) error {

--- a/internal/cli/mod_sync.go
+++ b/internal/cli/mod_sync.go
@@ -267,19 +267,30 @@ func planSyncInstallation(ctx context.Context, application *app.App, graph *depe
 	// needs their names and versions to fold them into the save-driven
 	// mod-list.json planning (see the RunE closure above).
 	var dependencyEntries []save.MODEntry
-	targets, err := releaseDownloadTargets(releases, modDir)
-	if err != nil {
-		return nil, nil, err
-	}
 	for m, release := range releases {
 		if !requested[m] {
 			dependencyEntries = append(dependencyEntries, save.MODEntry{Name: m.Name, Version: release.Version})
 		}
 	}
 
-	result := make([]syncInstallTarget, len(targets))
-	for i, target := range targets {
-		result[i] = syncInstallTarget{downloadTarget: target}
+	// Iterate graph.Nodes() rather than the releases map directly: map
+	// iteration order is random, and it would otherwise shuffle the
+	// "Install:" confirmation list between identical runs (mirrors
+	// planInstall's use of graph.Nodes() for the same reason).
+	var result []syncInstallTarget
+	for _, node := range graph.Nodes() {
+		release, ok := releases[node.MOD]
+		if !ok {
+			continue
+		}
+		if err := validateFilename(release.FileName); err != nil {
+			return nil, nil, err
+		}
+		result = append(result, syncInstallTarget{downloadTarget: downloadTarget{
+			MOD:        node.MOD,
+			Release:    release,
+			OutputPath: filepath.Join(modDir, release.FileName),
+		}})
 	}
 	return result, dependencyEntries, nil
 }

--- a/internal/cli/mod_sync.go
+++ b/internal/cli/mod_sync.go
@@ -10,10 +10,10 @@ import (
 
 	"github.com/spf13/cobra"
 
-	"github.com/sakuro/factorix/internal/api"
 	"github.com/sakuro/factorix/internal/app"
 	"github.com/sakuro/factorix/internal/dependency"
 	"github.com/sakuro/factorix/internal/mod"
+	"github.com/sakuro/factorix/internal/resolver"
 	"github.com/sakuro/factorix/internal/save"
 	"github.com/sakuro/factorix/internal/settings"
 )
@@ -249,65 +249,32 @@ func planSyncInstallation(ctx context.Context, application *app.App, graph *depe
 		return nil, nil, err
 	}
 
-	specs := make([]modSpec, len(entries))
+	specs := make([]resolver.Spec, len(entries))
 	for i, entry := range entries {
-		// Version stays set even in latest mode so error messages can name
-		// the save-file version.
-		specs[i] = modSpec{MOD: mod.MOD{Name: entry.Name}, Latest: !strict, Version: entry.Version}
+		specs[i] = resolver.Spec{MOD: mod.MOD{Name: entry.Name}, Latest: !strict, Version: entry.Version}
 	}
-
-	infos, err := fetchMODInfoConcurrently(ctx, jobs, specs, func(ctx context.Context, spec modSpec) (fetchedMODInfo, error) {
-		info, err := portal.GetMODFull(ctx, spec.MOD.Name)
-		if err != nil {
-			return fetchedMODInfo{}, err
-		}
-		release := selectRelease(info, spec)
-		if release == nil {
-			return fetchedMODInfo{}, fmt.Errorf("Release not found for %s@%s", spec.MOD.Name, spec.Version)
-		}
-		return fetchedMODInfo{MOD: spec.MOD, MODInfo: info, Release: *release}, nil
-	})
+	res := &resolver.Resolver{Portal: portal, Logger: application.Logger}
+	releases, err := res.Resolve(ctx, graph, specs, resolver.Options{Jobs: jobs, FollowRecommended: includeRecommended})
 	if err != nil {
 		return nil, nil, err
 	}
 
-	releases := make(map[mod.MOD]api.Release, len(infos))
-	frontier := make([]mod.MOD, 0, len(infos))
-	known := make(map[mod.MOD]bool, len(infos))
-	for _, info := range infos {
-		if err := graph.AddUninstalledMOD(info.MOD, info.Release.Version, info.Release.InfoJSON.Dependencies); err != nil {
-			return nil, nil, err
-		}
-		releases[info.MOD] = info.Release
-		frontier = append(frontier, info.MOD)
-		known[info.MOD] = true
-	}
-
-	if err := resolveInstallDependencies(ctx, application, graph, releases, frontier, jobs, includeRecommended); err != nil {
-		return nil, nil, err
-	}
-
-	targets, err := buildDownloadTargets(infos, modDir)
-	if err != nil {
-		return nil, nil, err
+	requested := make(map[mod.MOD]bool, len(specs))
+	for _, spec := range specs {
+		requested[spec.MOD] = true
 	}
 	// Dependency-resolved MODs aren't in entries/saveMODs, so the caller
 	// needs their names and versions to fold them into the save-driven
 	// mod-list.json planning (see the RunE closure above).
 	var dependencyEntries []save.MODEntry
+	targets, err := releaseDownloadTargets(releases, modDir)
+	if err != nil {
+		return nil, nil, err
+	}
 	for m, release := range releases {
-		if known[m] {
-			continue
+		if !requested[m] {
+			dependencyEntries = append(dependencyEntries, save.MODEntry{Name: m.Name, Version: release.Version})
 		}
-		if err := validateFilename(release.FileName); err != nil {
-			return nil, nil, err
-		}
-		targets = append(targets, downloadTarget{
-			MOD:        m,
-			Release:    release,
-			OutputPath: filepath.Join(modDir, release.FileName),
-		})
-		dependencyEntries = append(dependencyEntries, save.MODEntry{Name: m.Name, Version: release.Version})
 	}
 
 	result := make([]syncInstallTarget, len(targets))

--- a/internal/cli/portal_integration_download_test.go
+++ b/internal/cli/portal_integration_download_test.go
@@ -57,6 +57,66 @@ func TestMODDownloadRecursiveAgainstMockPortal(t *testing.T) {
 	assert.FileExists(t, filepath.Join(dir, "dep-mod_1.2.0.zip"))
 }
 
+func TestMODDownloadRecursivePullsInRecommendedDependency(t *testing.T) {
+	s := baseSandbox(t)
+	dir := filepath.Join(s.root, "downloads")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	portal := newMockPortal(t,
+		portalMOD{
+			Name: "top-mod", Title: "Top MOD", Owner: "alice",
+			Releases: []portalRelease{{
+				Version: "1.0.0", FileName: "top-mod_1.0.0.zip", DownloadURL: "/download/top-mod_1.0.0.zip",
+				InfoJSON: portalInfoJSON{FactorioVersion: "2.0", Dependencies: []string{"+ lib-mod"}},
+			}},
+		},
+		portalMOD{
+			Name: "lib-mod", Title: "Lib MOD", Owner: "bob",
+			Releases: []portalRelease{{
+				Version: "2.0.0", FileName: "lib-mod_2.0.0.zip", DownloadURL: "/download/lib-mod_2.0.0.zip",
+				InfoJSON: portalInfoJSON{FactorioVersion: "2.0"},
+			}},
+		},
+	)
+	portal.withPortal(t)
+
+	out, err := runCLI(t, "mod", "download", "top-mod", "-d", dir, "-r")
+	require.NoError(t, err)
+	assert.Contains(t, out, "Downloaded 2 MOD(s)")
+	assert.FileExists(t, filepath.Join(dir, "top-mod_1.0.0.zip"))
+	assert.FileExists(t, filepath.Join(dir, "lib-mod_2.0.0.zip"))
+}
+
+func TestMODDownloadRecursiveIgnoresRecommendedDependencyWithFlag(t *testing.T) {
+	s := baseSandbox(t)
+	dir := filepath.Join(s.root, "downloads")
+	require.NoError(t, os.MkdirAll(dir, 0o755))
+	// lib-mod is registered and fetchable so this test proves the flag
+	// itself excludes it, not that the fetch would have failed anyway.
+	portal := newMockPortal(t,
+		portalMOD{
+			Name: "top-mod", Title: "Top MOD", Owner: "alice",
+			Releases: []portalRelease{{
+				Version: "1.0.0", FileName: "top-mod_1.0.0.zip", DownloadURL: "/download/top-mod_1.0.0.zip",
+				InfoJSON: portalInfoJSON{FactorioVersion: "2.0", Dependencies: []string{"+ lib-mod"}},
+			}},
+		},
+		portalMOD{
+			Name: "lib-mod", Title: "Lib MOD", Owner: "bob",
+			Releases: []portalRelease{{
+				Version: "2.0.0", FileName: "lib-mod_2.0.0.zip", DownloadURL: "/download/lib-mod_2.0.0.zip",
+				InfoJSON: portalInfoJSON{FactorioVersion: "2.0"},
+			}},
+		},
+	)
+	portal.withPortal(t)
+
+	out, err := runCLI(t, "mod", "download", "top-mod", "-d", dir, "-r", "--ignore-recommended")
+	require.NoError(t, err)
+	assert.Contains(t, out, "Downloaded 1 MOD(s)")
+	assert.FileExists(t, filepath.Join(dir, "top-mod_1.0.0.zip"))
+	assert.NoFileExists(t, filepath.Join(dir, "lib-mod_2.0.0.zip"))
+}
+
 func TestMODDownloadRecursiveSkipsIncompatibleDependency(t *testing.T) {
 	s := baseSandbox(t)
 	dir := filepath.Join(s.root, "downloads")

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -1,0 +1,71 @@
+package resolver
+
+import (
+	"context"
+	"fmt"
+	"log/slog"
+
+	"golang.org/x/sync/errgroup"
+
+	"github.com/sakuro/factorix/internal/api"
+	"github.com/sakuro/factorix/internal/mod"
+)
+
+// Portal is the subset of the MOD Portal API the resolver needs. Only the
+// full endpoint is usable here: /full is the only response that carries
+// each release's dependencies.
+type Portal interface {
+	GetMODFull(ctx context.Context, name string) (*api.MODInfo, error)
+}
+
+// Resolver fetches MODs from the Portal and resolves their dependencies.
+type Resolver struct {
+	Portal Portal
+	Logger *slog.Logger
+}
+
+// Fetched pairs a requested MOD with its full info and selected release.
+type Fetched struct {
+	MOD     mod.MOD
+	Info    *api.MODInfo
+	Release api.Release
+}
+
+// Fetch resolves each spec to a release with up to jobs concurrent Portal
+// requests. Any spec that cannot be fetched or has no matching release
+// fails the whole call: these are MODs the user explicitly asked for.
+func (r *Resolver) Fetch(ctx context.Context, specs []Spec, jobs int) ([]Fetched, error) {
+	return concurrentFetch(ctx, jobs, specs, func(ctx context.Context, spec Spec) (Fetched, error) {
+		info, err := r.Portal.GetMODFull(ctx, spec.MOD.Name)
+		if err != nil {
+			return Fetched{}, err
+		}
+		release := spec.Select(info)
+		if release == nil {
+			return Fetched{}, fmt.Errorf("Release not found for %s@%s", spec.MOD.Name, spec.VersionLabel())
+		}
+		return Fetched{MOD: spec.MOD, Info: info, Release: *release}, nil
+	})
+}
+
+// concurrentFetch runs resolve for each spec, jobs at a time, preserving
+// input order in the results.
+func concurrentFetch(ctx context.Context, jobs int, specs []Spec, resolve func(context.Context, Spec) (Fetched, error)) ([]Fetched, error) {
+	results := make([]Fetched, len(specs))
+	group, ctx := errgroup.WithContext(ctx)
+	group.SetLimit(jobs)
+	for i, spec := range specs {
+		group.Go(func() error {
+			result, err := resolve(ctx, spec)
+			if err != nil {
+				return err
+			}
+			results[i] = result
+			return nil
+		})
+	}
+	if err := group.Wait(); err != nil {
+		return nil, err
+	}
+	return results, nil
+}

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -4,6 +4,7 @@ import (
 	"context"
 	"fmt"
 	"log/slog"
+	"strings"
 
 	"golang.org/x/sync/errgroup"
 
@@ -107,18 +108,19 @@ func (r *Resolver) Resolve(ctx context.Context, graph *dependency.Graph, specs [
 	return releases, nil
 }
 
-// missingDependency is a dependency edge pointing at a MOD not yet in the
-// graph, remembered with its requirement and dependent for fetching.
+// missingDependency aggregates, for one MOD absent from the graph, the
+// version requirements and dependents of every edge pointing at it in the
+// current wave.
 type missingDependency struct {
-	mod         mod.MOD
-	requirement *dependency.VersionRequirement
-	requiredBy  mod.MOD
+	requirements []*dependency.VersionRequirement
+	requiredBy   []mod.MOD
 }
 
 func (r *Resolver) resolveDependencies(ctx context.Context, graph *dependency.Graph, releases map[mod.MOD]api.Release, frontier []mod.MOD, opts Options) error {
 	processed := map[mod.MOD]bool{}
 	for len(frontier) > 0 {
-		var missing []missingDependency
+		missing := map[mod.MOD]*missingDependency{}
+		var order []mod.MOD
 		for _, m := range frontier {
 			if processed[m] {
 				continue
@@ -137,7 +139,14 @@ func (r *Resolver) resolveDependencies(ctx context.Context, graph *dependency.Gr
 				if graph.Contains(edge.To) {
 					continue
 				}
-				missing = append(missing, missingDependency{mod: edge.To, requirement: edge.Requirement, requiredBy: m})
+				dep, ok := missing[edge.To]
+				if !ok {
+					dep = &missingDependency{}
+					missing[edge.To] = dep
+					order = append(order, edge.To)
+				}
+				dep.requirements = append(dep.requirements, edge.Requirement)
+				dep.requiredBy = append(dep.requiredBy, m)
 			}
 		}
 		frontier = nil
@@ -145,28 +154,26 @@ func (r *Resolver) resolveDependencies(ctx context.Context, graph *dependency.Gr
 			continue
 		}
 
-		specs := make([]Spec, len(missing))
-		for i, dep := range missing {
-			specs[i] = Spec{MOD: dep.mod, Latest: true}
+		specs := make([]Spec, len(order))
+		for i, m := range order {
+			specs[i] = Spec{MOD: m, Latest: true}
 		}
 		results, err := concurrentFetch(ctx, opts.Jobs, specs, func(ctx context.Context, spec Spec) (Fetched, error) {
-			var requirement *dependency.VersionRequirement
-			var requiredBy mod.MOD
-			for _, dep := range missing {
-				if dep.mod == spec.MOD {
-					requirement = dep.requirement
-					requiredBy = dep.requiredBy
-					break
-				}
+			dep := missing[spec.MOD]
+			names := make([]string, len(dep.requiredBy))
+			for i, m := range dep.requiredBy {
+				names[i] = m.Name
 			}
+			requiredBy := strings.Join(names, ",")
+
 			info, err := r.Portal.GetMODFull(ctx, spec.MOD.Name)
 			if err != nil {
-				r.Logger.Warn("Skipping dependency", "mod", spec.MOD.Name, "required_by", requiredBy.Name, "reason", err)
+				r.Logger.Warn("Skipping dependency", "mod", spec.MOD.Name, "required_by", requiredBy, "reason", err)
 				return Fetched{}, nil
 			}
-			release := SelectCompatible(info, requirement)
+			release := SelectCompatible(info, dep.requirements...)
 			if release == nil {
-				r.Logger.Warn("Skipping dependency", "mod", spec.MOD.Name, "required_by", requiredBy.Name, "reason", "no compatible release found")
+				r.Logger.Warn("Skipping dependency", "mod", spec.MOD.Name, "required_by", requiredBy, "reason", "no compatible release found")
 				return Fetched{}, nil
 			}
 			return Fetched{MOD: spec.MOD, Info: info, Release: *release}, nil

--- a/internal/resolver/resolver.go
+++ b/internal/resolver/resolver.go
@@ -8,6 +8,7 @@ import (
 	"golang.org/x/sync/errgroup"
 
 	"github.com/sakuro/factorix/internal/api"
+	"github.com/sakuro/factorix/internal/dependency"
 	"github.com/sakuro/factorix/internal/mod"
 )
 
@@ -68,4 +69,122 @@ func concurrentFetch(ctx context.Context, jobs int, specs []Spec, resolve func(c
 		return nil, err
 	}
 	return results, nil
+}
+
+// Options tunes Resolve.
+type Options struct {
+	Jobs              int  // concurrent Portal requests
+	FollowRecommended bool // also follow recommended dependency edges
+}
+
+// Resolve fetches each spec from the Portal, adds it to graph (via
+// AddUninstalledMOD), then walks required (and, per opts, recommended)
+// edges breadth-first, fetching MODs not yet in the graph and extending it
+// until the frontier is empty. It returns the selected release for every
+// spec and every dependency it added. Explicitly requested specs fail
+// hard; a transitive dependency that cannot be fetched or has no release
+// satisfying its version requirement is skipped with a warning. Base and
+// expansion MODs are never fetched.
+func (r *Resolver) Resolve(ctx context.Context, graph *dependency.Graph, specs []Spec, opts Options) (map[mod.MOD]api.Release, error) {
+	initial, err := r.Fetch(ctx, specs, opts.Jobs)
+	if err != nil {
+		return nil, err
+	}
+
+	releases := make(map[mod.MOD]api.Release, len(initial))
+	frontier := make([]mod.MOD, 0, len(initial))
+	for _, f := range initial {
+		if err := graph.AddUninstalledMOD(f.MOD, f.Release.Version, f.Release.InfoJSON.Dependencies); err != nil {
+			return nil, err
+		}
+		releases[f.MOD] = f.Release
+		frontier = append(frontier, f.MOD)
+	}
+
+	if err := r.resolveDependencies(ctx, graph, releases, frontier, opts); err != nil {
+		return nil, err
+	}
+	return releases, nil
+}
+
+// missingDependency is a dependency edge pointing at a MOD not yet in the
+// graph, remembered with its requirement and dependent for fetching.
+type missingDependency struct {
+	mod         mod.MOD
+	requirement *dependency.VersionRequirement
+	requiredBy  mod.MOD
+}
+
+func (r *Resolver) resolveDependencies(ctx context.Context, graph *dependency.Graph, releases map[mod.MOD]api.Release, frontier []mod.MOD, opts Options) error {
+	processed := map[mod.MOD]bool{}
+	for len(frontier) > 0 {
+		var missing []missingDependency
+		for _, m := range frontier {
+			if processed[m] {
+				continue
+			}
+			processed[m] = true
+			for _, edge := range graph.EdgesFrom(m) {
+				relevant := edge.Type == dependency.TypeRequired || (opts.FollowRecommended && edge.Type == dependency.TypeRecommended)
+				if !relevant {
+					continue
+				}
+				// The base MOD and the official expansions are not on the
+				// Portal; they are installed with the game, never fetched.
+				if edge.To.IsBase() || edge.To.IsExpansion() {
+					continue
+				}
+				if graph.Contains(edge.To) {
+					continue
+				}
+				missing = append(missing, missingDependency{mod: edge.To, requirement: edge.Requirement, requiredBy: m})
+			}
+		}
+		frontier = nil
+		if len(missing) == 0 {
+			continue
+		}
+
+		specs := make([]Spec, len(missing))
+		for i, dep := range missing {
+			specs[i] = Spec{MOD: dep.mod, Latest: true}
+		}
+		results, err := concurrentFetch(ctx, opts.Jobs, specs, func(ctx context.Context, spec Spec) (Fetched, error) {
+			var requirement *dependency.VersionRequirement
+			var requiredBy mod.MOD
+			for _, dep := range missing {
+				if dep.mod == spec.MOD {
+					requirement = dep.requirement
+					requiredBy = dep.requiredBy
+					break
+				}
+			}
+			info, err := r.Portal.GetMODFull(ctx, spec.MOD.Name)
+			if err != nil {
+				r.Logger.Warn("Skipping dependency", "mod", spec.MOD.Name, "required_by", requiredBy.Name, "reason", err)
+				return Fetched{}, nil
+			}
+			release := SelectCompatible(info, requirement)
+			if release == nil {
+				r.Logger.Warn("Skipping dependency", "mod", spec.MOD.Name, "required_by", requiredBy.Name, "reason", "no compatible release found")
+				return Fetched{}, nil
+			}
+			return Fetched{MOD: spec.MOD, Info: info, Release: *release}, nil
+		})
+		if err != nil {
+			return err
+		}
+
+		for _, f := range results {
+			if f.Info == nil {
+				continue // skipped above with a warning
+			}
+			if err := graph.AddUninstalledMOD(f.MOD, f.Release.Version, f.Release.InfoJSON.Dependencies); err != nil {
+				return err
+			}
+			releases[f.MOD] = f.Release
+			frontier = append(frontier, f.MOD)
+		}
+	}
+	return nil
 }

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -12,23 +12,32 @@ import (
 	"github.com/stretchr/testify/require"
 
 	"github.com/sakuro/factorix/internal/api"
+	"github.com/sakuro/factorix/internal/dependency"
 	"github.com/sakuro/factorix/internal/mod"
 )
 
 // fakePortal serves canned MODInfo responses.
 type fakePortal struct {
-	mu   sync.Mutex
-	mods map[string]*api.MODInfo
+	mu        sync.Mutex
+	mods      map[string]*api.MODInfo
+	requested []string
 }
 
 func (f *fakePortal) GetMODFull(_ context.Context, name string) (*api.MODInfo, error) {
 	f.mu.Lock()
 	defer f.mu.Unlock()
+	f.requested = append(f.requested, name)
 	info, ok := f.mods[name]
 	if !ok {
 		return nil, fmt.Errorf("%w: %s", api.ErrMODNotOnPortal, name)
 	}
 	return info, nil
+}
+
+func (f *fakePortal) requestedNames() []string {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	return append([]string(nil), f.requested...)
 }
 
 // modInfo builds a MODInfo with one release per version string; the last
@@ -85,4 +94,111 @@ func TestFetch(t *testing.T) {
 func TestSpecVersionLabel(t *testing.T) {
 	assert.Equal(t, "latest", Spec{MOD: mod.MOD{Name: "a"}, Latest: true}.VersionLabel())
 	assert.Equal(t, "1.2.0", Spec{MOD: mod.MOD{Name: "a"}, Version: mustVersion(t, "1.2.0")}.VersionLabel())
+}
+
+func TestResolve(t *testing.T) {
+	newResolver := func(mods map[string]*api.MODInfo) (*Resolver, *fakePortal) {
+		portal := &fakePortal{mods: mods}
+		return &Resolver{Portal: portal, Logger: discardLogger()}, portal
+	}
+	latestSpec := func(name string) Spec {
+		return Spec{MOD: mod.MOD{Name: name}, Latest: true}
+	}
+
+	t.Run("resolves required chain recursively", func(t *testing.T) {
+		r, _ := newResolver(map[string]*api.MODInfo{
+			"app":  modInfo(t, "app", []string{"lib"}, "1.0.0"),
+			"lib":  modInfo(t, "lib", []string{"core"}, "1.0.0"),
+			"core": modInfo(t, "core", nil, "1.0.0"),
+		})
+		graph := dependency.NewGraph()
+		releases, err := r.Resolve(context.Background(), graph, []Spec{latestSpec("app")}, Options{Jobs: 2})
+		require.NoError(t, err)
+		assert.Len(t, releases, 3)
+		assert.True(t, graph.Contains(mod.MOD{Name: "core"}))
+	})
+
+	t.Run("follows recommended only when enabled", func(t *testing.T) {
+		mods := map[string]*api.MODInfo{
+			"app":   modInfo(t, "app", []string{"+ extra"}, "1.0.0"),
+			"extra": modInfo(t, "extra", nil, "1.0.0"),
+		}
+		r, _ := newResolver(mods)
+		releases, err := r.Resolve(context.Background(), dependency.NewGraph(), []Spec{latestSpec("app")}, Options{Jobs: 2, FollowRecommended: true})
+		require.NoError(t, err)
+		assert.Contains(t, releases, mod.MOD{Name: "extra"})
+
+		r2, portal2 := newResolver(mods)
+		releases, err = r2.Resolve(context.Background(), dependency.NewGraph(), []Spec{latestSpec("app")}, Options{Jobs: 2})
+		require.NoError(t, err)
+		assert.NotContains(t, releases, mod.MOD{Name: "extra"})
+		assert.NotContains(t, portal2.requestedNames(), "extra")
+	})
+
+	t.Run("honors dependency version requirements", func(t *testing.T) {
+		r, _ := newResolver(map[string]*api.MODInfo{
+			"app": modInfo(t, "app", []string{"lib <= 1.5.0"}, "1.0.0"),
+			"lib": modInfo(t, "lib", nil, "1.0.0", "2.0.0"),
+		})
+		releases, err := r.Resolve(context.Background(), dependency.NewGraph(), []Spec{latestSpec("app")}, Options{Jobs: 2})
+		require.NoError(t, err)
+		assert.Equal(t, "1.0.0", releases[mod.MOD{Name: "lib"}].Version.String())
+	})
+
+	t.Run("never fetches base or expansion dependencies", func(t *testing.T) {
+		r, portal := newResolver(map[string]*api.MODInfo{
+			"app": modInfo(t, "app", []string{"base >= 2.0.0", "quality", "space-age"}, "1.0.0"),
+		})
+		releases, err := r.Resolve(context.Background(), dependency.NewGraph(), []Spec{latestSpec("app")}, Options{Jobs: 2})
+		require.NoError(t, err)
+		assert.Len(t, releases, 1)
+		assert.Equal(t, []string{"app"}, portal.requestedNames())
+	})
+
+	t.Run("skips dependencies already in the graph", func(t *testing.T) {
+		r, portal := newResolver(map[string]*api.MODInfo{
+			"app": modInfo(t, "app", []string{"lib"}, "1.0.0"),
+		})
+		graph := dependency.NewGraph()
+		require.NoError(t, graph.AddNode(dependency.Node{MOD: mod.MOD{Name: "lib"}, Version: mustVersion(t, "1.0.0"), Enabled: true, Installed: true}))
+		releases, err := r.Resolve(context.Background(), graph, []Spec{latestSpec("app")}, Options{Jobs: 2})
+		require.NoError(t, err)
+		assert.NotContains(t, releases, mod.MOD{Name: "lib"})
+		assert.NotContains(t, portal.requestedNames(), "lib")
+	})
+
+	t.Run("marks installed-but-disabled spec for enable and still returns its release", func(t *testing.T) {
+		r, _ := newResolver(map[string]*api.MODInfo{
+			"app": modInfo(t, "app", nil, "1.0.0"),
+		})
+		graph := dependency.NewGraph()
+		require.NoError(t, graph.AddNode(dependency.Node{MOD: mod.MOD{Name: "app"}, Version: mustVersion(t, "1.0.0"), Installed: true}))
+		releases, err := r.Resolve(context.Background(), graph, []Spec{latestSpec("app")}, Options{Jobs: 2})
+		require.NoError(t, err)
+		assert.Contains(t, releases, mod.MOD{Name: "app"})
+		node, ok := graph.Node(mod.MOD{Name: "app"})
+		require.True(t, ok)
+		assert.Equal(t, dependency.OpEnable, node.Operation)
+	})
+
+	t.Run("skips unfetchable transitive dependency with warning", func(t *testing.T) {
+		r, _ := newResolver(map[string]*api.MODInfo{
+			"app": modInfo(t, "app", []string{"gone"}, "1.0.0"),
+		})
+		graph := dependency.NewGraph()
+		releases, err := r.Resolve(context.Background(), graph, []Spec{latestSpec("app")}, Options{Jobs: 2})
+		require.NoError(t, err)
+		assert.NotContains(t, releases, mod.MOD{Name: "gone"})
+		assert.False(t, graph.Contains(mod.MOD{Name: "gone"}))
+	})
+
+	t.Run("skips transitive dependency with no compatible release", func(t *testing.T) {
+		r, _ := newResolver(map[string]*api.MODInfo{
+			"app": modInfo(t, "app", []string{"lib >= 9.0.0"}, "1.0.0"),
+			"lib": modInfo(t, "lib", nil, "1.0.0"),
+		})
+		releases, err := r.Resolve(context.Background(), dependency.NewGraph(), []Spec{latestSpec("app")}, Options{Jobs: 2})
+		require.NoError(t, err)
+		assert.NotContains(t, releases, mod.MOD{Name: "lib"})
+	})
 }

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -1,0 +1,88 @@
+package resolver
+
+import (
+	"context"
+	"fmt"
+	"io"
+	"log/slog"
+	"sync"
+	"testing"
+
+	"github.com/stretchr/testify/assert"
+	"github.com/stretchr/testify/require"
+
+	"github.com/sakuro/factorix/internal/api"
+	"github.com/sakuro/factorix/internal/mod"
+)
+
+// fakePortal serves canned MODInfo responses.
+type fakePortal struct {
+	mu   sync.Mutex
+	mods map[string]*api.MODInfo
+}
+
+func (f *fakePortal) GetMODFull(_ context.Context, name string) (*api.MODInfo, error) {
+	f.mu.Lock()
+	defer f.mu.Unlock()
+	info, ok := f.mods[name]
+	if !ok {
+		return nil, fmt.Errorf("%w: %s", api.ErrMODNotOnPortal, name)
+	}
+	return info, nil
+}
+
+// modInfo builds a MODInfo with one release per version string; the last
+// version listed carries the given dependency strings.
+func modInfo(t *testing.T, name string, deps []string, versions ...string) *api.MODInfo {
+	t.Helper()
+	info := &api.MODInfo{Name: name}
+	for i, vs := range versions {
+		v, err := mod.ParseMODVersion(vs)
+		require.NoError(t, err)
+		release := api.Release{Version: v, FileName: name + "_" + vs + ".zip"}
+		if i == len(versions)-1 {
+			release.InfoJSON.Dependencies = deps
+		}
+		info.Releases = append(info.Releases, release)
+	}
+	return info
+}
+
+func discardLogger() *slog.Logger {
+	return slog.New(slog.NewTextHandler(io.Discard, nil))
+}
+
+func TestFetch(t *testing.T) {
+	portal := &fakePortal{mods: map[string]*api.MODInfo{
+		"alpha": modInfo(t, "alpha", nil, "1.0.0", "1.1.0"),
+		"beta":  modInfo(t, "beta", nil, "2.0.0"),
+	}}
+	r := &Resolver{Portal: portal, Logger: discardLogger()}
+
+	t.Run("resolves latest and exact specs", func(t *testing.T) {
+		fetched, err := r.Fetch(context.Background(), []Spec{
+			{MOD: mod.MOD{Name: "alpha"}, Latest: true},
+			{MOD: mod.MOD{Name: "beta"}, Version: mustVersion(t, "2.0.0")},
+		}, 2)
+		require.NoError(t, err)
+		require.Len(t, fetched, 2)
+		assert.Equal(t, "1.1.0", fetched[0].Release.Version.String())
+		assert.Equal(t, "2.0.0", fetched[1].Release.Version.String())
+		assert.NotNil(t, fetched[0].Info)
+	})
+
+	t.Run("unknown MOD fails the call", func(t *testing.T) {
+		_, err := r.Fetch(context.Background(), []Spec{{MOD: mod.MOD{Name: "ghost"}, Latest: true}}, 1)
+		require.Error(t, err)
+	})
+
+	t.Run("missing release fails with spec label", func(t *testing.T) {
+		_, err := r.Fetch(context.Background(), []Spec{{MOD: mod.MOD{Name: "beta"}, Version: mustVersion(t, "9.9.9")}}, 1)
+		require.ErrorContains(t, err, "beta@9.9.9")
+	})
+}
+
+func TestSpecVersionLabel(t *testing.T) {
+	assert.Equal(t, "latest", Spec{MOD: mod.MOD{Name: "a"}, Latest: true}.VersionLabel())
+	assert.Equal(t, "1.2.0", Spec{MOD: mod.MOD{Name: "a"}, Version: mustVersion(t, "1.2.0")}.VersionLabel())
+}

--- a/internal/resolver/resolver_test.go
+++ b/internal/resolver/resolver_test.go
@@ -201,4 +201,40 @@ func TestResolve(t *testing.T) {
 		require.NoError(t, err)
 		assert.NotContains(t, releases, mod.MOD{Name: "lib"})
 	})
+
+	t.Run("merges requirements from multiple dependents", func(t *testing.T) {
+		r, portal := newResolver(map[string]*api.MODInfo{
+			"app":  modInfo(t, "app", []string{"lib1", "lib2"}, "1.0.0"),
+			"lib1": modInfo(t, "lib1", []string{"core"}, "1.0.0"),
+			"lib2": modInfo(t, "lib2", []string{"core <= 1.5.0"}, "1.0.0"),
+			"core": modInfo(t, "core", nil, "1.0.0", "2.0.0"),
+		})
+		releases, err := r.Resolve(context.Background(), dependency.NewGraph(), []Spec{latestSpec("app")}, Options{Jobs: 2})
+		require.NoError(t, err)
+		require.Contains(t, releases, mod.MOD{Name: "core"})
+		assert.Equal(t, "1.0.0", releases[mod.MOD{Name: "core"}].Version.String())
+
+		requested := portal.requestedNames()
+		count := 0
+		for _, name := range requested {
+			if name == "core" {
+				count++
+			}
+		}
+		assert.Equal(t, 1, count, "core should be fetched exactly once, got requests: %v", requested)
+	})
+
+	t.Run("skips dependency whose combined requirements are unsatisfiable", func(t *testing.T) {
+		r, _ := newResolver(map[string]*api.MODInfo{
+			"app":  modInfo(t, "app", []string{"lib1", "lib2"}, "1.0.0"),
+			"lib1": modInfo(t, "lib1", []string{"core >= 2.0.0"}, "1.0.0"),
+			"lib2": modInfo(t, "lib2", []string{"core <= 1.5.0"}, "1.0.0"),
+			"core": modInfo(t, "core", nil, "1.0.0", "2.0.0"),
+		})
+		graph := dependency.NewGraph()
+		releases, err := r.Resolve(context.Background(), graph, []Spec{latestSpec("app")}, Options{Jobs: 2})
+		require.NoError(t, err)
+		assert.NotContains(t, releases, mod.MOD{Name: "core"})
+		assert.False(t, graph.Contains(mod.MOD{Name: "core"}))
+	})
 }

--- a/internal/resolver/select.go
+++ b/internal/resolver/select.go
@@ -33,20 +33,35 @@ func SelectExact(info *api.MODInfo, version mod.MODVersion) *api.Release {
 	return nil
 }
 
-// SelectCompatible returns the latest release satisfying the requirement:
-// with a nil requirement it is SelectLatest; otherwise latest_release when
-// that satisfies the requirement, else the highest satisfying version.
+// SelectCompatible returns the latest release satisfying every given
+// requirement (nil requirements are ignored): with no effective
+// requirement it is SelectLatest; otherwise latest_release when that
+// satisfies all requirements, else the highest satisfying version.
 // Returns nil when no release satisfies.
-func SelectCompatible(info *api.MODInfo, requirement *dependency.VersionRequirement) *api.Release {
-	if requirement == nil {
+func SelectCompatible(info *api.MODInfo, requirements ...*dependency.VersionRequirement) *api.Release {
+	var active []*dependency.VersionRequirement
+	for _, r := range requirements {
+		if r != nil {
+			active = append(active, r)
+		}
+	}
+	if len(active) == 0 {
 		return SelectLatest(info)
 	}
-	if info.LatestRelease != nil && requirement.SatisfiedBy(info.LatestRelease.Version) {
+	satisfiesAll := func(v mod.MODVersion) bool {
+		for _, r := range active {
+			if !r.SatisfiedBy(v) {
+				return false
+			}
+		}
+		return true
+	}
+	if info.LatestRelease != nil && satisfiesAll(info.LatestRelease.Version) {
 		return info.LatestRelease
 	}
 	var compatible []api.Release
 	for _, r := range info.Releases {
-		if requirement.SatisfiedBy(r.Version) {
+		if satisfiesAll(r.Version) {
 			compatible = append(compatible, r)
 		}
 	}

--- a/internal/resolver/select.go
+++ b/internal/resolver/select.go
@@ -1,6 +1,6 @@
-// Package resolver selects MOD Portal releases and (in later stages)
-// resolves MOD dependencies against the Portal. It is the single place
-// where "latest" is defined for every command.
+// Package resolver selects MOD Portal releases and resolves MOD
+// dependencies against the Portal. It is the single place where "latest"
+// is defined for every command.
 package resolver
 
 import (

--- a/internal/resolver/select_test.go
+++ b/internal/resolver/select_test.go
@@ -100,4 +100,20 @@ func TestSelectCompatible(t *testing.T) {
 		requirement := &dependency.VersionRequirement{Operator: dependency.OpGreaterEqual, Version: mustVersion(t, "9.0.0")}
 		assert.Nil(t, SelectCompatible(info, requirement))
 	})
+
+	t.Run("multiple requirements narrow the selection", func(t *testing.T) {
+		multi := &api.MODInfo{Releases: []api.Release{release(t, "1.0.0"), release(t, "1.5.0"), release(t, "2.0.0")}}
+		lower := &dependency.VersionRequirement{Operator: dependency.OpGreaterEqual, Version: mustVersion(t, "1.2.0")}
+		upper := &dependency.VersionRequirement{Operator: dependency.OpLessEqual, Version: mustVersion(t, "1.8.0")}
+		got := SelectCompatible(multi, lower, upper)
+		require.NotNil(t, got)
+		assert.Equal(t, "1.5.0", got.Version.String())
+	})
+
+	t.Run("nil entries among requirements are ignored", func(t *testing.T) {
+		requirement := &dependency.VersionRequirement{Operator: dependency.OpLessEqual, Version: mustVersion(t, "1.5.0")}
+		got := SelectCompatible(info, nil, requirement, nil)
+		require.NotNil(t, got)
+		assert.Equal(t, "1.0.0", got.Version.String())
+	})
 }

--- a/internal/resolver/spec.go
+++ b/internal/resolver/spec.go
@@ -1,0 +1,30 @@
+package resolver
+
+import (
+	"github.com/sakuro/factorix/internal/api"
+	"github.com/sakuro/factorix/internal/mod"
+)
+
+// Spec is a parsed MOD specification: a name plus either "latest" or an
+// exact version.
+type Spec struct {
+	MOD     mod.MOD
+	Latest  bool
+	Version mod.MODVersion // meaningless when Latest
+}
+
+// Select returns the release the spec designates, or nil when absent.
+func (s Spec) Select(info *api.MODInfo) *api.Release {
+	if s.Latest {
+		return SelectLatest(info)
+	}
+	return SelectExact(info, s.Version)
+}
+
+// VersionLabel renders the requested version for error messages.
+func (s Spec) VersionLabel() string {
+	if s.Latest {
+		return "latest"
+	}
+	return s.Version.String()
+}


### PR DESCRIPTION
## Summary
Replace the two parallel dependency-resolution BFS implementations (`resolveInstallDependencies`, `resolveDownloadDependencies`) with a single graph-based engine, `Resolver.Resolve`, in `internal/resolver`. `mod install`, `mod sync`, and `mod download --recursive` all now share it.

## Changes
- Add `resolver.Spec`, `Resolver.Fetch` (explicit specs, hard failure), and `Resolver.Resolve` (BFS over required/recommended edges, warn-and-skip on transitive failures)
- Migrate install/sync/download to the engine; delete the two legacy BFS implementations and the hardcoded `builtinMODs` list (base/expansion skipping now uses `mod.MOD.IsBase()/IsExpansion()`)
- Fix a pre-existing bug uncovered during development: when two dependents in the same BFS wave required the same transitive MOD with different version constraints, only one dependent's requirement was honored, silently risking an incompatible version. `SelectCompatible` is now variadic and merges every dependent's requirement per MOD.

## Behavior changes
- `mod download --recursive` now follows recommended dependencies by default (previously required-only); a new `--ignore-recommended` flag opts out, matching install/sync
- Dependency resolution never queries the Portal for base/expansion MODs (previously install/sync did and relied on the fetch failing with a warning)
- `mod sync`'s "Release not found" error for a latest-mode spec now names it `@latest` instead of the save-file version

## Test Plan
- `mise run default` (test + e2e + vet + lint + fmt-check) passes
- New `internal/resolver` unit tests cover the BFS, recommended-edge toggling, version-requirement satisfaction, base/expansion skipping, and the diamond-dependency requirement merge
- New integration tests cover `mod download --recursive` following (and, with `--ignore-recommended`, not following) a recommended dependency

Closes #181
Related to #184
